### PR TITLE
Apply a default fixed font to nav-button-label when themes.googleusercon...

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -35,7 +35,7 @@ ul.scripts-list
 #nav-buttons{
 }
 .nav-button-label{
-	font-family: 'Squada One', cursive;
+	font-family: 'Squada One', cursive, sans-serif;
 	font-weight: 400;
 	color: #004e70;
 	font-size: 1.9em;


### PR DESCRIPTION
...tent.com is blocked from NoScript.

This maintains the nav-button height.
