### PR TITLE
Add content type change list item for webhook instructions on GH.

### DIFF
--- a/views/addScripts.html
+++ b/views/addScripts.html
@@ -10,6 +10,7 @@
     <ol>
       <li>Add a Webhook (in the repo settings) to the repos containing the script(s)</li>
       <li>Paste the URL below as the "Payload URL"</li>
+      <li>Change the Content type to "application/x-www-form-urlencoded"</li>
       <li>Click "Add webhook"</li>
     </ol>
   <p>Use the default settings for everything else.</p>


### PR DESCRIPTION
This used to be set to a compatible type of `application/vnd.github.v3+form` but the new default is `application/json` and does currently work with this type.
