### PR TITLE
Use 404 status code for Fallback routes

### DIFF
--- a/app.js
+++ b/app.js
@@ -34,7 +34,7 @@ app.configure(function(){
   // See https://hacks.mozilla.org/2013/01/building-a-node-js-server-that-wont-melt-a-node-js-holiday-season-part-5/
   app.use(function (req, res, next) {
     // check if we're toobusy
-    if (toobusy()) { 
+    if (toobusy()) {
       res.send(503, 'I\'m busy right now, sorry :(');
     } else {
       next();
@@ -44,7 +44,7 @@ app.configure(function(){
   // Force HTTPS
   if (process.env.NODE_ENV === 'production') {
     app.use(function (req, res, next) {
-      res.setHeader('Strict-Transport-Security', 
+      res.setHeader('Strict-Transport-Security',
         'max-age=8640000; includeSubDomains');
 
       if (req.headers['x-forwarded-proto'] !== 'https') {
@@ -201,9 +201,8 @@ app.get(listRegex('\/', 'script'), main.home);
 app.use(express.static(__dirname + '/public'));
 app.use(function (req, res, next) {
   var user = req.session.user;
-  res.render('404', {
+  res.status(404).render('404', {
     title: '404 Not Found',
-    username: user ? user.name : null 
+    username: user ? user.name : null
   });
 });
-


### PR DESCRIPTION
- Useful for determining what's potentially broken during testing
- Automatic editor white-space cleanup
