### PR TITLE
Correction in emulation of unicode word boundary and detection of first ...

### DIFF
--- a/libs/modelQuery.js
+++ b/libs/modelQuery.js
@@ -46,7 +46,7 @@ var parseSearchConditions = function(q, prefixSearchFields, fullSearchFields) {
   terms.forEach(function (term) {
     var isNonASCII = /^\W/.test(term);
     if (isNonASCII) {
-      prefixStr += '(?=.*?(\|[ \n\r\t.,\'"\+!?-]+)' + term  + ')';
+      prefixStr += '(?=.*?([ \n\r\t.,\'"\+!?-]+)' + term  + ')';
     } else {
       prefixStr += '(?=.*?\\b' + term  + ')';
     }


### PR DESCRIPTION
...char being non-word.
- Match STYLEGUIDE standard for identifier naming
- Remove stray re begin at... grr
- Trim the terms as not allowing searching on spaces

Applies to #133

Try this @sizzlemctwizzle ... I think this covers the bases that have been presented by jesus2099
