### PR TITLE
Fix missing showing of spelling of `@license`

### DIFF
--- a/views/pages/scriptPage.html
+++ b/views/pages/scriptPage.html
@@ -37,6 +37,7 @@
               {{/script.hasGroups}}
               {{#script.meta.homepage}}<p><i class="fa fa-fw fa-home"></i> <b>Homepage:</b> <a href="{{meta.homepage}}">{{script.meta.homepage}}</a></p>{{/script.meta.homepage}}
               {{#script.meta.copyright}}<p><i class="fa fa-fw fa-legal"></i> <b>Copyright:</b> {{script.meta.copyright}}</p>{{/script.meta.copyright}}
+              {{#script.meta.license}}<p><i class="fa fa-fw fa-legal"></i> <b>License:</b> {{script.meta.license}}</p>{{/script.meta.license}}
               {{#script.meta.licence}}<p><i class="fa fa-fw fa-legal"></i> <b>Licence:</b> {{script.meta.licence}}</p>{{/script.meta.licence}}
               {{#script.meta.collaborator}}<p><i class="fa fa-fw fa-user"></i> <b>Collaborator:</b> {{.}}</p>{{/script.meta.collaborator}}
               {{#script.fork}}


### PR DESCRIPTION
Some scripts aren't showing license spelling on script home pages.
