### PR TITLE
Don't set default license on script libraries.

### DIFF
--- a/controllers/script.js
+++ b/controllers/script.js
@@ -84,8 +84,8 @@ var getScriptPageTasks = function(options) {
         options.script.meta.licenses.push({ name: license });
       });
     }
-  } else {
-    options.script.meta.licenses = [{ name: 'MIT License (Expat)' }];
+  } else if (!script.isLib) {
+      options.script.meta.licenses = [{ name: 'MIT License (Expat)' }];
   }
 
   // Show the groups the script belongs to


### PR DESCRIPTION
- I assume that @Zren isn't finished with library pages but notated in [TOS.md](https://github.com/OpenUserJs/OpenUserJS.org/blob/master/TOS.md) that libraries should state in their code what the license is for now.

Since we aren't reading any kind of meta it's going to make things a bit weird until those lib pages are filled out a bit more... so recommend turning this feature off on those pages until it is figured out.

Applies to #161 and tested on dev.
