### PR TITLE
Add "fakes3.bat" for native Windows use.

### DIFF
--- a/fakes3.bat
+++ b/fakes3.bat
@@ -1,0 +1,1 @@
+fakes3 -r fakeS3 -p 10001


### PR DESCRIPTION
This is the Windows version of the Linux/Mac "fakes3.sh" script.  The command ('fakes3 ...') remains the same since the user's Ruby bin (which contains the FakeS3 gem's "fakes3.bat") should be in the system path.
Related to #167
See https://github.com/OpenUserJs/OpenUserJS.org/pull/167#issuecomment-46126043
