### PR TITLE
dev: Fix 404 message for missing favicon.ico

### DIFF
--- a/public/favicon.ico
+++ b/public/favicon.ico
@@ -1,0 +1,1 @@
+images/favicon.ico


### PR DESCRIPTION
- Make a symlink _(soft)_ to favicon.ico for dev to remove the error of not finding the ico. Affects only dev and `/images` path should be used for code refs and edits... ignore any "no newline at end of file" messages or it will break
- Now it will show in dev under Nix... Win7+ or greater is probably required for this to show as found since it handles file symbolic links... XP _(EOLd)_ and before only do dirs.
