### PR TITLE
Fix #137 : Missing scripts within group

### DIFF
--- a/controllers/group.js
+++ b/controllers/group.js
@@ -244,7 +244,7 @@ exports.view = function (req, res, next) {
     scriptListQuery.find({_id: {$in: group._scriptIds}});
 
     // scriptListQuery: isLib=false
-    scriptListQuery.find({isLib: false});
+    scriptListQuery.find({isLib: {$ne: true}});
 
     // scriptListQuery: Defaults
     modelQuery.applyScriptListQueryDefaults(scriptListQuery, options, req);


### PR DESCRIPTION
`script.isLib` isn't guaranteed to be set apparently.
