### PR TITLE
Fix pseudo unique *(e.g. non-upmixed but unique)* `@icon` key to use **last value** only

### DIFF
--- a/libs/modelParser.js
+++ b/libs/modelParser.js
@@ -94,8 +94,8 @@ var parseScript = function(scriptData) {
       script.icon16Url = script.meta.icon;
       script.icon45Url = script.meta.icon;
     } else if (_.isArray(script.meta.icon) && !_.isEmpty(script.meta.icon)) {
-      script.icon16Url = script.meta.icon[0];
-      script.icon45Url = script.meta.icon[script.meta.icon.length >= 2 ? 1 : 1];
+      script.icon16Url = script.meta.icon[script.meta.icon.length - 1];
+      script.icon45Url = script.meta.icon[script.meta.icon.length - 1];
     }
   }
   if (script.meta.icon64) {


### PR DESCRIPTION
This is from GM standards... GM **always** picks last value if there is a conflict to resolve... **not** the first. If we want a specific custom 45px size icon we're going to have to implement one _(for metadata blocks)_ and probably/optionally put in the prefix support portion from CI.

Refs:
- https://github.com/OpenUserJs/OpenUserJS.org/pull/129#issuecomment-45696640

---

Tested in dev ~~as much as can at the moment since script pages are currently offline~~ ... currently shows properly with this pr in [my dev script list](http://localhost:8080/users/Marti/scripts) with uso - More Pages and [my pro script list with this current bug](https://openuserjs.org/users/Marti/scripts). Trying not to have the same/similar mistakes from USO... let's not repeat them please. :)
