### PR TITLE
Auth As Target User. Implement #111

### DIFF
--- a/app.js
+++ b/app.js
@@ -188,6 +188,7 @@ app.get('/:type(scripts|libs)/:username/:namespace?/:scriptname/issues/:topic/:a
 
 // Admin routes
 app.get('/admin', admin.adminPage);
+app.get('/admin/authas', admin.authAsUser);
 app.get('/admin/json', admin.adminJsonView);
 app.get('/admin/user/:id', admin.adminUserView);
 app.get('/admin/api', admin.adminApiKeysPage);

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -122,6 +122,9 @@ var setupUserSidePanel = function (options) {
   if (authedUser && authedUser.isAdmin && (authedUser.role < user.role || options.isYou)) {
     options.adminTools = {};
 
+    // Auth As This User
+    options.adminTools.authAsUserUrl = '/admin/authas?username=' + encodeURIComponent(user.name);
+
     // user.role
     // Allow authedUser to raise target user role to the level below him.
     var roles = _.map(userRoles, function (roleName, index) {

--- a/views/includes/userAdminToolsPanel.html
+++ b/views/includes/userAdminToolsPanel.html
@@ -21,6 +21,7 @@
       </div>
     </form>
     <a href="/admin/json?model=User&id={{{user._id}}}" class="btn btn-link col-xs-12"><i class="fa fa-database"></i> Raw JSON Data</a>
+    {{#adminTools.authAsUserUrl}}<a href="{{{adminTools.authAsUserUrl}}}" class="btn btn-link col-xs-12"><i class="fa fa-sign-in"></i> Auth As This User</a>{{/adminTools.authAsUserUrl}}
   </div>
 </div>
 {{/adminTools}}


### PR DESCRIPTION
Must be of higher rank than target user.

In the future, we should log who does this in the login history.
