### PR TITLE
Repair GH repo page url view only to point to master as committed originally...

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -1004,6 +1004,9 @@ exports.userGitHubRepoPage = function (req, res, next) {
       },
       function (repo, callback) {
         options.repo = repo;
+        options.repoAsEncoded = {
+          default_branch: encodeURI(options.repo.default_branch)
+        }
 
         github.gitdata.getJavascriptBlobs({
           user: encodeURIComponent(repo.owner.login),

--- a/views/pages/userGitHubRepoPage.html
+++ b/views/pages/userGitHubRepoPage.html
@@ -34,7 +34,7 @@
                 </div>
 
                 <p>
-                  <a href="https://github.com/{{repo.owner.login}}/{{repo.name}}/tree/{{repo.default_branch}}}/{{pathAsEncoded.full}}" target="_blank">{{path.dir}}<b>{{path.name}}</b>{{path.ext}}</a>
+                  <a href="https://github.com/{{repo.owner.login}}/{{repo.name}}/tree/{{repoAsEncoded.default_branch}}/{{pathAsEncoded.full}}" target="_blank">{{path.dir}}<b>{{path.name}}</b>{{path.ext}}</a>
                   <span class="label label-default">{{size}} bytes</span>
                 </p>
                 {{#canUpload}}


### PR DESCRIPTION
... in #89

Applies to #200
- I currently see no advantage of pointing the view url to the current `tree/HEAD` when clicking the url to go to GH during the import process. I do however see a disadvantage of not being able to traverse up their breadcrumb list and being locked into a specific commit hash
- Since the import process is probably dependent upon `/tree/HEAD` now leaving that alone
- Add `target="_blank"` to this url since we do this anyways with multiple entries and keeps that window/tab open for importing after checking with GH
- Fix white space issue with optional target after POST routine returns

---

Tested in dev okay.
