### PR TITLE
Remove the BOM from the only file I have found it on.

### DIFF
--- a/views/header.html
+++ b/views/header.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
 
 <head>


### PR DESCRIPTION
If running Linux a good recursive method for detecting these is:

``` sh-session
$ find . -type f -print0 | xargs -0r awk '/^\xEF\xBB\xBF/ {print FILENAME} {nextfile}'
```

Applies to #200 and #198

---

Byte Order Mark _(BOM)_
