### PR TITLE
Ignore duplicate meta data values. Fixes #232

### DIFF
--- a/controllers/scriptStorage.js
+++ b/controllers/scriptStorage.js
@@ -237,7 +237,8 @@ function parseMeta(aString) {
       }
       if (!header[key] || unique[key]) {
         header[key] = value || '';
-      } else {
+      } else if (header[key] !== (value || '')
+          && !(header[key] instanceof Array && header[key].indexOf(value) > -1)) {
         if (!(header[key] instanceof Array)) {
           header[key] = [header[key]];
         }


### PR DESCRIPTION
There's no need for duplicate meta data item. 
I'm considering an item duplicate when **both key and value** are exactly the same.

This will ignore meta data items like

```
// @description value
// @description value
```

But also (see difference in `s` and `c`):

```
// @lisense    MIT
// @license    MIT
```

Doing this in `parseMeta` saves us using [`_.uniq`](http://underscorejs.org/#uniq) for every instance used in the controllers. 
e.g. for `homepageURL` or any other meta data:

``` javascript
_.uniq(script.meta.homepageURL).forEach(function(homepage) {
  ...
});
```

Fixes original bug report in https://github.com/OpenUserJs/OpenUserJS.org/issues/232
