### PR TITLE
Access script source without triggering install count

### DIFF
--- a/app.js
+++ b/app.js
@@ -172,9 +172,13 @@ app.get('/libs/:username/:scriptname', script.lib(script.view));
 app.get('/lib/:scriptname/edit', script.lib(script.edit));
 app.post('/lib/:scriptname/edit', script.lib(script.edit));
 app.get('/libs/:username/:scriptname/source', script.lib(user.editScript));
-app.get('/libs/src/:username/:scriptname', scriptStorage.sendScript);
 app.get('/vote/libs/:username/:scriptname/:vote', script.lib(script.vote));
 //app.get(listRegex('\/use\/lib\/([^\/]+?)\/([^\/]+?)', 'script'), script.useLib);
+
+// Raw source
+app.get('/src/:type(scripts|libs)/:username/:scriptname',
+  scriptStorage.sendScript);
+app.get('/libs/src/:username/:scriptname', scriptStorage.sendScript); // Legacy
 
 // Issues routes
 app_route('/:type(scripts|libs)/:username/:namespace?/:scriptname/issues/:open(closed)?').get(issue.list);

--- a/controllers/scriptStorage.js
+++ b/controllers/scriptStorage.js
@@ -115,8 +115,8 @@ exports.sendScript = function (req, res, next) {
     res.set('Content-Type', 'text/javascript; charset=utf-8');
     stream.pipe(res);
 
-    // Don't count installs on libraries
-    if (script.isLib) { return; }
+    // Don't count installs on raw source route
+    if (script.isLib || req.route.params.type) { return; }
 
     // Update the install count
     ++script.installs;
@@ -232,7 +232,7 @@ exports.storeScript = function (user, meta, buf, callback, update) {
   var libraryRegex = new RegExp('^https?:\/\/' +
     (process.env.NODE_ENV === 'production' ?
       'openuserjs\.org' : 'localhost:8080') +
-    '\/libs\/src\/(.+?\/.+?\.js)$', '');
+    '\/(?:libs\/src|src\/libs)\/(.+?\/.+?\.js)$', '');
 
   if (!meta) { return callback(null); }
 

--- a/libs/modelParser.js
+++ b/libs/modelParser.js
@@ -77,7 +77,7 @@ var getScriptEditSourcePageUrl = function (script) {
 
 var getScriptInstallPageUrl = function (script) {
   var isLib = script.isLib || false;
-  return (isLib ? '/libs/src/' : '/install/') + script.installName;
+  return (isLib ? '/src/libs/' : '/install/') + script.installName;
 };
 
 //


### PR DESCRIPTION
It might be useful to allow access to the script source without triggering the install count. This would discourage people from artificially inflating the install count if they need access to the source for some other reason. I'm weary of people using this instead of uploading their script as a library, but at least this way it won't inflate their install count.

**Unrelated thought**: we really need to implement cache control for library source (since TM is downloading the source every time its internal cache expires). This is causing more bandwidth usage than it should.
