### PR TITLE
Loosen up the death grip on #19 with `switch`

### DIFF
--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -377,7 +377,7 @@ The following **may not** be used:
 * `Function` constructor (it uses `eval()`)
 * `with()` *(it can be highly inconsistent)*
 
-Do not pass strings to `setTimeout` or `setInterval`. They use `eval()`. If you're trying to force some function to run asynchronously use [`setImmediate`](http://nodejs.org/api/timers.html#timers_setimmediate_callback_arg) *(or [`process.nextTick`](http://nodejs.org/api/process.html#process_process_nexttick_callback) if you really know what you're doing)*.
+Do not pass strings to `setTimeout` or `setInterval`. They use `eval()`. If you're trying to force a server side function to run asynchronously use [`setImmediate`](http://nodejs.org/api/timers.html#timers_setimmediate_callback_arg) *(or [`process.nextTick`](http://nodejs.org/api/process.html#process_process_nexttick_callback) if you really know what you're doing)*.
 
 `parseInt()` must be used with a radix parameter, e.g.,
 ```javascript


### PR DESCRIPTION
- `switch` is designed to handle multiple logic cases since ES3 and forward.
- There is no requirement for the prior restrictions in any of the _(external)_ styleguides currently mentioned in #19
- Noted that curly braces can be used for code folding, otherwise they are mostly useless imho and as far as I know
- Added `expressionNth` to the sample with a simple fall through.
- GMs requirement of adding a comment for fallthroughs seems rather tautological since this is how the statement has been in the C family of languages and all of its derivatives for many decades.

---

Unless I'm missing something entirely the prior restriction was/is "ludicrous"... I am open to read any missed reasoning why this was initially drafted into the STYLEGUIDE.md and why we would want to prevent a set of logic paths from being used with a core statement.

See also:
- https://github.com/OpenUserJs/OpenUserJS.org/commit/0263c797d323cdf76be9cd6f11093903ea250b69#commitcomment-6905688 from ~2 days ago which went out to all admins with no response... so bringing it front and center here with a sooner label since there has been some time to think about this already.
