### PR TITLE
Fix url to full paren percent encoding when replying.

### DIFF
--- a/views/includes/scripts/commentReplyScript.html
+++ b/views/includes/scripts/commentReplyScript.html
@@ -10,9 +10,10 @@
     document.location.hash = $comment.attr('id');
 
     var text = $replyTextarea.text();
-    if (!/^\s*$/.test(text))
+    if (!/^\s*$/.test(text)) {
       text += '\n\n'; // Add linebreak if reply already started.
-    text += '[Re](' + document.location.href + '): ';
+    }
+    text += '[Re](' + document.location.href.replace(/\(/g, '%28').replace(/\)/g, '%29') + '): ';
     text += '[@' + $author.text() + '](' + $author.attr('href') + '): ';
     text += '  \n';
     $replyTextarea.text(text);


### PR DESCRIPTION
- Don't know why this isn't done by default with `encodeURI` or `encodeURIComponent` but needs to be done otherwise we end up with `Re#comment-146b1dd0263):` when a script name and/or discussion has parens in it.

---

May apply to #200 ... perhaps needing discussion. As I [mentioned previously](https://github.com/OpenUserJs/OpenUserJS.org/issues/200#issuecomment-47064518), and tested, copying from the Fx/SM address bar encodes parens... but is completely inconsistent in other browsers using that method. Fx/SM isn't immune because `encodeURI` and `encodeURIComponent` don't percent encode parens either... neither does copy link. :\

Tested on dev at [http://localhost:8080/scripts/Marti/RFC_2606%C2%A73_-_license_and_licence_%28recovered%29_Unit_Test/issues/Testing_%28again%29#comment-1471d5de88d](http://localhost:8080/scripts/Marti/RFC_2606%C2%A73_-_license_and_licence_%28recovered%29_Unit_Test/issues/Testing_%28again%29#comment-1471d5de88d)

You can see the historical behavior at [http://localhost:8080/announcements/%5BJust_out_of_curiosity%5D(httpsopenuserjs.org)#comment-146ba914792](http://localhost:8080/announcements/%5BJust_out_of_curiosity%5D%28httpsopenuserjs.org%29#comment-146ba914792) < -- Only messes up when I have site JavaScript enabled for OUJS with NoScript installed.
