### PR TITLE
One of many CSS fixes for #265

### DIFF
--- a/public/css/common.css
+++ b/public/css/common.css
@@ -123,6 +123,7 @@ h2.page-heading {
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 32em;
+  max-width: 20vw;
 }
 
 #reply-control {


### PR DESCRIPTION
Closes #265

Use ellipsis and clip overflow to fixed and viewport width percentage. Viewable on portable devices without severe squishing. Retains original styling with the UI bug fix.

_awaits the usual reviewing_ ;) :)

---

Interim fix via user.js [published here](https://openuserjs.org/scripts/Marti/oujs_-_Issue_268_Interim_Fix) with this.

---

And another more complicated CSS fix provided from @trespassersW at https://openuserjs.org/discuss/The_new_layout#comment-14748b77c97

Similar but inversed to #221 with anchor splitting.
