### PR TITLE
Fix the default sorting to persist in Libraries when clicking...

### DIFF
--- a/views/includes/scriptList.html
+++ b/views/includes/scriptList.html
@@ -1,10 +1,10 @@
 <table class="table table-hover">
   <thead>
     <tr>
-      <th class="text-center"><a href="?orderBy=name&orderDir=asc{{#librariesOnly}}&library=true{{/librariesOnly}}">Name</a></th>
-      <th class="text-center td-fit"><a href="?orderBy=installs&orderDir=desc{{#librariesOnly}}&library=true{{/librariesOnly}}">Installs</a></th>
-      <th class="text-center td-fit"><a href="?orderBy=rating&orderDir=desc{{#librariesOnly}}&library=true{{/librariesOnly}}">Rating</a></th>
-      <th class="text-center td-fit"><a href="?orderBy=updated&orderDir=desc{{#librariesOnly}}&library=true{{/librariesOnly}}">Last Updated</a></th>
+      <th class="text-center"><a href="?orderBy=name&orderDir=asc{{#librariesOnly}}&library=true{{/librariesOnly}}{{#isFlagged}}&flagged=true{{/isFlagged}}">Name</a></th>
+      <th class="text-center td-fit"><a href="?orderBy=installs&orderDir=desc{{#librariesOnly}}&library=true{{/librariesOnly}}{{#isFlagged}}&flagged=true{{/isFlagged}}">Installs</a></th>
+      <th class="text-center td-fit"><a href="?orderBy=rating&orderDir=desc{{#librariesOnly}}&library=true{{/librariesOnly}}{{#isFlagged}}&flagged=true{{/isFlagged}}">Rating</a></th>
+      <th class="text-center td-fit"><a href="?orderBy=updated&orderDir=desc{{#librariesOnly}}&library=true{{/librariesOnly}}{{#isFlagged}}&flagged=true{{/isFlagged}}">Last Updated</a></th>
     </tr>
   </thead>
   <tbody>


### PR DESCRIPTION
... `Name`, `Installs`, `Rating` and `Last Updated`
