### PR TITLE
Add the Greasemonkey API to highlighting and let ACE know it's a global ...

### DIFF
--- a/public/js/ace/mode-javascript.js
+++ b/public/js/ace/mode-javascript.js
@@ -61,7 +61,7 @@ var JavaScriptHighlightRules = function() {
             "decodeURI|decodeURIComponent|encodeURI|encodeURIComponent|eval|isFinite|" + // Non-constructor functions
             "isNaN|parseFloat|parseInt|"                                               +
             "JSON|Math|"                                                               + // Other
-            "GM_getValue|GM_listValues|GM_setClipboard|GM_setValue|GM_getResourceText|GM_getResourceURL|GM_addStyle|GM_xmlhttpRequest|GM_log|GM_openInTab|GM_registerMenuCommand|"  + // GM_*
+            "GM_getValue|GM_listValues|GM_setClipboard|GM_setValue|GM_getResourceText|GM_getResourceURL|GM_addStyle|GM_xmlhttpRequest|GM_log|GM_openInTab|GM_registerMenuCommand|unsafeWindow|"  + // GM API
             "this|arguments|prototype|window|document"                                 , // Pseudo
         "keyword":
             "const|yield|import|get|set|" +

--- a/public/js/ace/worker-javascript.js
+++ b/public/js/ace/worker-javascript.js
@@ -9007,6 +9007,7 @@ exports.browser = {
   SVGZoomAndPan        : false,
   TimeEvent            : false,
   top                  : false,
+  unsafeWindow         : false,
   URL                  : false,
   WebSocket            : false,
   window               : false,


### PR DESCRIPTION
...object set
- This will remove a ton of the little yellow triangles. If ACE is ever updated we'll need to readd this to our local copy if they change it.
- Automatic editor whitespace adjustment
