### PR TITLE
Post fixes for #309

### DIFF
--- a/libs/templateHelpers.js
+++ b/libs/templateHelpers.js
@@ -139,9 +139,13 @@ exports.pageMetadata = pageMetadata;
 
 // Switch order direction.
 function orderDir(aReq, aOptions, aOrderBy, aOrderDirDefault) {
+  var orderDirReverse = null;
+
   aOrderDirDefault = aOrderDirDefault || 'desc';
-  var aOrderDirReverse = (aOrderDirDefault === 'desc') ? 'asc' : 'desc';
-  if (typeof (aOptions.orderDir) === 'undefined') aOptions.orderDir = {};
-  aOptions.orderDir[aOrderBy] = aReq.query.orderDir === aOrderDirDefault ? aOrderDirReverse : aOrderDirDefault;
+  orderDirReverse = (aOrderDirDefault === 'desc') ? 'asc' : 'desc';
+  if (typeof (aOptions.orderDir) === 'undefined') {
+    aOptions.orderDir = {};
+  }
+  aOptions.orderDir[aOrderBy] = aReq.query.orderDir === aOrderDirDefault ? orderDirReverse : aOrderDirDefault;
 }
 exports.orderDir = orderDir;

--- a/views/includes/discussionList.html
+++ b/views/includes/discussionList.html
@@ -2,15 +2,15 @@
   <table class="table table-hover table-condensed table-striped">
     <thead>
       <tr>
-        <th class="text-center"><a href="?orderBy=topic&orderDir={{{orderDir.topic}}}">Topic</a></th>
+        <th class="text-center"><a href="?orderBy=topic&orderDir={{orderDir.topic}}">Topic</a></th>
         {{#multipleCategories}}
         <th class="text-center td-fit">Category</th>
         {{/multipleCategories}}
         <th class="text-center td-fit">Users</th>
-        <th class="text-center td-fit"><a href="?orderBy=comments&orderDir={{{orderDir.comments}}}">Replies</a></th>
+        <th class="text-center td-fit"><a href="?orderBy=comments&orderDir={{orderDir.comments}}">Replies</a></th>
         <th class="text-center td-fit">Views</th>
-        <th class="text-center td-fit"><a href="?orderBy=created&orderDir={{{orderDir.created}}}">Created</a></th>
-        <th class="text-center td-fit"><a href="?orderBy=updated&orderDir={{{orderDir.updated}}}">Updated</a></th>
+        <th class="text-center td-fit"><a href="?orderBy=created&orderDir={{orderDir.created}}">Created</a></th>
+        <th class="text-center td-fit"><a href="?orderBy=updated&orderDir={{orderDir.updated}}">Updated</a></th>
       </tr>
     </thead>
     <tbody>

--- a/views/includes/groupList.html
+++ b/views/includes/groupList.html
@@ -1,9 +1,9 @@
 <table class="table table-hover table-condensed">
   <thead>
     <tr>
-      <th><a href="?orderBy=name&orderDir={{{orderDir.name}}}">Name</a></th>
+      <th><a href="?orderBy=name&orderDir={{orderDir.name}}">Name</a></th>
       <th class="text-center">Size</th>
-      <th class="text-center"><a href="?orderBy=rating&orderDir={{{orderDir.rating}}}">Rating</a></th>
+      <th class="text-center"><a href="?orderBy=rating&orderDir={{orderDir.rating}}">Rating</a></th>
     </tr>
   </thead>
   <tbody>

--- a/views/includes/removedItemList.html
+++ b/views/includes/removedItemList.html
@@ -1,11 +1,11 @@
 <table class="table table-hover table-condensed">
   <thead>
     <tr>
-      <th class="text-center td-fit"><a href="?orderBy=model&orderDir={{{orderDir.model}}}">Type</a></th>
+      <th class="text-center td-fit"><a href="?orderBy=model&orderDir={{orderDir.model}}">Type</a></th>
       <th>Item</th>
       <th>Reason</th>
-      <th class="text-center td-fit"><a href="?orderBy=removerName&orderDir={{{orderDir.removerName}}}">Removed By</a></th>
-      <th class="text-center td-fit"><a href="?orderBy=removed&orderDir={{{orderDir.removed}}}">Date</a></th>
+      <th class="text-center td-fit"><a href="?orderBy=removerName&orderDir={{orderDir.removerName}}">Removed By</a></th>
+      <th class="text-center td-fit"><a href="?orderBy=removed&orderDir={{orderDir.removed}}">Date</a></th>
     </tr>
   </thead>
   <tbody>

--- a/views/includes/scriptList.html
+++ b/views/includes/scriptList.html
@@ -1,10 +1,10 @@
 <table class="table table-hover">
   <thead>
     <tr>
-      <th class="text-center"><a href="?orderBy=name&orderDir={{{orderDir.name}}}{{#librariesOnly}}&library=true{{/librariesOnly}}{{#isFlagged}}&flagged=true{{/isFlagged}}">Name</a></th>
-      <th class="text-center td-fit"><a href="?orderBy=installs&orderDir={{{orderDir.install}}}{{#librariesOnly}}&library=true{{/librariesOnly}}{{#isFlagged}}&flagged=true{{/isFlagged}}">Installs</a></th>
-      <th class="text-center td-fit"><a href="?orderBy=rating&orderDir={{{orderDir.rating}}}{{#librariesOnly}}&library=true{{/librariesOnly}}{{#isFlagged}}&flagged=true{{/isFlagged}}">Rating</a></th>
-      <th class="text-center td-fit"><a href="?orderBy=updated&orderDir={{{orderDir.updated}}}{{#librariesOnly}}&library=true{{/librariesOnly}}{{#isFlagged}}&flagged=true{{/isFlagged}}">Last Updated</a></th>
+      <th class="text-center"><a href="?orderBy=name&orderDir={{orderDir.name}}{{#librariesOnly}}&library=true{{/librariesOnly}}{{#isFlagged}}&flagged=true{{/isFlagged}}">Name</a></th>
+      <th class="text-center td-fit"><a href="?orderBy=installs&orderDir={{orderDir.install}}{{#librariesOnly}}&library=true{{/librariesOnly}}{{#isFlagged}}&flagged=true{{/isFlagged}}">Installs</a></th>
+      <th class="text-center td-fit"><a href="?orderBy=rating&orderDir={{orderDir.rating}}{{#librariesOnly}}&library=true{{/librariesOnly}}{{#isFlagged}}&flagged=true{{/isFlagged}}">Rating</a></th>
+      <th class="text-center td-fit"><a href="?orderBy=updated&orderDir={{orderDir.updated}}{{#librariesOnly}}&library=true{{/librariesOnly}}{{#isFlagged}}&flagged=true{{/isFlagged}}">Last Updated</a></th>
     </tr>
   </thead>
   <tbody>

--- a/views/includes/userList.html
+++ b/views/includes/userList.html
@@ -1,8 +1,8 @@
 <table class="table table-hover table-condensed">
   <thead>
     <tr>
-      <th><a href="?orderBy=name&orderDir={{{orderDir.name}}}{{#isFlagged}}&flagged=true{{/isFlagged}}">Name</a></th>
-      <th><a href="?orderBy=role&orderDir={{{orderDir.role}}}{{#isFlagged}}&flagged=true{{/isFlagged}}">Rank</a></th>
+      <th><a href="?orderBy=name&orderDir={{orderDir.name}}{{#isFlagged}}&flagged=true{{/isFlagged}}">Name</a></th>
+      <th><a href="?orderBy=role&orderDir={{orderDir.role}}{{#isFlagged}}&flagged=true{{/isFlagged}}">Rank</a></th>
     </tr>
   </thead>
   <tbody>


### PR DESCRIPTION
- STYLEGUIDE fixes
- Named local variable to be local instead of argument
- Use `{{` instead of `{{{` to present any boogs that may appear later on... makes them quite visible.
