### PR TITLE
Add Script.installsSinceUpdate & show in author panel.

### DIFF
--- a/controllers/scriptStorage.js
+++ b/controllers/scriptStorage.js
@@ -74,6 +74,8 @@ exports.sendScript = function (aReq, aRes, aNext) {
 
     // Update the install count
     ++aScript.installs;
+    ++aScript.installsSinceUpdate;
+
     aScript.save(function (aErr, aScript) { });
   });
 };
@@ -298,6 +300,7 @@ exports.storeScript = function (aUser, aMeta, aBuf, aCallback, aUpdate) {
       if (aRemoved || (!aScript && (aUpdate || collaborators))) {
         return aCallback(null);
       } else if (!aScript) {
+        // New script
         aScript = new Script({
           name: isLibrary ? aMeta : aMeta.name,
           author: aUser.name,
@@ -315,6 +318,7 @@ exports.storeScript = function (aUser, aMeta, aBuf, aCallback, aUpdate) {
           _authorId: aUser._id
         });
       } else {
+        // Script already exists.
         if (!aScript.isLib) {
           if (collaborators && (aScript.meta.oujs && aScript.meta.oujs.author != aMeta.oujs.author
               || (aScript.meta.oujs && JSON.stringify(aScript.meta.oujs.collaborator) !=
@@ -325,6 +329,7 @@ exports.storeScript = function (aUser, aMeta, aBuf, aCallback, aUpdate) {
           aScript.uses = libraries;
         }
         aScript.updated = new Date();
+        aScript.installsSinceUpdate = 0;
       }
 
       aScript.save(function (aErr, aScript) {

--- a/models/script.js
+++ b/models/script.js
@@ -7,7 +7,8 @@ var scriptSchema = new Schema({
   // Visible
   name: String,
   author: String,
-  installs: Number,
+  installs: { type: Number, default: 0 },
+  installsSinceUpdate: { type: Number, default: 0 },
   rating: Number,
   about: String,
   updated: Date,

--- a/views/includes/scriptAuthorToolsPanel.html
+++ b/views/includes/scriptAuthorToolsPanel.html
@@ -8,6 +8,12 @@
       <li><a href="{{{script.scriptEditMetadataPageUrl}}}"><i class="fa fa-edit"></i> Edit Script Info</a></li>
       <li><a href="{{{script.scriptEditSourcePageUrl}}}"><i class="fa fa-file-text"></i> Edit Script</a></li>
     </ul>
+
+    <hr>
+
+    <h4>Installs per Version <small>since <time>2 Sept 2014</time></small></h4>
+
+    <p><code>{{script.meta.version}}{{^script.meta.version}}Current{{/script.meta.version}}</code> <span class="label label-default">{{script.installsSinceUpdate}} installs</span></p>
   </div>
 </div>
 <div class="panel panel-danger">


### PR DESCRIPTION
![](http://i.imgur.com/9WyumBq.png)

This only tracks the current version right now.

This is one method of creating a useful install count. We could expand on this by adding another property with `{ type: Object }` that contains `{ version: installCount, version: installCount }`.

Only shown in the author panel for now.
