### PR TITLE
Sort by group size (Mentioned in #306). Popular groups sortBy -size

### DIFF
--- a/controllers/group.js
+++ b/controllers/group.js
@@ -114,12 +114,13 @@ exports.addScriptToGroups = function (aScript, aGroupNames, aCallback) {
     async.parallel(tasks, function () {
       aScript.save(aCallback);
 
-      // Update the group ratings in the background
+      // Update the groups in the background
       aGroups.forEach(function (aGroup) {
         Script.find({ _id: { $in: aGroup._scriptIds } }, // TODO: STYLEGUIDE.md conformance needed here
           function (aErr, aScripts) {
             if (aErr || aScripts.length < 2) { return; }
 
+            aGroup.size = aScripts.length;
             aGroup.rating = getRating(aScripts);
             aGroup.updated = new Date();
             aGroup.save(function () { });
@@ -167,6 +168,7 @@ exports.list = function (aReq, aRes) {
 
   // Order dir
   orderDir(aReq, options, 'name', 'asc');
+  orderDir(aReq, options, 'size', 'desc');
   orderDir(aReq, options, 'rating', 'desc');
 
   // groupListQuery
@@ -181,7 +183,7 @@ exports.list = function (aReq, aRes) {
   // popularGroupListQuery
   var popularGroupListQuery = Group.find();
   popularGroupListQuery
-    .sort('-rating')
+    .sort('-size')
     .limit(25);
 
   //--- Tasks
@@ -299,7 +301,7 @@ exports.view = function (aReq, aRes, aNext) {
     // popularGroupListQuery
     var popularGroupListQuery = Group.find();
     popularGroupListQuery
-      .sort('-rating')
+      .sort('-size')
       .limit(25);
 
     // SideBar

--- a/controllers/index.js
+++ b/controllers/index.js
@@ -64,7 +64,7 @@ exports.home = function (aReq, aRes) {
   // popularGroupListQuery
   var popularGroupListQuery = Group.find();
   popularGroupListQuery
-    .sort('-rating')
+    .sort('-size')
     .limit(25);
 
   // Announcements

--- a/libs/modelParser.js
+++ b/libs/modelParser.js
@@ -271,7 +271,9 @@ var parseGroup = function (aGroupData) {
   // Intermediates
   var group = aGroupData;
 
-  group.size = group._scriptIds.length;
+  if (!group.size) {
+    group.size = group._scriptIds.length;
+  }
   group.multiple = group._scriptIds.length > 1;
 
   group.groupPageUrl = '/group/' + group.name.replace(/\s+/g, '_');
@@ -283,6 +285,7 @@ var parseGroup = function (aGroupData) {
       _id: { $in: group._scriptIds }
     }, function (aErr, aScripts) {
       if (!aErr && aScripts.length > 1) {
+        group.size = aScripts.length;
         group.rating = getRating(aScripts);
       }
 

--- a/models/group.js
+++ b/models/group.js
@@ -2,12 +2,14 @@
 
 var mongoose = require('mongoose');
 var Schema = mongoose.Schema;
+var ObjectId = Schema.Types.ObjectId;
 
 var groupSchema = new Schema({
-  name: String,
-  rating: Number,
-  updated: Date,
-  _scriptIds: [Schema.Types.ObjectId]
+  name: { type: String },
+  rating: { tpye: Number, default: 0 },
+  updated: { type: Date, default: Date.now },
+  _scriptIds: [{ type: ObjectId, ref: 'Script' }],
+  size: { type: Number, default: 0 }
 });
 
 var Group = mongoose.model('Group', groupSchema);

--- a/views/includes/groupList.html
+++ b/views/includes/groupList.html
@@ -2,7 +2,7 @@
   <thead>
     <tr>
       <th><a href="?orderBy=name&orderDir={{orderDir.name}}">Name</a></th>
-      <th class="text-center">Size</th>
+      <th class="text-center"><a href="?orderBy=size&orderDir={{orderDir.size}}">Size</a></th>
       <th class="text-center"><a href="?orderBy=rating&orderDir={{orderDir.rating}}">Rating</a></th>
     </tr>
   </thead>

--- a/views/includes/popularGroupsPanel.html
+++ b/views/includes/popularGroupsPanel.html
@@ -1,7 +1,7 @@
 <div class="panel panel-default">
-  <div class="panel-heading">
+  <a href="/groups?orderBy=size&orderDir=desc" class="panel-heading">
     <div class="panel-title">Popular Groups</div>
-  </div>
+  </a>
   <div class="panel-body">
     <ul class="tagcloud">
       {{#popularGroupList}}


### PR DESCRIPTION
Will lazily update over 2h after pushing.
Linkifies Popular Group heading. Depends on #332 for CSS.

Edit: 
Need to merge #332 beforehand, but otherwise this is PR READY.
I changed the sort order for popular groups to be by size rather than rating.
