### PR TITLE
Fix #294 Show rendered line breaks & other misc options clientside.

### DIFF
--- a/libs/markdown.js
+++ b/libs/markdown.js
@@ -55,6 +55,7 @@ renderer.heading = function (aText, aLevel) {
 };
 
 // Set the options to use for rendering markdown
+// Keep in sync with ./views/includes/scripts/markdownEditor.html
 marked.setOptions({
   highlight: function (aCode, aLang) {
     if (aLang && hljs.getLanguage(aLang)) {

--- a/views/includes/scripts/markdownEditor.html
+++ b/views/includes/scripts/markdownEditor.html
@@ -1,0 +1,17 @@
+<!-- Markdown Editor -->
+<script type="text/javascript" src="/js/marked.js"></script>
+<script type="text/javascript" src="/js/bootstrap-markdown.js"></script>
+<script>
+  // Keep in sync with ./libs/markdown.js
+  marked.setOptions({
+    // highlight: ...
+    // renderer: ...
+    gfm: true,
+    tables: true,
+    breaks: true,
+    pedantic: false,
+    // sanitize: ...
+    smartLists: true,
+    smartypants: false
+  });
+</script>

--- a/views/pages/discussionPage.html
+++ b/views/pages/discussionPage.html
@@ -46,9 +46,7 @@
   <div id="show-reply-form-when-visible"></div>
   {{> includes/commentForm.html }}
   {{> includes/footer.html }}
-  <!-- Markdown Editor -->
-  <script type="text/javascript" src="/js/marked.js"></script>
-  <script type="text/javascript" src="/js/bootstrap-markdown.js"></script>
+  {{> includes/scripts/markdownEditor.html }}
   {{> includes/scripts/commentReplyScript.html }}
 </body>
 </html>

--- a/views/pages/newDiscussionPage.html
+++ b/views/pages/newDiscussionPage.html
@@ -36,8 +36,6 @@
     </div>
   </div>
   {{> includes/footer.html }}
-  <!-- Markdown Editor -->
-  <script type="text/javascript" src="/js/marked.js"></script>
-  <script type="text/javascript" src="/js/bootstrap-markdown.js"></script>
+  {{> includes/scripts/markdownEditor.html }}
 </body>
 </html>

--- a/views/pages/scriptEditMetadataPage.html
+++ b/views/pages/scriptEditMetadataPage.html
@@ -50,9 +50,7 @@
     </form>
   </div>
   {{> includes/footer.html }}
-  <!-- Markdown Editor -->
-  <script type="text/javascript" src="/js/marked.js"></script>
-  <script type="text/javascript" src="/js/bootstrap-markdown.js"></script>
+  {{> includes/scripts/markdownEditor.html }}
   <!-- Group Selector -->
   <script type="text/javascript" src="/js/select2.js"></script>
   <script type="text/javascript">

--- a/views/pages/scriptIssuePage.html
+++ b/views/pages/scriptIssuePage.html
@@ -54,9 +54,7 @@
   {{> includes/commentForm.html }}
 
   {{> includes/footer.html }}
-  <!-- Markdown Editor -->
-  <script type="text/javascript" src="/js/marked.js"></script>
-  <script type="text/javascript" src="/js/bootstrap-markdown.js"></script>
+  {{> includes/scripts/markdownEditor.html }}
   {{> includes/scripts/commentReplyScript.html }}
 </body>
 </html>

--- a/views/pages/scriptNewIssuePage.html
+++ b/views/pages/scriptNewIssuePage.html
@@ -39,8 +39,6 @@
   </div>
 
   {{> includes/footer.html }}
-  <!-- Markdown Editor -->
-  <script type="text/javascript" src="/js/marked.js"></script>
-  <script type="text/javascript" src="/js/bootstrap-markdown.js"></script>
+  {{> includes/scripts/markdownEditor.html }}
 </body>
 </html>

--- a/views/pages/userEditProfilePage.html
+++ b/views/pages/userEditProfilePage.html
@@ -30,8 +30,6 @@
     </div>
   </div>
   {{> includes/footer.html }}
-  <!-- Markdown Editor -->
-  <script type="text/javascript" src="/js/marked.js"></script>
-  <script type="text/javascript" src="/js/bootstrap-markdown.js"></script>
+  {{> includes/scripts/markdownEditor.html }}
 </body>
 </html>


### PR DESCRIPTION
In the future, we could render the other custom code (heading links) and such, but this should be fine for now.

All thanks to the answer here: https://github.com/toopay/bootstrap-markdown/issues/63
