### PR TITLE
Insert a BOM check for import and file upload

### DIFF
--- a/controllers/scriptStorage.js
+++ b/controllers/scriptStorage.js
@@ -227,11 +227,12 @@ exports.getMeta = function (aChunks, aCallback) {
   var str = '';
   var i = 0;
   var len = aChunks.length;
+  var header = null;
 
   for (; i < aChunks.length; ++i) {
-    var header = null;
+    header = null;
     str += aChunks[i];
-    header = /^\/\/ ==UserScript==([\s\S]*?)^\/\/ ==\/UserScript==/m.exec(str);
+    header = /^(?:\uFEFF)?\/\/ ==UserScript==([\s\S]*?)^\/\/ ==\/UserScript==/m.exec(str);
 
     if (header && header[1]) { return aCallback(parseMeta(header[1], true)); }
   }

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -925,7 +925,7 @@ exports.userGitHubImportScriptPage = function (aReq, aRes, aNext) {
 
       if (options.javascriptBlob.isUserJS) {
         //
-        var userscriptHeaderRegex = /^\/\/ ==UserScript==([\s\S]*?)^\/\/ ==\/UserScript==/m;
+        var userscriptHeaderRegex = /^(?:\uFEFF)?\/\/ ==UserScript==([\s\S]*?)^\/\/ ==\/UserScript==/m;
         var m = userscriptHeaderRegex.exec(aBlobUtf8);
         if (m && m[1]) {
           var userscriptMeta = scriptStorage.parseMeta(m[1], true);


### PR DESCRIPTION
- Similar to @janekptacijarabaci fix in greasemonkey/greasemonkey#1940 _(Node.js via dev is currently using UTF-16 Big Endian strings from [test file](/cvzi/Userscripts/blob/master/UTF8BOM_test/UTF8%20BOM%20test.user.js),  [mirrored at](/Martii/UserScripts/blob/master/src/RFC%202606%C2%A73/BOM%20test/UTF8%20BOM%20test.user.js), notated from [this comment](https://github.com/OpenUserJs/OpenUserJS.org/issues/200#issuecomment-55102781))_
- Fix compliance with STYLEGUIDE.md and usage of pre-initialized identifiers
- Currently **do not** propagate BOM _([Byte Order Mark](http://www.wikipedia.org/wiki/Byte_order_mark))_ with meta routine ~~or user.js source with and without installation count increment~~ _(whoops it does the part striked out by default but everyone should get my point with the meta routine... e.g. doesn't appear to be needed in there)_
- BOM currently shows up in Ace as a exclamation triangle with "This character may get silently deleted by one or more browsers" on dev.

**NOTE**: Many thanks to the report by @cvzi and applies to #200 and partially outlined in #198.

---

Tested on dev with [this script](http://localhost:8080/scripts/Marti/UTF8_BOM_test_%C3%B6_%E8%B4%B4%E5%90%A7%E6%A8%A1%E7%BB%84%E5%B1%8F%E8%94%BD) in `Mozilla/5.0 (X11; Linux x86_64; rv:32.0) Gecko/20100101 Firefox/32.0`
