### PR TITLE
Address the app generated 503s

### DIFF
--- a/app.js
+++ b/app.js
@@ -33,6 +33,7 @@ var sessionStore = new MongoStore({ mongoose_connection: db });
 // See https://hacks.mozilla.org/2013/01/building-a-node-js-server-that-wont-melt-a-node-js-holiday-season-part-5/
 app.use(function (aReq, aRes, aNext) {
   // check if we're toobusy
+  toobusy.maxLag(100);
   if (toobusy()) {
     statusCodePage(aReq, aRes, aNext, {
       statusCode: 503,

--- a/routes.js
+++ b/routes.js
@@ -150,6 +150,34 @@ module.exports = function (aApp) {
   // Home route
   app_route('/').get(main.home);
 
+  // Order is important here...
+  // Only referer check statics otherwise SEO will have issues
+  aApp.use(function (aReq, aRes, aNext) {
+    if (process.env.NODE_ENV === 'production'
+      && !/^https?:\/\/(?:.*\.)?(?:openuserjs|oujs)\.org/.test(aReq.headers.referer)) {
+
+      // Whitelist
+      switch (aReq.url) {
+        case '/images/favicon.ico':
+        case '/images/favicon16.ico':
+        case '/images/favicon64.png':
+        case '/xml/opensearch-groups.xml':
+        case '/xml/opensearch-libraries.xml':
+        case '/xml/opensearch-scripts.xml':
+        case '/xml/opensearch-users.xml':
+          aNext();
+          break;
+        default:
+          statusCodePage(aReq, aRes, aNext, {
+            statusCode: 404,
+            statusMessage: 'This is not the page you\'re are looking for!'
+          });
+      }
+    } else {
+      aNext();
+    }
+  });
+
   // Static Routes
   require('./routesStatic')(aApp);
 

--- a/routesStatic.js
+++ b/routesStatic.js
@@ -32,7 +32,7 @@ module.exports = function (aApp) {
     }
   }
 
-  aApp.use(express.static(path.join(__dirname, '/public'), { maxage: day * 1 }));
+  aApp.use(express.static(path.join(__dirname, 'public'), { maxage: day * 1 }));
 
   serveModule('/redist/npm', 'bootstrap', {
     'dist/js/bootstrap.js': { maxage: day * 1 }


### PR DESCRIPTION
- Use proper usage of `maxLag` for process bump.
- Add in simple referer check mentioned in #343 to prevent SEO/abuse.
- Remove separator from `./routesStatic.js` and let `join` do it's op.

Closes #345

**NOTE**: Server cloud services may already handle load balancing but keeping this in for the time being... if it crops up again, bump to a maximum of 175ms. toobusy-js does use timers that are never stopped even at the equivalent of `document-idle` event state. If this package proves long term to be an issue remove it completely... however during testing period it **PASSED**.
