### PR TITLE
Remove package toobusy-js

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ Repository | Reference | Recent Version
 [request][requestGHUrl] | [Documentation][requestDOCUrl] | [![NPM version][requestNPMVersionImage]][requestNPMUrl]
 [sanitize-html][sanitize-htmlGHUrl] | [Documentation][sanitize-htmlDOCUrl] | [![NPM version][sanitize-htmlNPMVersionImage]][sanitize-htmlNPMUrl]
 [select2][select2GHUrl] | [Documentation][select2DOCUrl] | [![NPM version][select2NPMVersionImage]][select2NPMUrl]
-[toobusy-js][toobusy-jsGHUrl] | [Documentation][toobusy-jsDOCUrl] | [![NPM version][toobusy-jsNPMVersionImage]][toobusy-jsNPMUrl]
 [underscore][underscoreGHUrl] | [Documentation][underscoreDOCUrl] | [![NPM version][underscoreNPMVersionImage]][underscoreNPMUrl]
 
 
@@ -239,11 +238,6 @@ Repository | Reference | Recent Version | Referenced
 [sanitize-htmlDOCUrl]: https://github.com/punkave/sanitize-html/blob/master/README.md
 [sanitize-htmlNPMUrl]: https://npmjs.org/package/sanitize-html
 [sanitize-htmlNPMVersionImage]: https://img.shields.io/npm/v/sanitize-html.svg?style=flat
-
-[toobusy-jsGHUrl]: https://github.com/STRML/node-toobusy
-[toobusy-jsDOCUrl]: https://github.com/STRML/node-toobusy/blob/master/README.md
-[toobusy-jsNPMUrl]: https://npmjs.org/package/toobusy-js
-[toobusy-jsNPMVersionImage]: https://img.shields.io/npm/v/toobusy-js.svg?style=flat
 
 [underscoreGHUrl]: https://github.com/jashkenas/underscore
 [underscoreDOCUrl]: http://underscorejs.org/

--- a/app.js
+++ b/app.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var toobusy = require('toobusy-js');
 var express = require('express');
 var minify = require('express-minify');
 var MongoStore = require('connect-mongo')(express);
@@ -29,20 +28,6 @@ db.once('open', function () {
 });
 
 var sessionStore = new MongoStore({ mongoose_connection: db });
-
-// See https://hacks.mozilla.org/2013/01/building-a-node-js-server-that-wont-melt-a-node-js-holiday-season-part-5/
-app.use(function (aReq, aRes, aNext) {
-  // check if we're toobusy
-  toobusy.maxLag(100);
-  if (toobusy()) {
-    statusCodePage(aReq, aRes, aNext, {
-      statusCode: 503,
-      statusMessage: 'We\'re busy right now. Try again later.',
-    });
-  } else {
-    aNext();
-  }
-});
 
 // Force HTTPS
 if (app.get('port') === 443) {


### PR DESCRIPTION
- Additional testing data info received that it works okay without it. This closes the `document-idle` equivalent detected timers previously mentioned.
