### PR TITLE
Set maximum script upload size to 1 MiB

### DIFF
--- a/models/settings.json
+++ b/models/settings.json
@@ -1,5 +1,5 @@
 {
   "secret" : "someSecretStringForSession",
   "connect" : "mongodb://nodejitsu_sizzlemctwizzle:b6vrl5hvkv2a3vvbaq1nor7fdl@ds045978.mongolab.com:45978/nodejitsu_sizzlemctwizzle_nodejitsudb8203815757",
-  "maximum_upload_script_size": 500000
+  "maximum_upload_script_size": 1048576
 }


### PR DESCRIPTION
- Same as USO was... recommend no higher to keep scripts legit and encourage use of `@require` and `@resource` for those types of scripts.

Closes #360
