### PR TITLE
Fix moment deprecation warnings

### DIFF
--- a/libs/modelParser.js
+++ b/libs/modelParser.js
@@ -30,7 +30,7 @@ var momentLangTinyDate = function (aDate) {
     return '[' + aDate.format("MMM 'YY") + ']';
   }
 };
-moment.lang('en-tiny', {
+moment.locale('en-tiny', {
   calendar : {
     sameDay : function () { return momentLangFromNow(this); },
     lastDay : function () { return momentLangFromNow(this); },
@@ -59,7 +59,7 @@ moment.lang('en-tiny', {
 var parseDateProperty = function (aObj, aKey) {
   var date = aObj[aKey];
   aObj[aKey + 'ISOFormat'] = date.toISOString();
-  aObj[aKey + 'Humanized'] = moment(date).lang('en-tiny').calendar();
+  aObj[aKey + 'Humanized'] = moment(date).locale('en-tiny').calendar();
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "github": "0.2.1",
     "highlight.js": "8.2.0",
     "marked": "0.3.2",
-    "moment": "2.8.2",
+    "moment": "2.8.3",
     "mongoose": "3.8.15",
     "mu2": "0.5.20",
     "passport": "0.2.0",


### PR DESCRIPTION
- This is still a little vague however it looks like it should be `locale` instead of `localeData` and does appear to work on dev.
- Update dependency in package to current version

External ref https://github.com/moment/moment/issues/1879#issuecomment-55341059

Affects #315
