### PR TITLE
Additional fix for icon size from #344

### DIFF
--- a/views/pages/scriptPage.html
+++ b/views/pages/scriptPage.html
@@ -88,7 +88,7 @@
             <ul>
             {{#script.usedBy}}
               <li>
-                <span class="script-icon hidden-xs">
+                <span class="page-heading-icon hidden-xs">
                   {{#icon16Url}}
                     <img src="{{{icon16Url}}}" alt="">
                   {{/icon16Url}}


### PR DESCRIPTION
- For actual library pages resize the lib icons too not just the script page list
