### PR TITLE
Fix full screen editor in bootstrap-markdown editor

### DIFF
--- a/public/css/common.css
+++ b/public/css/common.css
@@ -137,10 +137,6 @@ h2.page-heading {
   position: fixed;
 }
 
-#reply-control .md-editor {
-  height: 300px;
-}
-
 .md-editor {
   min-height: 300px;
 }


### PR DESCRIPTION
- Remove initial sizing

See also:
- #347
