### PR TITLE
More icon fixes

### DIFF
--- a/public/css/common.css
+++ b/public/css/common.css
@@ -262,6 +262,7 @@ h6:hover a.anchor {
 .user-content code,
 .document-content code {
   white-space: pre-wrap;
+  word-break: break-all;
 }
 .user-data img,
 .user-content img,

--- a/views/includes/comment.html
+++ b/views/includes/comment.html
@@ -26,7 +26,7 @@
           <section class="post-menu-area">
             <nav class="post-controls text-right">
               <button class="btn btn-sm btn-info btn-comment-reply" title="begin composing a reply to this post">
-                <i class="fa fa-reply"></i> Reply
+                <i class="fa fa-fw fa-reply"></i> Reply
               </button>
             </nav>
           </section>

--- a/views/includes/commentEditor.html
+++ b/views/includes/commentEditor.html
@@ -25,8 +25,8 @@
           </div>
           <section class="post-menu-area">
             <nav class="post-controls text-right">
-              <button class="btn btn-sm btn-info" title="submit your comment" type="submit">
-                <i class="fa fa-reply"></i> Submit
+              <button class="btn btn-sm btn-success" title="submit your comment" type="submit">
+                <i class="fa fa-fw fa-reply"></i> Submit
               </button>
             </nav>
           </section>

--- a/views/includes/commentForm.html
+++ b/views/includes/commentForm.html
@@ -2,8 +2,8 @@
   <form action="{{{discussion.discussionPageUrl}}}" method="post">
     <div class="container-fluid row user-content">
       <div class="submit-panel pull-right btn-toolbar">
-        <button class="btn btn-sm btn-success" type="submit">Reply</button>
-        <button class="btn btn-sm btn-danger" type="button" data-toggle="collapse" data-target="#reply-control">Cancel</button>
+        <button class="btn btn-sm btn-success" type="submit"><i class="fa fa-reply"></i> Reply</button>
+        <button class="btn btn-sm btn-danger" type="button" data-toggle="collapse" data-target="#reply-control"><i class="fa fa-close"></i> Cancel</button>
       </div>
       <textarea name="comment-content" data-provide="markdown" data-iconlibrary="fa" class="col-xs-12" placeholder="Type here using Markdown."></textarea>
     </div>

--- a/views/includes/scriptAuthorToolsPanel.html
+++ b/views/includes/scriptAuthorToolsPanel.html
@@ -1,7 +1,7 @@
 {{#authorTools}}
 <div class="panel panel-default">
   <div class="panel-heading">
-    <div class="panel-title">Author Tools</div>
+    <div class="panel-title"><i class="fa fa-fw fa-user"></i> Author Tools</div>
   </div>
   <div class="panel-body">
     <ul class="nav nav-pills nav-justified">
@@ -18,7 +18,7 @@
 </div>
 <div class="panel panel-danger">
   <div class="panel-heading">
-    <div class="panel-title">Danger Zone</div>
+    <div class="panel-title"><i class="fa fa-fw fa-bolt"></i> Danger Zone</div>
   </div>
   <div class="panel-body">
     <ul class="nav nav-pills nav-justified">

--- a/views/includes/scriptModals.html
+++ b/views/includes/scriptModals.html
@@ -11,9 +11,9 @@
       </div>
       <div class="modal-footer">
         <form action="{{{script.scriptEditMetadataPageUrl}}}" method="post">
-          <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+          <button type="button" class="btn btn-default" data-dismiss="modal"><i class="fa fa-fw fa-close"></i> Close</button>
           <input type="hidden" name="remove" value="true">
-          <button type="submit" class="btn btn-danger"><i class="fa trash-o"></i> Delete</button>
+          <button type="submit" class="btn btn-danger"><i class="fa fa-fw fa-trash-o"></i> Delete</button>
         </form>
       </div>
     </div>

--- a/views/includes/userToolsPanel.html
+++ b/views/includes/userToolsPanel.html
@@ -7,7 +7,7 @@
     </ul>
     <ul class="nav nav-pills nav-justified">
       <li><a href="/user/add/scripts"><i class="fa fa-file-code-o"></i> Add Script</a></li>
-      <li><a href="/user/add/lib"><i class="fa fa-folder-open-o"></i> Add Library</a></li>
+      <li><a href="/user/add/lib"><i class="fa fa-file-excel-o"></i> Add Library</a></li>
     </ul>
   </div>
 </div>

--- a/views/pages/adminPage.html
+++ b/views/pages/adminPage.html
@@ -11,10 +11,10 @@
       <div class="col-xs-12">
         <div class="list-group">
           <a href="/admin/api" class="list-group-item">
-            API Keys
+            <i class="octicon octicon-fw octicon-key"></i> API Keys
           </a>
           <a href="/admin/npmls" class="list-group-item">
-            Raw <code>npm ls --json</code> Data
+            <i class="fa fa-fw fa-database"></i> Raw <code>npm ls --json</code> Data
           </a>
         </div>
       </div>

--- a/views/pages/newScriptPage.html
+++ b/views/pages/newScriptPage.html
@@ -4,8 +4,10 @@
   <title>{{title}}</title>
   {{> includes/head.html }}
   <style>
-    .script-metadata-definitions .list-group-item-heading code {
+    .script-metadata-definitions .list-group-item-heading code,
+    .panel code {
       white-space: pre-line;
+      word-break: break-all;
     }
   </style>
 </head>
@@ -116,7 +118,7 @@
             <div class="list-group-item">
               <h4 class="list-group-item-heading"><i class="octicon octicon-fw octicon-repo-forked"></i> Fork An Existing Script</h4>
               <p class="list-group-item-text">
-                While logged in, click the fork button on any script's main page, or view a script's source and "Submit As Fork".
+                While logged in, click the fork button on any script's main page, or view a script's source and "Submit Code as Fork".
               </p>
             </div>
             <a href="{{{authedUser.userGitHubRepoListPageUrl}}}" class="list-group-item">
@@ -126,7 +128,7 @@
               </p>
             </a>
             <div role="alert" class="alert alert-info">
-              <i class="octicon octicon-fw octicon-info"></i> <strong>LIMITS</strong>: The current upload size limit is set at <span class="label label-default">{{maximumUploadScriptSize}} bytes</span> per script.
+              <i class="fa fa-fw fa-info-circle"></i> <strong>LIMITS</strong>: The current transfer size limit is set at <span class="label label-default">{{maximumUploadScriptSize}} bytes</span> per script.
             </div>
           </div>
         </div>
@@ -139,9 +141,9 @@
               <h4>Instructions</h4>
               <p>Firstly you must upload the script to the site. You can <a href="{{{authedUser.userGitHubRepoListPageUrl}}}">Import from Github</a> to speed things up.</p>
               <ol>
-                <li>On your target GitHub repo, click Settings > Webhooks & Services > Add Webhook.</li>
-                <li>In the Payload URL input, paste <code>https://openuserjs.org/github/hook</code></li>
-                <li>Change the Content Type dropdown to <code>application/x-www-form-urlencoded</code></li>
+                <li>On your target GitHub repo, click Settings > Webhooks &amp; Services > Add Webhook.</li>
+                <li>In the Payload URL input, paste<br /><code>https://openuserjs.org/github/hook</code></li>
+                <li>Change the Content Type dropdown to<br /><code>application/x-www-form-urlencoded</code></li>
                 <li>Click <code>Add Webhook</code>.</li>
               </ol>
               <p>After adding the webhook, push a change to GitHub to make sure it's working.</p>

--- a/views/pages/scriptEditMetadataPage.html
+++ b/views/pages/scriptEditMetadataPage.html
@@ -25,7 +25,7 @@
                     <textarea name="about" data-provide="markdown" data-iconlibrary="fa" rows="20" class="col-xs-12">{{script.about}}</textarea>
                   </div>
                   <div class="form-group">
-                    <button type="submit" class="btn btn-success">Save</button>
+                    <button type="submit" class="btn btn-success"><i class="fa fa-fw fa-save"></i> Save</button>
                   </div>
                 </div>
               </div>

--- a/views/pages/scriptIssueListPage.html
+++ b/views/pages/scriptIssueListPage.html
@@ -19,7 +19,7 @@
           <div class="input-group pull-left col-sm-1">
           </div>
           <a class="btn btn-sm btn-success pull-right" href="{{{category.categoryPostDiscussionPageUrl}}}" id="create-topic">
-            <i class="fa fa-plus"></i> New Issue
+            <i class="fa fa-fw fa-plus"></i> New Issue
           </a>
         </div>
         {{#script.hasSupport}}

--- a/views/pages/scriptViewSourcePage.html
+++ b/views/pages/scriptViewSourcePage.html
@@ -32,7 +32,7 @@
               {{/newScript}}
             {{/isLib}}
           </div>
-          <input class="btn btn-success pull-right" type="button" id="submit_code" value="Submit Code{{^owner}} as Fork{{/owner}}" />
+          <button class="btn btn-success pull-right" type="submit" id="submit_code">{{#owner}}<i class="fa fa-fw fa-save"></i>{{/owner}}{{^owner}}<i class="fa fa-fw fa-code-fork"></i>{{/owner}} Submit Code{{^owner}} as Fork{{/owner}}</button>
         </form>
         {{/readOnly}}
       </div>

--- a/views/pages/userEditProfilePage.html
+++ b/views/pages/userEditProfilePage.html
@@ -14,7 +14,7 @@
           <div class="col-xs-12">
             {{> includes/userPageHeader.html }}
             <form action="" method="post">
-              <button type="submit" class="btn btn-success pull-right">Save</button>
+              <button type="submit" class="btn btn-success pull-right"><i class="fa fa-fw fa-save"></i> Save</button>
               <h3>Description</h3>
               <p><strong>Use <a target="_blank" href="https://help.github.com/articles/github-flavored-markdown">GitHub Flavored Markdown</a> for formatting.</strong></p>
               <div class="user-content">

--- a/views/pages/userGitHubRepoPage.html
+++ b/views/pages/userGitHubRepoPage.html
@@ -18,7 +18,7 @@
             <p>The following files with the file extension <code>.user.js</code> and <code>.js</code> can be imported from this repo.</p>
 
             {{#openImportInNewTab}}
-            <div class="alert alert-info">Multiple scripts detected. Will open a new tab when importing a script.</div>
+            <div class="alert alert-info"><i class="fa fa-fw fa-info-circle"></i> Multiple scripts detected. Will open a new tab when importing a script.</div>
             {{/openImportInNewTab}}
 
             <ul class="list-group">


### PR DESCRIPTION
- Octicon info button _(font icon)_ looks aweful compared to fa... so switching
- Doc tweak on grammar
- Add missing info button to repo list page
- Correct icon for add library in the user tools panel
- Improve code tag breaking when viewport is super small on add script/lib page ... `word-break: break-all;` doesn't appear to work this round with scaling... but leaving in for the time being.
- Apply same rule for #342 line breaking ... again doesn't appear to work this round of testing but should.
- Add icons to comment popup
- Add icon to user tools
- Add icon to Danger Zone
- Add icons to Admin section
- Add icons to source code editor save button... retro here with the diskette ;) Flip to using button tag instead of input tag.
- Add icon to edit profile
- Add icon to edit script info
- Match text in new script page for forking
- Fix trash can icon in delete script from https://github.com/OpenUserJs/OpenUserJS.org/commit/e181d75981b6773027d2f118a169e452429d2dad#diff-6d9ae343f51e28845070092fbd834246R16 _(we all make em :)_
- Add icon in delete script
- Add `fa-fw` class to general reply button _(the blue one)_ for symmetry on all buttons save for the md editor which doesn't have this one for preview by default
- Add `fa-fw` class to new issue and correct from info to success for symmetry

There's probably more but this should be the bulk of them.

Applies to #186
