### PR TITLE
Downgrade the *aws-sdk* package to prevent app crashing

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "app",
   "dependencies": {
     "async": "0.9.0",
-    "aws-sdk": "2.0.23",
+    "aws-sdk": "2.0.21",
     "bootstrap": "3.1.1",
     "bootstrap-markdown": "2.7.0",
     "connect-mongo": "0.4.1",


### PR DESCRIPTION
_hopefully_
- As I stated in commit summary in https://github.com/OpenUserJs/OpenUserJS.org/commit/b486122264e74d501b2f822ccbef7daeaba78675 there is no way to know for sure if these updates will work flawlessly on production since it's "reals3" instead of fakes3.

---

We'll try updating this again at a later date and release. If this doesn't do it then we'll probably need to downgrade _mongoose_ as well after one more downgrade of _aws-sdk_. This is a timing issue ... so will be checking in the next 48ish hours.
