### PR TITLE
Fix "Write Script Online"

### DIFF
--- a/controllers/script.js
+++ b/controllers/script.js
@@ -21,7 +21,15 @@ var modelParser = require('../libs/modelParser');
 var countTask = require('../libs/tasks').countTask;
 var pageMetadata = require('../libs/templateHelpers').pageMetadata;
 
-// Let script controllers know this is a lib route
+// Let controllers know this is a `new` route
+exports.new = function (aController) {
+  return (function (aReq, aRes, aNext) {
+    aReq.route.params.isNew = true;
+    aController(aReq, aRes, aNext);
+  });
+};
+
+// Let controllers know this is a `lib` route
 exports.lib = function (aController) {
   return (function (aReq, aRes, aNext) {
     aReq.route.params.isLib = true;

--- a/routes.js
+++ b/routes.js
@@ -60,10 +60,10 @@ module.exports = function (aApp) {
 
   // Adding script/library routes
   app_route('/user/add/scripts').get(user.newScriptPage);
-  app_route('/user/add/scripts/new').get(user.editScript).post(user.submitSource);
+  app_route('/user/add/scripts/new').get(script.new(user.editScript)).post(script.new(user.submitSource));
   app_route('/user/add/scripts/upload').post(user.uploadScript);
   app_route('/user/add/lib').get(user.newLibraryPage);
-  app_route('/user/add/lib/new').get(script.lib(user.editScript)).post(script.lib(user.submitSource));
+  app_route('/user/add/lib/new').get(script.new(script.lib(user.editScript))).post(script.new(script.lib(user.submitSource)));
   app_route('/user/add/lib/upload').post(script.lib(user.uploadScript));
   app_route('/user/add').get(function (aReq, aRes) { aRes.redirect('/user/add/scripts'); });
 

--- a/views/pages/scriptViewSourcePage.html
+++ b/views/pages/scriptViewSourcePage.html
@@ -7,7 +7,7 @@
     #editor {
       position: relative;
       min-height: 200px;
-      height: calc(100vh - 303px);
+      height: calc(100vh - {{#newScript}}190{{/newScript}}{{^newScript}}303{{/newScript}}px);
     }
    .path-divider {
       margin: 0 .25em;
@@ -20,7 +20,7 @@
   <div class="container-fluid">
     <div class="row">
       <div class="col-md-12">
-        {{> includes/scriptPageHeader.html }}
+        {{^newScript}}{{> includes/scriptPageHeader.html }}{{/newScript}}
         <pre id="editor">{{source}}</pre>
         {{^readOnly}}
         <form action="{{#isLib}}/user/add/lib/new{{/isLib}}{{^isLib}}/user/add/scripts/new{{/isLib}}" id="code_form" method="post">


### PR DESCRIPTION
- Add similar code to `script.js` controller to let all controllers know it's a `new` route.
- Add similar _(nested function calls)_ code to `routes.js` to indicate `new` script route.
- Add existing `newScript` checks to view ... **NOTE**: Possible naming consistency issue across the board here with preexisting identifiers.
- Continue using `editScript` as a complete catch-all... pre-existing condition... reorder a bit for some efficiency.
- Eliminate extra `pageMetadata` call
- Change `getExistingScript` to test req parm `isNew` instead of possible `scriptname` that could be absent.

Refs:
- #150
- https://openuserjs.org/discuss/No_more_new_scripts_possible
