### PR TITLE
Fix serveModule on Windows;

### DIFF
--- a/routesStatic.js
+++ b/routesStatic.js
@@ -13,7 +13,7 @@ module.exports = function (aApp) {
 
     if (!aModuleOption || typeof aModuleOption === 'number') {
       aApp.use(
-        path.join(aRoot, aModuleName),
+        aRoot + '/' + aModuleName,
         express.static(
           path.join(moduleRoot, aModuleName),
           { maxage: aModuleOption }
@@ -22,7 +22,7 @@ module.exports = function (aApp) {
     } else {
       for (moduleFile in aModuleOption) {
         aApp.use(
-          path.join(aRoot, aModuleName, moduleFile),
+          aRoot + '/' + aModuleName + '/' + moduleFile,
           express.static(
             path.join(moduleRoot, aModuleName, moduleFile),
             { maxage: aModuleOption[moduleFile].maxage }


### PR DESCRIPTION
This fixes 404's for all modules served trough `serveModule` on my Windows setup.

I've not found the reason why...

Can someone confirm that this is still working on their envoriment:
- [X] Windows
- [ ] Mac
- [ ] Linux

See https://github.com/OpenUserJs/OpenUserJS.org/issues/330
