### PR TITLE
Remove a deprecation warning

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var express = require('express');
+var methodOverride = require('method-override');
 var minify = require('express-minify');
 var MongoStore = require('connect-mongo')(express);
 var mongoose = require('mongoose');
@@ -50,7 +51,7 @@ if (process.env.NODE_ENV !== 'production') {
 app.use(express.urlencoded());
 app.use(express.json());
 app.use(express.compress());
-app.use(express.methodOverride());
+app.use(methodOverride('X-HTTP-Method-Override'));
 
 // Order is very important here (i.e mess with at your own risk)
 app.use(express.cookieParser());

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "highlight.js": "8.3.0",
     "jquery": "2.1.1",
     "marked": "0.3.2",
+    "method-override": "2.3.0",
     "moment": "2.8.3",
     "mongoose": "3.8.19",
     "mu2": "0.5.20",


### PR DESCRIPTION
- Express 3 deprecated this a while back to a separate package. It is currently default used with POST request response so this probably needs to be kept in. Basically they are forcing this `Vary` header _(mod)_ in on all form request responses...e.g. defining a newer type of standard. `'X-HTTP-Method-Override'` is placed in regardless of `methodOverride` parm being used or not. Pkg docs say to use it in intial setup.

Tested on route `'/script/:namespace?/:scriptname/edit'`

See also:
- https://github.com/OpenUserJs/OpenUserJS.org/issues/315#issuecomment-59668729 and forward
