### PR TITLE
Project version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "OpenUserJS.org",
   "description": "An open source user scripts repo built using Node.js",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "main": "app",
   "dependencies": {
     "ace-builds": "git://github.com/ajaxorg/ace-builds#7fafd12",


### PR DESCRIPTION
- This should prevent further contamination from nodejitsu/jitsu with their deploy routines when sizzle deploys and the created duplicate snapshots.
