### PR TITLE
Fix operator precedence

### DIFF
--- a/app.js
+++ b/app.js
@@ -98,7 +98,7 @@ app.set('views', __dirname + '/views');
 
 // Setup minification
 // Order is important here as Ace will fail with an invalid content encoding issue
-if (minify && isPro || isDev) {
+if (minify && (isPro || isDev)) {
   app.use(minify());
 }
 


### PR DESCRIPTION
Reapplies to:
- #434
- #431

Eventually this test should go away when @Zren takes the necessary time to reinstall his Windows machine instead of making a personal exception since his machine is misconfigured.
