### PR TITLE
Better forum layout according to browser size

### DIFF
--- a/views/pages/categoryListPage.html
+++ b/views/pages/categoryListPage.html
@@ -12,7 +12,7 @@
         <h2 class="page-heading">
           Discuss
         </h2>
-        <div class="list-group">
+        <div class="list-group col-sm-12 col-md-2 col-lg-3">
           {{#categoryList}}
           <a href="{{{categoryPageUrl}}}" class="list-group-item">
             <h4 class="list-group-item-heading">{{name}}</h4>
@@ -20,7 +20,7 @@
           </a>
           {{/categoryList}}
         </div>
-        <div class="panel panel-default">
+        <div class="panel panel-default col-sm-12 col-md-10 col-lg-9">
           {{> includes/discussionList.html }}
         </div>
         <div class="text-center">


### PR DESCRIPTION
Ref: https://github.com/OpenUserJs/OpenUserJS.org/issues/435

I agree with @TimidScript that the forum could utilize it's space better on big screens.

What I did was make the menu slide to the left of the forum posts on desktop (and bigger) browsers.

![Better forum layout according to browser size](https://cloud.githubusercontent.com/assets/55841/5158823/9f3c695c-734b-11e4-8692-a95ffe9bfa45.jpg)
