### PR TITLE
Make Dev node engine Dep Match Current Pro

### DIFF
--- a/controllers/admin.js
+++ b/controllers/admin.js
@@ -137,17 +137,17 @@ exports.adminJsonView = function (aReq, aRes, aNext) {
   options.isAdmin = authedUser && authedUser.isAdmin;
 
   if (!options.isAdmin)
-    return aRes.send(403, { status: 403, message: 'Not an admin.' });
+    return aRes.status(403).send({ status: 403, message: 'Not an admin.' });
 
   var model = jsonModelMap[modelname];
   if (!model)
-    return aRes.send(400, { status: 400, message: 'Invalid model.' });
+    return aRes.status(400).send({ status: 400, message: 'Invalid model.' });
 
   model.findOne({
     _id: id
   }, function (aErr, aObj) {
     if (aErr || !aObj)
-      return aRes.send(404, { status: 404, message: 'Id doesn\'t exist.' });
+      return aRes.status(404).send({ status: 404, message: 'Id doesn\'t exist.' });
 
     aRes.json(aObj);
   });
@@ -298,7 +298,7 @@ exports.adminApiKeysPage = function (aReq, aRes, aNext) {
 
 // View everything about current modules for the server
 // This is mostly for debugging in production
-exports.adminNpmLsView = function (aReq, aRes, aNext) {
+exports.adminNpmListView = function (aReq, aRes, aNext) {
   var authedUser = aReq.session.user;
 
   //
@@ -310,11 +310,36 @@ exports.adminNpmLsView = function (aReq, aRes, aNext) {
   options.isAdmin = authedUser && authedUser.isAdmin;
 
   if (!options.isAdmin)
-    return aRes.send(403, { status: 403, message: 'Not an admin.' });
+    return aRes.status(403).send({ status: 403, message: 'Not an admin.' });
 
   exec('npm ls --json', function (aErr, aStdout, aStderr) {
-    if (aErr) return aRes.send(501, { status: 501, message: 'Not implemented.' });
+    if (aErr) return aRes.status(501).send({ status: 501, message: 'Not implemented.' });
     aRes.json(JSON.parse(aStdout));
+  });
+};
+
+// View current version of npm
+// This is mostly for debugging in production
+exports.adminNpmVersionView = function (aReq, aRes, aNext) {
+  var authedUser = aReq.session.user;
+
+  //
+  var options = {};
+
+  // Session
+  authedUser = options.authedUser = modelParser.parseUser(authedUser);
+  options.isMod = authedUser && authedUser.isMod;
+  options.isAdmin = authedUser && authedUser.isAdmin;
+
+  if (!options.isAdmin)
+    return aRes.status(403).send({ status: 403, message: 'Not an admin.' });
+
+  exec('npm --version', function (aErr, aStdout, aStderr) {
+    if (aErr) return aRes.status(501).send({ status: 501, message: 'Not implemented.' });
+
+    aRes.set('Content-Type', 'text/plain; charset=UTF-8');
+    aRes.write(aStdout + '\n');
+    aRes.end();
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -71,6 +71,6 @@
     "start": "node app.js"
   },
   "engines": {
-    "node": ">=0.10.7"
+    "node": ">=0.10.33"
   }
 }

--- a/routes.js
+++ b/routes.js
@@ -97,7 +97,8 @@ module.exports = function (aApp) {
   aApp.route('/admin/json').get(admin.adminJsonView);
   aApp.route('/admin/user/:id').get(admin.adminUserView);
   aApp.route('/admin/api').get(admin.adminApiKeysPage);
-  aApp.route('/admin/npmls').get(admin.adminNpmLsView);
+  aApp.route('/admin/npm/list').get(admin.adminNpmListView);
+  aApp.route('/admin/npm/version').get(admin.adminNpmVersionView);
   aApp.route('/admin/api/update').post(admin.apiAdminUpdate);
 
   // Moderation routes

--- a/views/pages/adminPage.html
+++ b/views/pages/adminPage.html
@@ -13,8 +13,11 @@
           <a href="/admin/api" class="list-group-item">
             <i class="octicon octicon-fw octicon-key"></i> API Keys
           </a>
-          <a href="/admin/npmls" class="list-group-item">
-            <i class="fa fa-fw fa-database"></i> Raw <code>npm ls --json</code> Data
+          <a href="/admin/npm/list" class="list-group-item">
+            <i class="fa fa-fw fa-database"></i> Raw <code>npm ls --json</code> JSON Data
+          </a>
+          <a href="/admin/npm/version" class="list-group-item">
+            <i class="fa fa-fw fa-database"></i> Raw <code>npm --version</code> Shell Session Data
           </a>
         </div>
       </div>


### PR DESCRIPTION
- Bump requested node to current pro node stable
- Rename route to be less cryptic and tiered based for npm functions with alteration of affected controller with handler
- Update view to reflect new urls
- Squash some deprecation warnings in here since we changed to _express_ 4 at #417
