### PR TITLE
Resync dev to pro version with additional bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "OpenUserJS.org",
   "description": "An open source user scripts repo built using Node.js",
-  "version": "0.1.4",
+  "version": "0.1.6",
   "main": "app",
   "dependencies": {
     "ace-builds": "git://github.com/ajaxorg/ace-builds#7fafd12",


### PR DESCRIPTION
- Apparently nodejitsu leaked a deploy between us and it's safer to bump this to 0.1.6 so no snapshots get overwritten
