### PR TITLE
Fixed issue UTF-8 without BOM

### DIFF
--- a/views/includes/scripts/lazyIconScript.html
+++ b/views/includes/scripts/lazyIconScript.html
@@ -1,4 +1,4 @@
-﻿<script type="text/javascript">
+<script type="text/javascript">
   $(window).load(function () {
     window.setTimeout(function () {
       $('[data-icon-src]').each(function () {


### PR DESCRIPTION
Fixes an issue with weird character on the `lazyIconScript.html` file, probably the BOM in UTF-8.

See extra space below footer on https://openuserjs.org/group/github

Ref https://github.com/OpenUserJs/OpenUserJS.org/pull/449
