### PR TITLE
Remove big bottom margin on script description

### DIFF
--- a/public/css/common.css
+++ b/public/css/common.css
@@ -88,10 +88,6 @@ a.disabled, a[disabled] {
   color: #666;
 }*/
 
-body > .container-fluid > .row > .container-fluid.col-sm-8 {
-  margin-bottom: 100px;
-}
-
 h2.page-heading {
   margin-top: 0;
 }


### PR DESCRIPTION
Happens on desktop and mobile.

![screenie](https://cloud.githubusercontent.com/assets/55841/5305806/5629f8f8-7bff-11e4-98db-4a8dfa30d069.jpg)
