### PR TITLE
Add a build metadata placeholder in for project version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "OpenUserJS.org",
   "description": "An open source user scripts repo built using Node.js",
-  "version": "0.1.6",
+  "version": "0.1.6+0000000",
   "main": "app",
   "dependencies": {
     "ace-builds": "git://github.com/ajaxorg/ace-builds#7fafd12",


### PR DESCRIPTION
- This may need to be reverted if nodejitsu/_jitsu_ chokes next deploy but is needed for testing

See also:
- http://semver.org/ Item 10

This is the preferred methodology for #426 however a lot depends on the hosting site.
