### PR TITLE
Failure in *aws-sdk* still

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "ace-builds": "git://github.com/ajaxorg/ace-builds#7fafd12",
     "async": "0.9.0",
-    "aws-sdk": "2.0.30",
+    "aws-sdk": "2.0.21",
     "body-parser": "1.10.0",
     "bootstrap": "3.1.1",
     "bootstrap-markdown": "2.7.0",


### PR DESCRIPTION
1. Nodejitsu 505 socket hangup
2. Nodejitsu 404
3. Restarts

``` sh-session
$ jitsu logs
[12/04 22:20:44 MST][out] GitHub client authenticated
[12/04 22:21:40 MST][err] /opt/run/snapshot/package/node_modules/aws-sdk/lib/request.js:32
[12/04 22:21:40 MST][err]               ^
[12/04 22:21:40 MST][err]           throw err;
[12/04 22:21:40 MST][err]
[12/04 22:21:40 MST][err] NoSuchKey: The specified key does not exist.
[12/04 22:21:40 MST][err]     at Request.extractError (/opt/run/snapshot/package/node_modules/aws-sdk/lib/services/s3.js:343:35)
[12/04 22:21:40 MST][err]     at Request.callListeners (/opt/run/snapshot/package/node_modules/aws-sdk/lib/sequential_executor.js:100:18)
[12/04 22:21:40 MST][err]     at Request.emit (/opt/run/snapshot/package/node_modules/aws-sdk/lib/sequential_executor.js:77:10)
[12/04 22:21:40 MST][err]     at Request.emit (/opt/run/snapshot/package/node_modules/aws-sdk/lib/request.js:604:14)
[12/04 22:21:40 MST][err]     at Request.transition (/opt/run/snapshot/package/node_modules/aws-sdk/lib/request.js:21:12)
[12/04 22:21:40 MST][err]     at AcceptorStateMachine.runTo (/opt/run/snapshot/package/node_modules/aws-sdk/lib/state_machine.js:14:12)
[12/04 22:21:40 MST][err]     at /opt/run/snapshot/package/node_modules/aws-sdk/lib/state_machine.js:26:10
[12/04 22:21:40 MST][err]     at Request.<anonymous> (/opt/run/snapshot/package/node_modules/aws-sdk/lib/request.js:22:9)
[12/04 22:21:40 MST][err]     at Request.<anonymous> (/opt/run/snapshot/package/node_modules/aws-sdk/lib/request.js:606:12)
[12/04 22:21:40 MST][err]     at Request.callListeners (/opt/run/snapshot/package/node_modules/aws-sdk/lib/sequential_executor.js:104:18)
```

Applies to #479 revert
