### PR TITLE
Revert the error trap routine

### DIFF
--- a/controllers/scriptStorage.js
+++ b/controllers/scriptStorage.js
@@ -50,13 +50,6 @@ exports.getSource = function (aReq, aCallback) {
 
   Script.findOne({ installName: caseInsensitive(installName) },
     function (aErr, aScript) {
-      if (aErr) {
-        console.error(installName);
-        console.error(JSON.stringify(aErr));
-        console.error(JSON.stringify(aScript.toObject()));
-        return aCallback(null);
-      }
-
       if (!aScript) {
         return aCallback(null);
       }


### PR DESCRIPTION
- This should probably be readdressed soon but this handler is part of the reason why we can't upgrade to the latest _aws-sdk_. [Will issue](/OpenUserJs/OpenUserJS.org/issues/486) sometime tomorrow'ish.
