### PR TITLE
Graceful failure when S3 *(fake or real)* doesn't have key

### DIFF
--- a/controllers/scriptStorage.js
+++ b/controllers/scriptStorage.js
@@ -50,14 +50,24 @@ exports.getSource = function (aReq, aCallback) {
 
   Script.findOne({ installName: caseInsensitive(installName) },
     function (aErr, aScript) {
+      var s3Object = null;
+
       if (!aScript) {
         return aCallback(null);
       }
 
+      s3Object = s3.getObject({ Bucket: bucketName, Key: installName }).createReadStream().
+        on('error', function () {
+          if (isPro) {
+            console.error('S3 Key Not Found ' + installName);
+          }
+
+          return aCallback(null);
+        });
+
       // Get the script
-      aCallback(aScript, s3.getObject({ Bucket: bucketName, Key: installName })
-        .createReadStream());
-  });
+      aCallback(aScript, s3Object);
+    });
 };
 
 exports.sendScript = function (aReq, aRes, aNext) {


### PR DESCRIPTION
- Directly related to #37. Stops net timeout when picking some other script _(source)_ that isn't present in fakeS3. Eventually when _aws-sdk_ is updated this will be needed so it doesn't [halt dev](https://github.com/OpenUserJs/OpenUserJS.org/pull/479#issuecomment-65741757).

Possibly applicable routine to #486 for inline live migration
