### PR TITLE
Force a couple of mustache options to always happen

### DIFF
--- a/libs/modelQuery.js
+++ b/libs/modelQuery.js
@@ -152,10 +152,10 @@ var applyModelListQueryFlaggedFilter = function (aModelListQuery, aOptions, aFla
     // Mod
     if (aFlaggedQuery) {
       if (aFlaggedQuery === 'true') {
+        aOptions.isFlagged = true;
+        aOptions.searchBarPlaceholder = aOptions.searchBarPlaceholder.replace(/^Search /, 'Search Flagged ');
         if (!_.findWhere(aOptions.searchBarFormHiddenVariables, { name: 'flagged' })) {
-          aOptions.isFlagged = true;
           aOptions.searchBarFormHiddenVariables.push({ name: 'flagged', value: 'true' });
-          aOptions.searchBarPlaceholder = aOptions.searchBarPlaceholder.replace(/^Search /, 'Search Flagged ');
         }
         aModelListQuery.and({ flags: { $gt: 0 } });
       }


### PR DESCRIPTION
- Very odd boog... dev had `Search Flagged Libraries` and pro had `Search Libraries` until I blanked out dev lib flags... then they matched. Force the text in along with the flag just to be sure. DOM duplication now appears to be related only to the logic issue at #492

Post fix for #491
