### PR TITLE
Post #503 fix

### DIFF
--- a/views/pages/scriptViewSourcePage.html
+++ b/views/pages/scriptViewSourcePage.html
@@ -84,7 +84,6 @@
 
       // Older browser JavaScript work-around for #136
       if (!hasAnyCalc()) {
-        $("#footer > nav").addClass("navbar-fixed-bottom");
         $("#editor").height(calcHeight());
         $(document).on("resize", function () {
           $("#editor").height(calcHeight);


### PR DESCRIPTION
* Super small viewports need approximate body padding with fixed navbars as:

``` javascript
        $("#footer > nav").addClass("navbar-fixed-bottom");
        document.body.style.setProperty("padding-bottom", "55px", "");
```

Since Opera Presto is definitely outdated removing fixed footer... symmetrical with other existing pages and not really worth pursuing but available if wanted.