### PR TITLE
Add missing basic modals for user/script removal

### DIFF
--- a/routes.js
+++ b/routes.js
@@ -117,8 +117,7 @@ module.exports = function (aApp) {
   aApp.route('/flag/libs/:username/:scriptname/:unflag?').get(script.lib(script.flag));
 
   // Remove route
-  // TODO: Make POST route
-  aApp.route(/^\/remove\/(.+?)\/(.+)$/).get(remove.rm);
+  aApp.route(/^\/remove\/(.+?)\/(.+)$/).post(remove.rm);
 
   // Group routes
   aApp.route('/groups').get(group.list);

--- a/views/includes/scriptModToolsPanel.html
+++ b/views/includes/scriptModToolsPanel.html
@@ -11,7 +11,7 @@
     {{> includes/flagModelSnippet.html }}
     {{/script}}
     <ul class="nav nav-pills nav-justified">
-      <li><a href="{{{script.scriptRemovePageUrl}}}" class="{{^canRemove}}disabled{{/canRemove}}"><i class="fa fa-trash-o"></i> Remove Script</a></li>
+      <li><a href="#" data-toggle="modal" data-target="#removeScriptModal" class="{{^canRemove}}disabled{{/canRemove}}"><i class="fa fa-ban"></i> Remove Script</a></li>
     </ul>
   </div>
 </div>

--- a/views/includes/scriptModals.html
+++ b/views/includes/scriptModals.html
@@ -3,7 +3,7 @@
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
         <h4 class="modal-title">Delete {{script.fullName}}</h4>
       </div>
       <div class="modal-body">
@@ -20,3 +20,25 @@
   </div>
 </div>
 {{/authorTools}}
+{{#modTools}}
+<div class="modal fade" id="removeScriptModal">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+        <h4 class="modal-title">Remove {{script.fullName}}</h4>
+      </div>
+      <div class="modal-body">
+        <p>Are you sure you want to remove this script? You cannot undo this.</p>
+      </div>
+      <div class="modal-footer">
+        <form action="{{{script.scriptRemovePageUrl}}}" method="post">
+          <button type="button" class="btn btn-default" data-dismiss="modal"><i class="fa fa-fw fa-close"></i> Close</button>
+          <input type="hidden" name="remove" value="true">
+          <button type="submit" class="btn btn-danger"><i class="fa fa-fw fa-ban"></i> Remove</button>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+{{/modTools}}

--- a/views/includes/userModToolsPanel.html
+++ b/views/includes/userModToolsPanel.html
@@ -11,7 +11,7 @@
     {{> includes/flagModelSnippet.html }}
     {{/user}}
     <ul class="nav nav-pills nav-justified">
-      <li><a href="{{{user.userRemovePageUrl}}}" class="{{^canRemove}}disabled{{/canRemove}}"><i class="fa fa-trash-o"></i> Remove User</a></li>
+      <li><a href="#" data-toggle="modal" data-target="#removeUserModal" class="{{^canRemove}}disabled{{/canRemove}}"><i class="fa fa-ban"></i> Remove User</a></li>
     </ul>
   </div>
 </div>

--- a/views/includes/userModals.html
+++ b/views/includes/userModals.html
@@ -1,0 +1,22 @@
+{{#modTools}}
+<div class="modal fade" id="removeUserModal">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+        <h4 class="modal-title">Remove {{user.name}}</h4>
+      </div>
+      <div class="modal-body">
+        <p>Are you sure you want to remove this user? You cannot undo this.</p>
+      </div>
+      <div class="modal-footer">
+        <form action="{{{user.userRemovePageUrl}}}" method="post">
+          <button type="button" class="btn btn-default" data-dismiss="modal"><i class="fa fa-fw fa-close"></i> Close</button>
+          <input type="hidden" name="remove" value="true">
+          <button type="submit" class="btn btn-danger"><i class="fa fa-fw fa-ban"></i> Remove</button>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+{{/modTools}}

--- a/views/pages/modPage.html
+++ b/views/pages/modPage.html
@@ -25,7 +25,7 @@
         <h3>Removed Items</h3>
         <div class="list-group">
           <a href="/mod/removed" class="list-group-item">
-            <i class="fa fa-fw fa-trash-o"></i> Graveyard (Removed Items)
+            <i class="fa fa-fw fa-ban"></i> Graveyard (Removed Items)
           </a>
         </div>
       </div>

--- a/views/pages/userPage.html
+++ b/views/pages/userPage.html
@@ -27,6 +27,7 @@
       </div>
     </div>
   </div>
+  {{> includes/userModals.html }}
   {{> includes/footer.html }}
 </body>
 </html>


### PR DESCRIPTION
* Convert to a post route reusing same handler in controller
* Create and include `userModals.html`
* Use HTML entity instead of `x`
* Change *font-awesome* icon for removal to ban icon for a better visual cue between delete *(trash)* and removal *(Graveyard)*
* Very minimal change and mostly *(99.99%)* UI views interaction for removal... yes it does graze [#262 section block](https://github.com/OpenUserJs/OpenUserJS.org/issues/262#issuecomment-57592127) however this has been needed for current mods and up... Making it a very small change and is why it isn't complete with the "reason" here.


Applies to #261