### PR TITLE
Fix another library icon in mod page

### DIFF
--- a/views/pages/modPage.html
+++ b/views/pages/modPage.html
@@ -16,7 +16,7 @@
             <i class="fa fa-fw fa-file-code-o"></i> <i class="fa fa-fw fa-flag"></i> Flagged Scripts
           </a>
           <a href="/?library=true&flagged=true" class="list-group-item">
-            <i class="fa fa-fw fa-folder-open-o"></i> <i class="fa fa-fw fa-flag"></i> Flagged Libraries
+            <i class="fa fa-fw fa-file-excel-o"></i> <i class="fa fa-fw fa-flag"></i> Flagged Libraries
           </a>
           <a href="/users?flagged=true" class="list-group-item">
             <i class="fa fa-fw fa-user"></i> <i class="fa fa-fw fa-flag"></i> Flagged Users


### PR DESCRIPTION
* Should be symmetric across the board... the old one was a folder instead of being the x document