### PR TITLE
Enable glyph icons to work from bootstrap

### DIFF
--- a/public/css/bootstrap-custom.css
+++ b/public/css/bootstrap-custom.css
@@ -2386,8 +2386,8 @@ input[type="button"].btn-block {
 }
 @font-face {
   font-family: 'Glyphicons Halflings';
-  src: url('../fonts/glyphicons-halflings-regular.eot');
-  src: url('../fonts/glyphicons-halflings-regular.eot?#iefix') format('embedded-opentype'), url('../fonts/glyphicons-halflings-regular.woff') format('woff'), url('../fonts/glyphicons-halflings-regular.ttf') format('truetype'), url('../fonts/glyphicons-halflings-regular.svg#glyphicons_halflingsregular') format('svg');
+  src: url('/redist/npm/bootstrap/dist/fonts/glyphicons-halflings-regular.eot');
+  src: url('/redist/npm/bootstrap/dist/fonts/glyphicons-halflings-regular.eot?#iefix') format('embedded-opentype'), url('/redist/npm/bootstrap/dist/fonts/glyphicons-halflings-regular.woff') format('woff'), url('/redist/npm/bootstrap/dist/fonts/glyphicons-halflings-regular.ttf') format('truetype'), url('/redist/npm/bootstrap/dist/fonts/glyphicons-halflings-regular.svg#glyphicons_halflingsregular') format('svg');
 }
 .glyphicon {
   position: relative;


### PR DESCRIPTION
* Should remove most of the 404's we've been intermittently getting too from other packages that support glyph icons
* Eventually when we split out and compile this on the fly with #249 this will need to be done in the configuration file for the .less file