### PR TITLE
Limit Item in Graveyard to fixed width

### DIFF
--- a/public/css/common.css
+++ b/public/css/common.css
@@ -115,7 +115,7 @@ h2.page-heading {
   white-space: nowrap;
 }
 
-.td-fit span.label {
+.td-fit span.label, .td-fit p {
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 32em;

--- a/views/includes/removedItemList.html
+++ b/views/includes/removedItemList.html
@@ -14,7 +14,7 @@
       <td class="td-fit">
         <p>{{model}}</p>
       </td>
-      <td>
+      <td class="td-fit">
         <p><a href="{{{url}}}" class="tr-link-a">{{itemDescription}}</a></p>
       </td>
       <td>


### PR DESCRIPTION
* One of many CSS fixes again just as in #268 via #265
* Reuse the same width... appears well and opens up the Reason to be the focal point

Also applies to #261