### PR TITLE
Fix Library require links to be protocol specific

### DIFF
--- a/controllers/script.js
+++ b/controllers/script.js
@@ -329,7 +329,8 @@ exports.view = function (aReq, aRes, aNext) {
     options.isOwner = authedUser && authedUser._id == script._authorId;
     modelParser.renderScript(script);
     script.installNameSlug = installNameSlug;
-    script.scriptPermalinkInstallPageUrl = 'http://' + aReq.get('host') + script.scriptInstallPageUrl;
+    script.scriptPermalinkInstallPageUrl = aReq.protocol + '://' + aReq.get('host') +
+      script.scriptInstallPageUrl;
 
     // Page metadata
     pageMetadata(options, ['About', script.name, (script.isLib ? 'Libraries' : 'Scripts')],

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -1473,7 +1473,8 @@ exports.editScript = function (aReq, aRes, aNext) {
       options.isOwner = authedUser && authedUser._id == script._authorId;
       modelParser.renderScript(script);
       script.installNameSlug = installNameSlug;
-      script.scriptPermalinkInstallPageUrl = 'http://' + aReq.get('host') + script.scriptInstallPageUrl;
+      script.scriptPermalinkInstallPageUrl = aReq.protocol + '://' + aReq.get('host') +
+        script.scriptInstallPageUrl;
 
       // Page metadata
       pageMetadata(options);


### PR DESCRIPTION
* Currently they show as http which our default is https ... so if the request comes from a https show https, etc.

**NOTE**: Btw this is cheating using the host header to get the port inclusion instead of crafting it from the components.