### PR TITLE
Remove the reply button on comments pages

### DIFF
--- a/views/includes/comment.html
+++ b/views/includes/comment.html
@@ -23,6 +23,7 @@
           <div class="user-data">
             {{{contentRendered}}}
           </div>
+          {{^isUserCommentListPage}}
           <section class="post-menu-area">
             <nav class="post-controls text-right">
               <div class="pull-right" {{^authedUser}} data-toggle="tooltip" data-placement="left" title="You need to be logged in to post!" {{/authedUser}}>
@@ -32,6 +33,7 @@
               </div>
              </nav>
           </section>
+          {{/isUserCommentListPage}}
         </div>
       </div>
     </div>


### PR DESCRIPTION
* Agreed that it doesn't make sense here. A user could comment and wouldn't know if there was already a response to a particular item. e.g. one should read the discussion first. Similar to public activity RSS on GH... one doesn't respond there you go to it.

Closes #463