### PR TITLE
Add top pagination with some more symmetry in the UI

### DIFF
--- a/public/css/bootstrap-custom.css
+++ b/public/css/bootstrap-custom.css
@@ -4120,7 +4120,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
 }
 .breadcrumb {
   padding: 8px 15px;
-  margin-bottom: 20px;
+  margin-bottom: 10px;
   list-style: none;
   background-color: #f5f5f5;
   border-radius: 4px;
@@ -4139,7 +4139,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
 .pagination {
   display: inline-block;
   padding-left: 0;
-  margin: 20px 0;
+  margin: 10px 0;
   border-radius: 4px;
 }
 .pagination > li {

--- a/views/includes/header.html
+++ b/views/includes/header.html
@@ -6,17 +6,17 @@
     </div>
     <div class="navbar-collapse navbar-collapse-top collapse">
       <ul class="nav navbar-nav navbar-right">
-        <li><a href="/"><span class="visible-xs"><i class="fa fa-file-code-o"></i> </span>Scripts</a></li>
-        <li><a href="/?library=true" title="Script Libraries"><span class="visible-xs"><i class="fa fa-file-excel-o"></i> </span>Libs</a></li>
+        <li><a href="/" title="Scripts"><span class="visible-xs"><i class="fa fa-file-code-o"></i> </span>Scripts</a></li>
+        <li><a href="/?library=true" title="Script Libraries"><span class="visible-xs"><i class="fa fa-file-excel-o"></i> </span>Libraries</a></li>
         <li><a href="/groups" title="Script Groups"><span class="visible-xs"><i class="fa fa-folder"></i> </span>Groups</a></li>
-        <li><a href="/forum" title="Discuss"><span class="visible-xs"><i class="fa fa-comment"></i> </span>Discuss</a></li>
+        <li><a href="/forum"><span class="visible-xs"><i class="fa fa-comment"></i> </span>Discussions</a></li>
         <li><a href="/users"><span class="visible-xs"><i class="fa fa-user"></i> </span>Users</a></li>
         {{#authedUser}}
         {{#authedUser.isMod}}
         <li><a href="/mod" title="Moderation"><i class="fa fa-eye"></i><span class="visible-xs"> Moderation</span></a></li>
         {{/authedUser.isMod}}
         {{#authedUser.isAdmin}}
-        <li><a href="/admin" title="Admin"><i class="fa fa-coffee"></i><span class="visible-xs"> Admin</span></a></li>
+        <li><a href="/admin" title="Administration"><i class="fa fa-coffee"></i><span class="visible-xs"> Admin</span></a></li>
         {{/authedUser.isAdmin}}
         <!-- <li><a href="#" class="disabled"><i class="fa fa-envelope-o"></i> 0<span class="visible-xs"> Unread Messages</span></a></li> -->
         <li><a href="{{authedUser.userPageUrl}}" title="My profile">{{authedUser.name}}</a></li>

--- a/views/includes/scripts/commentReplyScript.html
+++ b/views/includes/scripts/commentReplyScript.html
@@ -2,7 +2,7 @@
   // Show spacer div
   $('#reply-control').on('shown.bs.collapse', function () {
     $('#show-reply-form-when-visible').css({
-      height: '200px'
+      height: '210px'
     });
   });
 

--- a/views/pages/categoryListPage.html
+++ b/views/pages/categoryListPage.html
@@ -10,15 +10,19 @@
     <div class="row">
       <div class="col-sm-12">
         <h2 class="page-heading">
-          Discuss
+          Discussions
         </h2>
         <div class="list-group col-sm-12 col-md-2 col-lg-3">
+          <h3>Categories</h3>
           {{#categoryList}}
           <a href="{{{categoryPageUrl}}}" class="list-group-item">
             <h4 class="list-group-item-heading">{{name}}</h4>
             <p class="list-group-item-text">{{description}}</p>
           </a>
           {{/categoryList}}
+        </div>
+        <div class="text-center">
+          {{{paginationRendered}}}
         </div>
         <div class="panel panel-default col-sm-12 col-md-10 col-lg-9">
           {{> includes/discussionList.html }}

--- a/views/pages/discussionListPage.html
+++ b/views/pages/discussionListPage.html
@@ -18,6 +18,9 @@
             <i class="fa fa-plus"></i> Create Topic
           </a>
         </div>
+        <div class="text-center">
+          {{{paginationRendered}}}
+        </div>
         <div class="panel panel-default">
           {{> includes/discussionList.html }}
         </div>

--- a/views/pages/discussionPage.html
+++ b/views/pages/discussionPage.html
@@ -31,6 +31,9 @@
             <div class="container-fluid comments">
               <div class="row">
                 <section class="topic-area list-group">
+                  <div class="text-center">
+                    {{{paginationRendered}}}
+                  </div>
                   {{#commentList}}
                   {{> includes/comment.html }}
                   {{/commentList}}

--- a/views/pages/groupListPage.html
+++ b/views/pages/groupListPage.html
@@ -12,6 +12,9 @@
         <h2 class="page-heading">
           Groups
         </h2>
+        <div class="text-center">
+          {{{paginationRendered}}}
+        </div>
         <div class="panel panel-default">
           {{> includes/groupList.html }}
         </div>

--- a/views/pages/groupScriptListPage.html
+++ b/views/pages/groupScriptListPage.html
@@ -12,6 +12,9 @@
         <h2 class="page-heading">
           <a href="{{{group.groupPageUrl}}}" class="script-name">{{group.name}}</a>
         </h2>
+        <div class="text-center">
+          {{{paginationRendered}}}
+        </div>
         <div class="panel panel-default">
           {{> includes/scriptList.html }}
         </div>

--- a/views/pages/removedItemListPage.html
+++ b/views/pages/removedItemListPage.html
@@ -12,6 +12,9 @@
         <h2 class="page-heading">
           Removed Items
         </h2>
+        <div class="text-center">
+          {{{paginationRendered}}}
+        </div>
         <div class="panel panel-default">
           {{> includes/removedItemList.html }}
         </div>

--- a/views/pages/scriptIssueListPage.html
+++ b/views/pages/scriptIssueListPage.html
@@ -29,6 +29,9 @@
           The script author requests that you use their preferred primary support method when filing an issue. Please consider using that for regular issues.
         </div>
         {{/script.hasSupport}}
+        <div class="text-center">
+          {{{paginationRendered}}}
+        </div>
         <div class="panel panel-default">
           {{> includes/discussionList.html }}
         </div>

--- a/views/pages/scriptIssuePage.html
+++ b/views/pages/scriptIssuePage.html
@@ -39,6 +39,9 @@
           <div class="container-fluid comments">
             <div class="row">
               <section class="topic-area list-group">
+                <div class="text-center">
+                  {{{paginationRendered}}}
+                </div>
                 {{#commentList}}
                 {{> includes/comment.html }}
                 {{/commentList}}

--- a/views/pages/scriptListPage.html
+++ b/views/pages/scriptListPage.html
@@ -12,6 +12,9 @@
         <h2 class="page-heading">
           {{pageHeading}}
         </h2>
+        <div class="text-center">
+          {{{paginationRendered}}}
+        </div>
         <div class="panel panel-default">
           {{> includes/scriptList.html }}
         </div>

--- a/views/pages/userCommentListPage.html
+++ b/views/pages/userCommentListPage.html
@@ -15,6 +15,9 @@
             <div class="container-fluid comments">
               <div class="row">
                 <section class="topic-area list-group">
+                  <div class="text-center">
+                    {{{paginationRendered}}}
+                  </div>
                   {{#commentList}}
                   <div class="topic-title row container-fluid">
                     <ol class="breadcrumb pull-left">

--- a/views/pages/userGitHubRepoListPage.html
+++ b/views/pages/userGitHubRepoListPage.html
@@ -11,6 +11,9 @@
     <div class="row">
       <div class="col-md-8">
         <h2><a href="{{{userGitHubRepoListPageUrl}}}" class="script-author">{{githubUser.login}}</a></h2>
+        <div class="text-center">
+          {{{paginationRendered}}}
+        </div>
         <div class="list-group">
           {{#githubRepoList}}
           <a href="{{{userGitHubRepoPageUrl}}}" class="list-group-item">

--- a/views/pages/userListPage.html
+++ b/views/pages/userListPage.html
@@ -12,6 +12,9 @@
         <h2 class="page-heading">
           {{pageHeading}}
         </h2>
+        <div class="text-center">
+          {{{paginationRendered}}}
+        </div>
         <div class="panel panel-default">
           {{> includes/userList.html }}
         </div>

--- a/views/pages/userScriptListPage.html
+++ b/views/pages/userScriptListPage.html
@@ -12,6 +12,9 @@
         <div class="row">
           <div class="col-xs-12">
             {{> includes/userPageHeader.html }}
+            <div class="text-center">
+              {{{paginationRendered}}}
+            </div>
             <div class="panel panel-default">
               {{> includes/scriptList.html }}
             </div>


### PR DESCRIPTION
* `bootstrap-custom.css` needs some more tweaking as we have some slight pixel related CSS issues overall but will save that for another PR
* Add "Categories" header to main forum page
* Change "Discuss" labels to "Discussions" to match title... we have plenty of room
* Expand out "Libs" to "Libraries" ... again we have room with *bootstrap* and portable devices. Needed for translations in #18
* Change a few tooltips to match
* Adjust comment reply popup size to match changes

Applies to #531