### PR TITLE
Fix the bottom existing pagination at `/forum`

### DIFF
--- a/views/pages/categoryListPage.html
+++ b/views/pages/categoryListPage.html
@@ -21,14 +21,16 @@
           </a>
           {{/categoryList}}
         </div>
-        <div class="text-center">
-          {{{paginationRendered}}}
-        </div>
-        <div class="panel panel-default col-sm-12 col-md-10 col-lg-9">
-          {{> includes/discussionList.html }}
-        </div>
-        <div class="text-center">
-          {{{paginationRendered}}}
+        <div class="panel-group col-sm-offset-0 col-md-offset-2 col-lg-offset-3">
+          <div class="text-center">
+            {{{paginationRendered}}}
+          </div>
+          <div class="panel panel-default col-sm-12 col-md-12 col-lg-12">
+            {{> includes/discussionList.html }}
+          </div>
+          <div class="text-center">
+            {{{paginationRendered}}}
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
* Panel was initialized with pagination that skewed off center for additions and compounded by #443. This should align the existing pagination properly.

Applies to #531