### PR TITLE
Fix enforcing of `limit` QS fix for non-numerics in `limitRange`

### DIFF
--- a/libs/helpers.js
+++ b/libs/helpers.js
@@ -96,8 +96,11 @@ exports.cleanFilename = function (aFilename, aDefaultName) {
   return cleanName || aDefaultName;
 };
 
-exports.limitRange = function (aMin, aX, aMax) {
-  return Math.max(Math.min(aX, aMax), aMin);
+exports.limitRange = function (aMin, aX, aMax, aDefault) {
+  var x = Math.max(Math.min(aX, aMax), aMin);
+
+  // ES5 strict similar check to ES6 Number.isNaN()
+  return (x !== x ? aDefault : x);
 };
 
 exports.limitMin = function (aMin, aX) {

--- a/libs/templateHelpers.js
+++ b/libs/templateHelpers.js
@@ -80,7 +80,9 @@ var newPagination = function (aCurrentPage, aItemsPerPage) {
 
   //
   pagination.currentPage = aCurrentPage ? helpers.limitMin(1, aCurrentPage) : 1;
-  pagination.itemsPerPage = aItemsPerPage ? helpers.limitRange(1, aItemsPerPage, maxItemsPerPage) : defaultItemsPerPage;
+  pagination.itemsPerPage = aItemsPerPage ?
+    helpers.limitRange(1, aItemsPerPage, maxItemsPerPage, defaultItemsPerPage) :
+    defaultItemsPerPage;
 
   return pagination;
 };


### PR DESCRIPTION
* A STYLEGUIDE.md enforcement ... 100 character limit
* Change function parms to include default value into the function since this should always be under our jurisdiction... **minimal** change in existing templateHelper.js logic.
* Use ES5 strict compatible `NaN` conditional test

See also https://openuserjs.org/users/sizzle/comments#comment-148579ad751