### PR TITLE
Update *bootstrap* dep to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "async": "0.9.0",
     "aws-sdk": "2.0.21",
     "body-parser": "1.10.1",
-    "bootstrap": "3.1.1",
+    "bootstrap": "3.3.1",
     "bootstrap-markdown": "2.8.0",
     "compression": "1.3.0",
     "connect-mongo": "0.6.0",

--- a/public/css/bootstrap-custom.css
+++ b/public/css/bootstrap-custom.css
@@ -5146,7 +5146,6 @@ button.close {
   right: 0;
   bottom: 0;
   left: 0;
-  z-index: 1040;
   background-color: #000000;
 }
 .modal-backdrop.fade {


### PR DESCRIPTION
* `z-index` was the culprit for previously mentioned modal failure
* Watchpoint for *bootstrap* 3.1.1 changes to 3.3.1 ... if necessary will swap out entire modal sections of CSS with upstream as they do work and are more compact but reserving that task for #249

Closes #379