### PR TITLE
Revert *bootstrap* dep update

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "async": "0.9.0",
     "aws-sdk": "2.0.21",
     "body-parser": "1.10.1",
-    "bootstrap": "3.3.1",
+    "bootstrap": "3.1.1",
     "bootstrap-markdown": "2.8.0",
     "compression": "1.3.0",
     "connect-mongo": "0.6.0",


### PR DESCRIPTION
* Not our CSS interfering
* jQuery event listeners tested... okay
* Would appear that current *bootstrap-markdown* and current *bootstrap* aren't playing nice with `collapse`. e.g. comment reply box shows however it immediately closes itself. I have seen this behavior before a few times but usually a browser restart handled it... not this time. *bootstrap* 3.2.0, 3.3.0 and 3.3.1 all exhibit this behavior
* Leaving `z-index` fix in as 3.1.1 appears not to need this from testing.

Refs #540 and #379