### PR TITLE
Programmatic toggle and disable only page pagination

### DIFF
--- a/libs/templateHelpers.js
+++ b/libs/templateHelpers.js
@@ -21,6 +21,11 @@ var paginateTemplate = function (aOpts) {
   var distVisible = aOpts.distVisible || 4;
   var firstVisible = aOpts.firstVisible || true;
   var lastVisible = aOpts.firstVisible || true;
+  var soleVisible = aOpts.soleVisible || false;
+
+  if (!soleVisible && lastPage === 1) {
+    return null;
+  }
 
   var linkedPages = [];
 
@@ -32,6 +37,10 @@ var paginateTemplate = function (aOpts) {
 
   if (lastVisible && linkedPages.length > 0 && linkedPages[linkedPages.length - 1] !== lastPage)
     linkedPages.push(lastPage);
+
+  if (linkedPages.length === 0) {
+    return null;
+  }
 
   var html = '';
   html += '<ul class="pagination">';

--- a/views/includes/scripts/commentReplyScript.html
+++ b/views/includes/scripts/commentReplyScript.html
@@ -3,7 +3,7 @@
     // Show spacer div
     $('#reply-control').on('show.bs.collapse', function () {
       $('#show-reply-form-when-visible').css({
-        height: '210px'
+        height: '{{#paginationRendered}}210{{/paginationRendered}}{{^paginationRendered}}268{{/paginationRendered}}px'
       });
     });
 

--- a/views/pages/categoryListPage.html
+++ b/views/pages/categoryListPage.html
@@ -22,21 +22,27 @@
           {{/categoryList}}
         </div>
         <div class="panel-group col-sm-offset-0 col-md-offset-2 col-lg-offset-3">
+          {{#paginationRendered}}
           <div class="text-center collapse">
             {{{paginationRendered}}}
           </div>
+          {{/paginationRendered}}
           <div class="panel panel-default col-sm-12 col-md-12 col-lg-12">
             {{> includes/discussionList.html }}
           </div>
+          {{#paginationRendered}}
           <div class="text-center">
             {{{paginationRendered}}}
           </div>
+          {{/paginationRendered}}
         </div>
       </div>
     </div>
   </div>
   {{> includes/footer.html }}
-  {{> includes/scripts/showTopPagination.html }}
+  {{#paginationRendered}}
+    {{> includes/scripts/showTopPagination.html }}
+  {{/paginationRendered}}
   {{> includes/scripts/tableTrLinkScript.html }}
 </body>
 </html>

--- a/views/pages/discussionListPage.html
+++ b/views/pages/discussionListPage.html
@@ -18,20 +18,26 @@
             <i class="fa fa-plus"></i> Create Topic
           </a>
         </div>
+        {{#paginationRendered}}
         <div class="text-center collapse">
           {{{paginationRendered}}}
         </div>
+        {{/paginationRendered}}
         <div class="panel panel-default">
           {{> includes/discussionList.html }}
         </div>
+        {{#paginationRendered}}
         <div class="text-center">
           {{{paginationRendered}}}
         </div>
+        {{/paginationRendered}}
       </div>
     </div>
   </div>
   {{> includes/footer.html }}
-  {{> includes/scripts/showTopPagination.html }}
+  {{#paginationRendered}}
+    {{> includes/scripts/showTopPagination.html }}
+  {{/paginationRendered}}
   {{> includes/scripts/tableTrLinkScript.html }}
 </body>
 </html>

--- a/views/pages/discussionPage.html
+++ b/views/pages/discussionPage.html
@@ -31,15 +31,19 @@
             <div class="container-fluid comments">
               <div class="row">
                 <section class="topic-area list-group">
+                  {{#paginationRendered}}
                   <div class="text-center collapse">
                     {{{paginationRendered}}}
                   </div>
+                  {{/paginationRendered}}
                   {{#commentList}}
                   {{> includes/comment.html }}
                   {{/commentList}}
+                  {{#paginationRendered}}
                   <div class="text-center">
                     {{{paginationRendered}}}
                   </div>
+                  {{/paginationRendered}}
                 </section>
               </div>
             </div>
@@ -53,7 +57,9 @@
   <div id="show-reply-form-when-visible"></div>
   {{> includes/commentForm.html }}
   {{> includes/footer.html }}
-  {{> includes/scripts/showTopPagination.html }}
+  {{#paginationRendered}}
+    {{> includes/scripts/showTopPagination.html }}
+  {{/paginationRendered}}
   {{#authedUser}}
     {{> includes/scripts/markdownEditor.html }}
     {{> includes/scripts/commentReplyScript.html }}

--- a/views/pages/groupListPage.html
+++ b/views/pages/groupListPage.html
@@ -12,15 +12,19 @@
         <h2 class="page-heading">
           Groups
         </h2>
+        {{#paginationRendered}}
         <div class="text-center collapse">
           {{{paginationRendered}}}
         </div>
+        {{/paginationRendered}}
         <div class="panel panel-default">
           {{> includes/groupList.html }}
         </div>
+        {{#paginationRendered}}
         <div class="text-center">
           {{{paginationRendered}}}
         </div>
+        {{/paginationRendered}}
       </div>
       <div class="col-sm-4">
         {{> includes/searchBarPanel.html }}
@@ -29,7 +33,9 @@
     </div>
   </div>
   {{> includes/footer.html }}
-  {{> includes/scripts/showTopPagination.html }}
+  {{#paginationRendered}}
+    {{> includes/scripts/showTopPagination.html }}
+  {{/paginationRendered}}
   {{> includes/scripts/tableTrLinkScript.html }}
 </body>
 </html>

--- a/views/pages/groupScriptListPage.html
+++ b/views/pages/groupScriptListPage.html
@@ -12,15 +12,19 @@
         <h2 class="page-heading">
           <a href="{{{group.groupPageUrl}}}" class="script-name">{{group.name}}</a>
         </h2>
+        {{#paginationRendered}}
         <div class="text-center collapse">
           {{{paginationRendered}}}
         </div>
+        {{/paginationRendered}}
         <div class="panel panel-default">
           {{> includes/scriptList.html }}
         </div>
+        {{#paginationRendered}}
         <div class="text-center">
           {{{paginationRendered}}}
         </div>
+        {{/paginationRendered}}
       </div>
       <div class="col-sm-4">
         {{> includes/searchBarPanel.html }}
@@ -31,7 +35,9 @@
   </div>
   {{> includes/footer.html }}
   {{> includes/scripts/tableTrLinkScript.html }}
-  {{> includes/scripts/showTopPagination.html }}
+  {{#paginationRendered}}
+    {{> includes/scripts/showTopPagination.html }}
+  {{/paginationRendered}}
   {{> includes/scripts/lazyIconScript.html }}
 </body>
 </html>

--- a/views/pages/removedItemListPage.html
+++ b/views/pages/removedItemListPage.html
@@ -12,15 +12,19 @@
         <h2 class="page-heading">
           Removed Items
         </h2>
+        {{#paginationRendered}}
         <div class="text-center collapse">
           {{{paginationRendered}}}
         </div>
+        {{/paginationRendered}}
         <div class="panel panel-default">
           {{> includes/removedItemList.html }}
         </div>
+        {{#paginationRendered}}
         <div class="text-center">
           {{{paginationRendered}}}
         </div>
+        {{/paginationRendered}}
       </div>
       <div class="col-sm-4">
         {{> includes/searchBarPanel.html }}
@@ -35,6 +39,8 @@
   </div>
   {{> includes/footer.html }}
   {{> includes/scripts/tableTrLinkScript.html }}
-  {{> includes/scripts/showTopPagination.html }}
+  {{#paginationRendered}}
+    {{> includes/scripts/showTopPagination.html }}
+  {{/paginationRendered}}
 </body>
 </html>

--- a/views/pages/scriptIssueListPage.html
+++ b/views/pages/scriptIssueListPage.html
@@ -29,15 +29,19 @@
           The script author requests that you use their preferred primary support method when filing an issue. Please consider using that for regular issues.
         </div>
         {{/script.hasSupport}}
+        {{#paginationRendered}}
         <div class="text-center collapse">
           {{{paginationRendered}}}
         </div>
+        {{/paginationRendered}}
         <div class="panel panel-default">
           {{> includes/discussionList.html }}
         </div>
+        {{#paginationRendered}}
         <div class="text-center">
           {{{paginationRendered}}}
         </div>
+        {{/paginationRendered}}
       </div>
       <div class="container-fluid col-sm-4">
         {{> includes/searchBarPanel.html }}
@@ -54,7 +58,9 @@
   </div>
   {{> includes/footer.html }}
   {{> includes/scripts/tableTrLinkScript.html }}
-  {{> includes/scripts/showTopPagination.html }}
+  {{#paginationRendered}}
+    {{> includes/scripts/showTopPagination.html }}
+  {{/paginationRendered}}
   {{> includes/scripts/lazyIconScript.html }}
 </body>
 </html>

--- a/views/pages/scriptIssuePage.html
+++ b/views/pages/scriptIssuePage.html
@@ -39,15 +39,19 @@
           <div class="container-fluid comments">
             <div class="row">
               <section class="topic-area list-group">
+                {{#paginationRendered}}
                 <div class="text-center collapse">
                   {{{paginationRendered}}}
                 </div>
+                {{/paginationRendered}}
                 {{#commentList}}
                 {{> includes/comment.html }}
                 {{/commentList}}
+                {{#paginationRendered}}
                 <div class="text-center">
                   {{{paginationRendered}}}
                 </div>
+                {{/paginationRendered}}
               </section>
             </div>
           </div>
@@ -62,7 +66,9 @@
   <div id="show-reply-form-when-visible"></div>
   {{> includes/commentForm.html }}
   {{> includes/footer.html }}
-  {{> includes/scripts/showTopPagination.html }}
+  {{#paginationRendered}}
+      {{> includes/scripts/showTopPagination.html }}
+  {{/paginationRendered}}
   {{> includes/scripts/lazyIconScript.html }}
   {{#authedUser}}
   {{> includes/scripts/markdownEditor.html }}

--- a/views/pages/scriptListPage.html
+++ b/views/pages/scriptListPage.html
@@ -12,15 +12,19 @@
         <h2 class="page-heading">
           {{pageHeading}}
         </h2>
+        {{#paginationRendered}}
         <div class="text-center collapse">
           {{{paginationRendered}}}
         </div>
+        {{/paginationRendered}}
         <div class="panel panel-default">
           {{> includes/scriptList.html }}
         </div>
+        {{#paginationRendered}}
         <div class="text-center">
           {{{paginationRendered}}}
         </div>
+        {{/paginationRendered}}
       </div>
       <div class="col-sm-4">
         {{> includes/searchBarPanel.html }}
@@ -30,7 +34,9 @@
     </div>
   </div>
   {{> includes/footer.html }}
-  {{> includes/scripts/showTopPagination.html }}
+  {{#paginationRendered}}
+    {{> includes/scripts/showTopPagination.html }}
+  {{/paginationRendered}}
   {{> includes/scripts/tableTrLinkScript.html }}
   {{> includes/scripts/lazyIconScript.html }}
 </body>

--- a/views/pages/userCommentListPage.html
+++ b/views/pages/userCommentListPage.html
@@ -15,9 +15,11 @@
             <div class="container-fluid comments">
               <div class="row">
                 <section class="topic-area list-group">
+                  {{#paginationRendered}}
                   <div class="text-center collapse">
                     {{{paginationRendered}}}
                   </div>
+                  {{/paginationRendered}}
                   {{#commentList}}
                   <div class="topic-title row container-fluid">
                     <ol class="breadcrumb pull-left">
@@ -36,9 +38,11 @@
                     </div>
                   </div>
                   {{/commentList}}
+                  {{#paginationRendered}}
                   <div class="text-center">
                     {{{paginationRendered}}}
                   </div>
+                  {{/paginationRendered}}
                 </section>
               </div>
             </div>
@@ -51,6 +55,8 @@
     </div>
   </div>
   {{> includes/footer.html }}
-  {{> includes/scripts/showTopPagination.html }}
+  {{#paginationRendered}}
+    {{> includes/scripts/showTopPagination.html }}
+  {{/paginationRendered}}
 </body>
 </html>

--- a/views/pages/userGitHubRepoListPage.html
+++ b/views/pages/userGitHubRepoListPage.html
@@ -11,9 +11,11 @@
     <div class="row">
       <div class="col-md-8">
         <h2><a href="{{{userGitHubRepoListPageUrl}}}" class="script-author">{{githubUser.login}}</a></h2>
+        {{#paginationRendered}}
         <div class="text-center collapse">
           {{{paginationRendered}}}
         </div>
+        {{/paginationRendered}}
         <div class="list-group">
           {{#githubRepoList}}
           <a href="{{{userGitHubRepoPageUrl}}}" class="list-group-item">
@@ -21,15 +23,19 @@
           </a>
           {{/githubRepoList}}
         </div>
+        {{#paginationRendered}}
         <div class="text-center">
           {{{paginationRendered}}}
         </div>
+        {{/paginationRendered}}
       </div>
       <div class="col-md-4">
       </div>
     </div>
   </div>
   {{> includes/footer.html }}
-  {{> includes/scripts/showTopPagination.html }}
+  {{#paginationRendered}}
+    {{> includes/scripts/showTopPagination.html }}
+  {{/paginationRendered}}
 </body>
 </html>

--- a/views/pages/userListPage.html
+++ b/views/pages/userListPage.html
@@ -12,15 +12,19 @@
         <h2 class="page-heading">
           {{pageHeading}}
         </h2>
+        {{#paginationRendered}}
         <div class="text-center collapse">
           {{{paginationRendered}}}
         </div>
+        {{/paginationRendered}}
         <div class="panel panel-default">
           {{> includes/userList.html }}
         </div>
+        {{#paginationRendered}}
         <div class="text-center">
           {{{paginationRendered}}}
         </div>
+        {{/paginationRendered}}
       </div>
       <div class="col-sm-4">
         {{> includes/searchBarPanel.html }}
@@ -28,7 +32,9 @@
     </div>
   </div>
   {{> includes/footer.html }}
-  {{> includes/scripts/showTopPagination.html }}
+  {{#paginationRendered}}
+    {{> includes/scripts/showTopPagination.html }}
+  {{/paginationRendered}}
   {{> includes/scripts/tableTrLinkScript.html }}
 </body>
 </html>

--- a/views/pages/userScriptListPage.html
+++ b/views/pages/userScriptListPage.html
@@ -12,15 +12,19 @@
         <div class="row">
           <div class="col-xs-12">
             {{> includes/userPageHeader.html }}
+            {{#paginationRendered}}
             <div class="text-center collapse">
               {{{paginationRendered}}}
             </div>
+            {{/paginationRendered}}
             <div class="panel panel-default">
               {{> includes/scriptList.html }}
             </div>
+            {{#paginationRendered}}
             <div class="text-center">
               {{{paginationRendered}}}
             </div>
+            {{/paginationRendered}}
           </div>
         </div>
       </div>
@@ -31,7 +35,9 @@
     </div>
   </div>
   {{> includes/footer.html }}
-  {{> includes/scripts/showTopPagination.html }}
+  {{#paginationRendered}}
+    {{> includes/scripts/showTopPagination.html }}
+  {{/paginationRendered}}
   {{> includes/scripts/tableTrLinkScript.html }}
   {{> includes/scripts/lazyIconScript.html }}
 </body>


### PR DESCRIPTION
* Don't send the jQuery script if no more pages
* Adjust comment reply box value to accommodate on the fly
* This also allows some fixing of rendering on pages that have no items in the list e.g. too far out in `p` QSP.

Closes #531

**MISC NOTE**:
* Existing `pagination` object is "late" object creation e.g. accumulation of it's properties and methods occurs from iteration through existing methods and `lastPage` is calculated near the end of the process.