### PR TITLE
Fix for UI not showing zero calculated threshold to moderators and above

### DIFF
--- a/controllers/script.js
+++ b/controllers/script.js
@@ -254,7 +254,7 @@ var getScriptPageTasks = function (aOptions) {
       }
 
       flagLib.getThreshold(Script, script, aAuthor, function (aThreshold) {
-        aOptions.threshold = aThreshold;
+        aOptions.threshold = aThreshold.toString();
         aCallback();
       });
     });

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -77,7 +77,7 @@ var setupUserModerationUITask = function (aOptions) {
         }
 
         flagLib.getThreshold(User, user, aAuthor, function (aThreshold) {
-          aOptions.threshold = aThreshold;
+          aOptions.threshold = aThreshold.toString();
           aCallback();
         });
       });

--- a/views/includes/flagModelSnippet.html
+++ b/views/includes/flagModelSnippet.html
@@ -8,7 +8,7 @@
   <div class="form-group">
     <label class="col-sm-4 control-label">Threshold</label>
     <div class="col-sm-8">
-      <p class="form-control-static">{{#threshold}}{{threshold}}{{/threshold}}</p>
+      <p class="form-control-static">{{threshold}}</p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
* If `karma` is `-1` and fixed threshold is `1` then computed threshold for that model becomes zero thus not showing in view snippet. e.g. type casting here to let us know we are calculating and not a potentially bogus boog
* Remove unnecessary mustache conditional in view snippet ... we want to see if there's a bug not hide it

Applies to #262