### PR TITLE
Use defaults for Flags and Threshold

### DIFF
--- a/controllers/script.js
+++ b/controllers/script.js
@@ -52,6 +52,12 @@ var getScriptPageTasks = function (aOptions) {
   // Temporaries
   var htmlStub = null;
 
+  // Default to infinity
+  aOptions.threshold = '\u221E';
+
+  // Default to &ndash;
+  aOptions.flags = '\u2013';
+
   //--- Tasks
 
   // Show the number of open issues

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -50,6 +50,12 @@ var setupUserModerationUITask = function (aOptions) {
   var user = aOptions.user;
   var authedUser = aOptions.authedUser;
 
+  // Default to infinity
+  aOptions.threshold = '\u221E';
+
+  // Default to &ndash;
+  aOptions.flags = '\u2013';
+
   return function (aCallback) {
     var flagUrl = '/flag/users/' + user.name;
 
@@ -77,7 +83,7 @@ var setupUserModerationUITask = function (aOptions) {
         }
 
         flagLib.getThreshold(User, user, aAuthor, function (aThreshold) {
-          aOptions.threshold = aThreshold.toString();
+          aOptions.threshold = aThreshold || 0;
           aCallback();
         });
       });


### PR DESCRIPTION
* Use alternate "type casting" for threshold... more symmetric with flags code
* Show ininity and ndash... technically ndash should never show unless there is a coding bug with calculation with voting portion.