### PR TITLE
Prevent empty spaced commenting and topics

### DIFF
--- a/views/includes/commentForm.html
+++ b/views/includes/commentForm.html
@@ -2,8 +2,8 @@
   <form action="{{{discussion.discussionPageUrl}}}" method="post">
     <div class="container-fluid row user-content">
       <div class="submit-panel pull-right btn-toolbar">
-        <button class="btn btn-sm btn-success" type="submit"><i class="fa fa-reply"></i> Reply</button>
         <button class="btn btn-sm btn-danger" type="button" data-toggle="collapse" data-target="#reply-control"><i class="fa fa-close"></i> Cancel</button>
+        <button class="btn btn-sm btn-success" type="submit"><i class="fa fa-reply"></i> Reply</button>
       </div>
       <textarea name="comment-content" data-provide="markdown" data-iconlibrary="fa" class="col-xs-12" placeholder="Type here using Markdown."></textarea>
     </div>


### PR DESCRIPTION
* Basic statusCodePage for those users who are accidentally/intentionally putting in blank comments... applies to #37
* Some missed Apps Hungarian from #264 ... there's probably more. ;)
* Some STYLEGUIDE.md conformance with braces, newlines and indention
* Stray trailing comma fix
* Flip Cancel and Reply buttons... this may be some of the accidents with empty comments. Most likely when someone is going full screen they might be clicking reply on touch screens... favor canceling instead of replying if that's the case