### PR TITLE
Snug up top reminders in CSS

### DIFF
--- a/public/less/bootstrap/oujs-bootswatch.less
+++ b/public/less/bootstrap/oujs-bootswatch.less
@@ -131,8 +131,21 @@ table {
 }
 
 // Staged =====================================================================
-.close {
-  font-size: @close-font-size;
+body > .navbar {
+  margin-bottom: 0;
+}
+
+.reminders {
+  margin-bottom: @line-height-computed;
+}
+
+.reminders .alert.small {
+  margin-bottom: 0;
+  padding: (@alert-padding * 0.66)
+}
+
+.reminders .alert.small .close {
+  font-size: (@font-size-base * 1.25);
 }
 
 // Unstaged ===================================================================

--- a/public/less/bootstrap/oujs-variables.less
+++ b/public/less/bootstrap/oujs-variables.less
@@ -590,7 +590,7 @@
 //
 //## Define alert colors, border radius, and padding.
 
-@alert-padding:               10px;
+@alert-padding:               15px;
 @alert-border-radius:         @border-radius-base;
 @alert-link-font-weight:      bold;
 
@@ -778,7 +778,6 @@
 //##
 
 @close-font-weight:           bold;
-@close-font-size:             (@font-size-base * 1.25);
 @close-color:                 #000;
 @close-text-shadow:           0 1px 0 #fff;
 

--- a/views/includes/headerReminders.html
+++ b/views/includes/headerReminders.html
@@ -1,5 +1,5 @@
-<div>
-  <div class="alert alert-info alert-dismissible small" role="alert">
+<div class="reminders">
+  <div class="alert alert-info alert-dismissible small fade in" role="alert">
     <button type="button" class="close" data-dismiss="alert"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
     <p><i class="fa fa-fw fa-exclamation-triangle"></i> <b>REMINDER:</b> Don't miss out reading the <a class="alert-link" href="/announcements/Google_Authentication_Deprecation">Google Authentication Deprecation</a> with migration  announcement.</p>
   </div>


### PR DESCRIPTION
* Don't affect non-small alerts
* Assuming our main nav will always be at top... snug up the `margin-bottom`
* Add class to reminders
* Snug up reminders
* Undo default alert padding change and *(x) close from #568 and handle only in reminders that are small
* Use some more LESS syntax in staged area
* Add *bootstrap*s default fade effect on close... the timing is a bit short so not really noticable but if you stare it closely it does use CSS3.

**NOTES**:
* When removing reminders, which are currently static in the view, leave the parent `reminders` div in to maintain current spacing especially when closed.