### PR TITLE
Improve automatic highlight in *highlight.js* a bit

### DIFF
--- a/libs/markdown.js
+++ b/libs/markdown.js
@@ -98,11 +98,33 @@ renderer.heading = function (aText, aLevel) {
 // Keep in sync with ./views/includes/scripts/markdownEditor.html
 marked.setOptions({
   highlight: function (aCode, aLang) {
+    var obj = null;
+
     if (aLang && hljs.getLanguage(aLang)) {
-      return hljs.highlight(aLang, aCode).value;
-    } else {
-      return hljs.highlightAuto(aCode).value;
+      try {
+        return hljs.highlight(aLang, aCode).value;
+      } catch (aErr) {
+      }
     }
+
+    try {
+      obj = hljs.highlightAuto(aCode);
+
+      switch (obj.language) {
+        // Transform list of auto-detected language highlights
+        case 'dust':
+        case '1c':
+          // Narrow auto-detection to something that is more likely
+          return hljs.highlightAuto(aCode, ['css', 'html', 'js', 'json']).value;
+        // Any other detected go ahead and return
+        default:
+          return obj.value;
+      }
+    } catch (aErr) {
+    }
+
+    // If any external package failure don't block return e.g. prevent empty
+    return aCode;
   },
   renderer: renderer,
   gfm: true,


### PR DESCRIPTION
* try..catch routine for external failures if ever present e.g. don't block return
* Normalize to what we might expect if auto-detection returns the incorrect result... not foolproof but better than nothing and very basic
* Comment it up a bit