### PR TITLE
Change event capture for reply box and reminders

### DIFF
--- a/views/includes/scripts/commentReplyScript.html
+++ b/views/includes/scripts/commentReplyScript.html
@@ -73,7 +73,7 @@
     var handler = fireIfElementVisible($('#show-reply-form-when-visible'), callback);
 
     // jQuery
-    $(window).on('DOMContentLoaded load resize scroll', handler);
+    $(window).on('focus resize scroll', handler);
 
   })();
 </script>

--- a/views/includes/scripts/hideReminders.html
+++ b/views/includes/scripts/hideReminders.html
@@ -38,7 +38,7 @@
 
     var handler = fireIfElementVisible($('.reminders'), callback);
 
-    $(window).on('DOMContentLoaded load resize scroll', handler);
+    $(window).on('focus resize scroll', handler);
 
   })();
 </script>


### PR DESCRIPTION
* If a tab doesn't have focus don't bother doing anything for these e.g. multiple tabs opened don't start the timer and don't pop up the reply box a.k.a not concurrent op but user event driven