### PR TITLE
Browser compatibility fix for Chromium/Chrome based browsers and Opera P...

### DIFF
--- a/views/includes/scripts/commentReplyScript.html
+++ b/views/includes/scripts/commentReplyScript.html
@@ -73,7 +73,7 @@
     var handler = fireIfElementVisible($('#show-reply-form-when-visible'), callback);
 
     // jQuery
-    $(window).on('focus resize scroll', handler);
+    $(window).on('DOMContentLoaded load resize scroll', handler);
 
   })();
 </script>


### PR DESCRIPTION
...resto

* `focus` event doesn't appear to be handled properly in two other browsers so reverting comment reply box handler event... this may invalidate #575 in browsers that handle this incorrectly. `activate` and `create` do nothing additional in tested browsers... Mozilla rules again. ;)
* Restores ability to comment in those tested browsers without scroll and resize

---

**NOTE**:
* Reverse migration.