### PR TITLE
Some misc client side jQuery fixes

### DIFF
--- a/views/includes/scripts/commentReplyScript.html
+++ b/views/includes/scripts/commentReplyScript.html
@@ -1,5 +1,10 @@
 <script type="text/javascript">
   (function () {
+
+    var events = 'DOMContentLoaded load resize scroll';
+    var handler = null;
+    var didCallback = false;
+
     $('#reply-control').on('show.bs.collapse', function () {
       // Show spacer div
       $('#show-reply-form-when-visible').css({
@@ -18,17 +23,19 @@
     });
 
     $('.btn-comment-reply').click(function (aE) {
-      $('#reply-control').collapse('show');
-
       var $comment = $(aE.target).closest('.topic-post');
       var $author = $comment.find('.topic-meta-data .names .username').first();
       var $replyTextarea = $('#reply-control textarea[name="comment-content"]');
+      var value = null;
+
+      $('#reply-control').collapse('show');
 
       document.location.hash = $comment.attr('id');
 
-      var value = $replyTextarea.val();
+      value = $replyTextarea.val();
       if (!/^\s*$/.test(value)) {
-        value += '\n\n'; // Add linebreaks if reply already started.
+        // Add linebreaks if reply already started.
+        value += '\n\n';
       }
       value += '[Re](' + document.location.href.replace(/\(/g, '%28').replace(/\)/g, '%29') + '): ';
       value += '[@' + $author.text() + '](' + $author.attr('href') + '): ';
@@ -37,43 +44,29 @@
       $replyTextarea.focus();
     });
 
-    function isElementInViewport(aEl) {
-      if (aEl instanceof jQuery) {
-        aEl = aEl[0];
-      }
-
-      var rect = aEl.getBoundingClientRect();
-
-      return (
-        rect.top >= 0 &&
-        rect.left >= 0 &&
-        rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) && /*or $(window).height() */
-        rect.right <= (window.innerWidth || document.documentElement.clientWidth) /*or $(window).width() */
-      );
-    }
-
-    var hasShownReplyForm = false;
     function callback(aEl) {
-      if (!hasShownReplyForm) {
-        $('#reply-control').collapse('show');
-        hasShownReplyForm = true;
+      if (!didCallback) {
+        didCallback = true;
 
+        $('#reply-control').collapse('show');
         $('#reply-control textarea[name="comment-content"]').focus();
       }
     }
 
+    {{> includes/scripts/isElementInViewport.js }}
+
     function fireIfElementVisible(aEl, aCallback) {
       return function () {
         if (isElementInViewport(aEl)) {
+          $(window).off(events, handler);
+
           aCallback(aEl);
         }
       }
     }
 
-    var handler = fireIfElementVisible($('#show-reply-form-when-visible'), callback);
-
-    // jQuery
-    $(window).on('DOMContentLoaded load resize scroll', handler);
+    handler = fireIfElementVisible($('#show-reply-form-when-visible'), callback);
+    $(window).on(events, handler);
 
   })();
 </script>

--- a/views/includes/scripts/hideReminders.html
+++ b/views/includes/scripts/hideReminders.html
@@ -1,24 +1,13 @@
 <script type="text/javascript">
   (function () {
-    function isElementInViewport(aEl) {
-      if (aEl instanceof jQuery) {
-        aEl = aEl[0];
-      }
 
-      var rect = aEl.getBoundingClientRect();
+    var events = 'focus resize scroll';
+    var handler = null;
+    var didCallback = false;
 
-      return (
-        rect.top >= 0 &&
-        rect.left >= 0 &&
-        rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) && /*or $(window).height() */
-        rect.right <= (window.innerWidth || document.documentElement.clientWidth) /*or $(window).width() */
-      );
-    }
-
-    var hasShownReminders = false;
     function callback(aEl) {
-      if (!hasShownReminders) {
-        hasShownReminders = true;
+      if (!didCallback) {
+        didCallback = true;
 
         setTimeout(function () {
           $('.reminders .alert .close').each(function () {
@@ -28,17 +17,20 @@
       }
     }
 
+    {{> includes/scripts/isElementInViewport.js }}
+
     function fireIfElementVisible(aEl, aCallback) {
       return function () {
         if (isElementInViewport(aEl)) {
+          $(window).off(events, handler);
+
           aCallback(aEl);
         }
       }
     }
 
-    var handler = fireIfElementVisible($('.reminders'), callback);
-
-    $(window).on('focus resize scroll', handler);
+    handler = fireIfElementVisible($('.reminders'), callback);
+    $(window).on(events, handler);
 
   })();
 </script>

--- a/views/includes/scripts/isElementInViewport.js
+++ b/views/includes/scripts/isElementInViewport.js
@@ -1,0 +1,16 @@
+function isElementInViewport(aEl) {
+  var rect = null;
+
+  if (aEl instanceof jQuery) {
+    aEl = aEl[0];
+  }
+
+  rect = aEl.getBoundingClientRect();
+
+  return (
+    rect.top >= 0 &&
+    rect.left >= 0 &&
+    rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) && // or $(window).height()
+    rect.right <= (window.innerWidth || document.documentElement.clientWidth) // or $(window).width()
+  );
+}

--- a/views/includes/scripts/showTopPagination.html
+++ b/views/includes/scripts/showTopPagination.html
@@ -1,30 +1,22 @@
 <script type="text/javascript">
   (function () {
-    function isElementInViewport(aEl) {
-      if (aEl instanceof jQuery) {
-        aEl = aEl[0];
-      }
 
-      var rect = aEl.getBoundingClientRect();
-
-      return (
-        rect.top >= 0 &&
-        rect.left >= 0 &&
-        rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) && /*or $(window).height() */
-        rect.right <= (window.innerWidth || document.documentElement.clientWidth) /*or $(window).width() */
-      );
-    }
-
-    var hasShownPagination = false;
-    function callback(aEl) {
-      if (!hasShownPagination) {
-        aEl.collapse('show');
-        hasShownPagination = true;
-      }
-    }
+    var events = 'scroll';
+    var handler = null;
+    var didCallback = false;
 
     var lastScrollTop = 0;
     var hasScrolledDown = false;
+
+    function callback(aEl) {
+      if (!didCallback) {
+        didCallback = true;
+
+        aEl.collapse('show');
+      }
+    }
+
+    {{> includes/scripts/isElementInViewport.js }}
 
     function fireIfElementVisible(aEl, aCallback) {
       return function () {
@@ -34,6 +26,8 @@
           hasScrolledDown = true;
         } else {
           if (isElementInViewport(aEl) && hasScrolledDown) {
+            $(window).off(events, handler);
+
             aCallback(aEl);
           }
         }
@@ -41,10 +35,8 @@
       }
     }
 
-    var handler = fireIfElementVisible($('.pagination:first').parent(), callback);
-
-    // jQuery
-    $(window).on('scroll', handler);
+    handler = fireIfElementVisible($('.pagination:first').parent(), callback);
+    $(window).on(events, handler);
 
   })();
 </script>


### PR DESCRIPTION
* Turn off some init event handlers once they are triggered... applies to reminders and top pagination
* Keeping local conditionals in as turning off event handlers take longer than a local scoped variable boolean toggle.
* Some STYLEGUIDE.md conformance in these files
* Use mustache *(*mu2* package)* to load common, usually unchanging, .js code into local scope since it's shared across these e.g. make a client side library .js
* Renamed a few common variables... still plenty readable and easier to manage across the board
* jQuery `load` event [is said](http://www.w3schools.com/jquery/event_load.asp) to be deprecated but keeping in for possible backward compatibility
* Scoot some comments around... and remove the "jQuery" comment... we already know it's jQuery