### PR TITLE
Some misc client side jQuery fixes

### DIFF
--- a/views/includes/scripts/commentReplyScript.html
+++ b/views/includes/scripts/commentReplyScript.html
@@ -8,7 +8,9 @@
     $('#reply-control').on('show.bs.collapse', function () {
       // Show spacer div
       $('#show-reply-form-when-visible').css({
-        height: '{{#paginationRendered}}210{{/paginationRendered}}{{^paginationRendered}}268{{/paginationRendered}}px'
+        height:
+          {{#paginationRendered}}'210px'{{/paginationRendered}}
+          {{^paginationRendered}}'268px'{{/paginationRendered}}
       });
     });
 

--- a/views/includes/scripts/commentReplyTooltip.html
+++ b/views/includes/scripts/commentReplyTooltip.html
@@ -1,0 +1,11 @@
+<script type="text/javascript">
+  (function () {
+
+    $(function () {
+      $('.btn-comment-reply').parent().tooltip().click(function () {
+        $(this).tooltip('show');
+      });
+    });
+
+  })();
+</script>

--- a/views/includes/scripts/groupSelector.html
+++ b/views/includes/scripts/groupSelector.html
@@ -1,0 +1,51 @@
+<script type="text/javascript" charset="UTF-8" src="/redist/npm/select2/select2.js"></script>
+<script type="text/javascript">
+  (function () {
+
+    var preload_groups = {{{groupNameListJSON}}};
+    var preload_data = $.map(preload_groups, function (aGroup) {
+      return { id: aGroup, text: aGroup, locked: true };
+    });
+
+    $(document).ready(function () {
+      var canAddGroup = true;
+      var canCreateGroup = {{canCreateGroup}};
+      var prevTerm = '';
+
+      $('#groups').select2({
+        multiple: true,
+        minimumInputLength: 1,
+        query: function (aQuery) {
+          var url = '/api/group/search/' + encodeURIComponent(aQuery.term);
+
+          if (canCreateGroup) {
+            if (canAddGroup) {
+              if ($('#groups').val().length
+                && $('#groups').val().split(',').indexOf(prevTerm) > -1) {
+                canAddGroup = false;
+              } else {
+                prevTerm = aQuery.term;
+              }
+            } else if ($('#groups').val().split(',').indexOf(prevTerm) === -1) {
+              prevTerm = aQuery.term;
+              canAddGroup = true;
+            }
+
+            url += '/' + (canAddGroup ? 'true' : '');
+          }
+
+          $.ajax({ url: url, success: function (aData) {
+            var groups = { results: [] };
+
+            $.each(aData, function (index, group) {
+              groups.results.push({ id: group, text: group });
+            });
+            aQuery.callback(groups);
+          }});
+        }});
+
+      $('#groups').select2('data', preload_data);
+    });
+
+  })();
+</script>

--- a/views/includes/scripts/lazyIconScript.html
+++ b/views/includes/scripts/lazyIconScript.html
@@ -1,20 +1,27 @@
 <script type="text/javascript">
-  $(window).load(function () {
-    window.setTimeout(function () {
-      $('[data-icon-src]').each(function () {
-        var container = $(this);
-        var size = container.data('icon-size');
-        var img = new Image();
-        if (size) {
-          img.width = size;
-          img.height = size;
-        }
-        $(img).load(function () {
-          var that = $(this).hide();
-          container.empty().append(that);
-          that.fadeIn();
-        }).attr('src', container.data('icon-src'));
-      });
-    }, 13);
-  });
+  (function () {
+
+    $(window).load(function () {
+      window.setTimeout(function () {
+        $('[data-icon-src]').each(function () {
+          var container = $(this);
+          var size = container.data('icon-size');
+          var img = new Image();
+
+          if (size) {
+            img.width = size;
+            img.height = size;
+          }
+
+          $(img).load(function () {
+            var that = $(this).hide();
+
+            container.empty().append(that);
+            that.fadeIn();
+          }).attr('src', container.data('icon-src'));
+        });
+      }, 13);
+    });
+
+  })();
 </script>

--- a/views/includes/scripts/markdownEditor.html
+++ b/views/includes/scripts/markdownEditor.html
@@ -1,17 +1,20 @@
-<!-- Markdown Editor -->
-<script type="text/javascript" src="/redist/npm/marked/lib/marked.js"></script>
-<script type="text/javascript" src="/redist/npm/bootstrap-markdown/js/bootstrap-markdown.js"></script>
-<script>
-  // Keep in sync with ./libs/markdown.js
-  marked.setOptions({
-    // highlight: ...
-    // renderer: ...
-    gfm: true,
-    tables: true,
-    breaks: true,
-    pedantic: false,
-    // sanitize: ...
-    smartLists: true,
-    smartypants: false
-  });
+<script type="text/javascript" charset="UTF-8" src="/redist/npm/marked/lib/marked.js"></script>
+<script type="text/javascript" charset="UTF-8" src="/redist/npm/bootstrap-markdown/js/bootstrap-markdown.js"></script>
+<script type="text/javascript">
+  (function () {
+
+    // Keep in sync with `./libs/markdown.js`
+    marked.setOptions({
+      // highlight: ...
+      // renderer: ...
+      gfm: true,
+      tables: true,
+      breaks: true,
+      pedantic: false,
+      // sanitize: ...
+      smartLists: true,
+      smartypants: false
+    });
+
+  })();
 </script>

--- a/views/includes/scripts/scriptEditor.html
+++ b/views/includes/scripts/scriptEditor.html
@@ -1,0 +1,47 @@
+<script type="text/javascript" charset="UTF-8" src="/redist/npm/ace-builds/src/ace.js"></script>
+<script type="text/javascript">
+  (function () {
+
+    $(document).ready(function () {
+      var editor = ace.edit("editor");
+
+      function hasCalc(aPrefix) {
+        var el = null;
+
+        aPrefix = aPrefix || "";
+        el = document.createElement("div");
+        el.style.setProperty(aPrefix + "width", "calc(1px)", "");
+        return !!el.style.length;
+      }
+
+      function hasAnyCalc() {
+        return hasCalc("-moz-") || hasCalc("-ms-") || hasCalc("-o-") || hasCalc("-webkit-") || hasCalc();
+      }
+
+      function calcHeight() {
+        return window.innerHeight - {{#newScript}}190{{/newScript}}{{^newScript}}303{{/newScript}};
+      }
+
+      editor.setTheme("ace/theme/dawn");
+      editor.getSession().setMode("ace/mode/javascript");
+
+      {{#readOnly}}editor.setReadOnly(true);{{/readOnly}}
+      {{^readOnly}}
+      // TODO: Submit using AJAX
+      $('#submit_code').click(function () {
+        $('#source').val(editor.getValue());
+        $('#code_form').submit();
+      });
+      {{/readOnly}}
+
+      // Older browser JavaScript work-around for #136
+      if (!hasAnyCalc()) {
+        $("#editor").height(calcHeight());
+        $(document).on("resize", function () {
+          $("#editor").height(calcHeight);
+        });
+      }
+    });
+
+  })();
+</script>

--- a/views/includes/scripts/tableTrLinkScript.html
+++ b/views/includes/scripts/tableTrLinkScript.html
@@ -1,16 +1,31 @@
-<script>
-  $(document).ready(function () {
-    // https://stackoverflow.com/questions/4904938/link-entire-table-row
-    $('.tr-link').click(function (aE) {
-      if ($(aE.target).is('a,input,a *')) // anything else you don't want to trigger the click
-        return;
+<script type="text/javascript">
+  (function () {
 
-      var a = $(this).find('a.tr-link-a').first();
-      if (!a) return;
-      var url = a.attr('href');
-      if (!url) return;
-      window.location = url;
-      aE.stopPropagation();
-    })
-  });
+    $(document).ready(function () {
+      // https://stackoverflow.com/questions/4904938/link-entire-table-row
+
+      $('.tr-link').click(function (aE) {
+        var anchor = null;
+        var url = null;
+
+        if ($(aE.target).is('a,input,a *')) { // anything else you don't want to trigger the click
+          return;
+        }
+
+        anchor = $(this).find('a.tr-link-a').first();
+        if (!anchor) {
+          return;
+        }
+
+        url = anchor.attr('href');
+        if (!url) {
+          return;
+        }
+
+        window.location = url;
+        aE.stopPropagation();
+      })
+    });
+
+  })();
 </script>

--- a/views/pages/discussionPage.html
+++ b/views/pages/discussionPage.html
@@ -65,13 +65,7 @@
     {{> includes/scripts/commentReplyScript.html }}
   {{/authedUser}}
   {{^authedUser}}
-    <script>
-      $(function () {
-        $('.btn-comment-reply').parent().tooltip().click(function () {
-          $(this).tooltip('show');
-        });
-      });
-    </script>
+    {{> includes/scripts/commentReplyTooltip.html }}
   {{/authedUser}}
 </body>
 </html>

--- a/views/pages/scriptEditMetadataPage.html
+++ b/views/pages/scriptEditMetadataPage.html
@@ -52,50 +52,6 @@
   {{> includes/footer.html }}
   {{> includes/scripts/lazyIconScript.html }}
   {{> includes/scripts/markdownEditor.html }}
-  <!-- Group Selector -->
-  <script type="text/javascript" src="/redist/npm/select2/select2.js"></script>
-  <script type="text/javascript">
-    var preload_groups = {{{groupNameListJSON}}};
-    var preload_data = $.map(preload_groups, function (aGroup) {
-      return { id: aGroup, text: aGroup, locked: true };
-    });
-    $(document).ready(function () {
-      var canAddGroup = true;
-      var canCreateGroup = {{canCreateGroup}};
-      var prevTerm = '';
-
-      $('#groups').select2({
-        multiple: true,
-        minimumInputLength: 1,
-        query: function (aQuery) {
-          var url = '/api/group/search/' + encodeURIComponent(aQuery.term);
-
-          if (canCreateGroup) {
-            if (canAddGroup) {
-              if ($('#groups').val().length
-                && $('#groups').val().split(',').indexOf(prevTerm) > -1) {
-                canAddGroup = false;
-              } else {
-                prevTerm = aQuery.term;
-              }
-            } else if ($('#groups').val().split(',').indexOf(prevTerm) === -1) {
-              prevTerm = aQuery.term;
-              canAddGroup = true;
-            }
-
-            url += '/' + (canAddGroup ? 'true' : '');
-          }
-
-          $.ajax({ url: url, success: function (aData) {
-            var groups = { results: [] };
-            $.each(aData, function (index, group) {
-              groups.results.push({ id: group, text: group });
-            });
-            aQuery.callback(groups);
-          }});
-        }});
-      $('#groups').select2('data', preload_data);
-    });
-  </script>
+  {{> includes/scripts/groupSelector.html }}
 </body>
 </html>

--- a/views/pages/scriptIssuePage.html
+++ b/views/pages/scriptIssuePage.html
@@ -75,13 +75,7 @@
   {{> includes/scripts/commentReplyScript.html }}
   {{/authedUser}}
   {{^authedUser}}
-  <script>
-      $(function () {
-        $('.btn-comment-reply').parent().tooltip().click(function () {
-          $(this).tooltip('show');
-        });
-      });
-  </script>
+    {{> includes/scripts/commentReplyTooltip.html }}
   {{/authedUser}}
 </body>
 </html>

--- a/views/pages/scriptViewSourcePage.html
+++ b/views/pages/scriptViewSourcePage.html
@@ -49,47 +49,6 @@
   </div>
   {{> includes/footer.html }}
   {{> includes/scripts/lazyIconScript.html }}
-  <!-- Script Editor -->
-  <script type="text/javascript" charset="UTF-8" src="/redist/npm/ace-builds/src/ace.js"></script>
-  <script type="text/javascript">
-    $(document).ready(function () {
-      var editor = ace.edit("editor");
-
-      function hasCalc(aPrefix) {
-        aPrefix = aPrefix || "";
-        var el = document.createElement("div");
-        el.style.setProperty(aPrefix + "width", "calc(1px)", "");
-        return !!el.style.length;
-      }
-
-      function hasAnyCalc() {
-        return hasCalc("-moz-") || hasCalc("-ms-") || hasCalc("-o-") || hasCalc("-webkit-") || hasCalc();
-      }
-
-      function calcHeight() {
-       return window.innerHeight - {{#newScript}}190{{/newScript}}{{^newScript}}303{{/newScript}};
-      }
-
-      editor.setTheme("ace/theme/dawn");
-      editor.getSession().setMode("ace/mode/javascript");
-
-      {{#readOnly}}editor.setReadOnly(true);{{/readOnly}}
-      {{^readOnly}}
-      <!-- TODO: Submit using AJAX -->
-      $('#submit_code').click(function () {
-        $('#source').val(editor.getValue());
-        $('#code_form').submit();
-      });
-      {{/readOnly}}
-
-      // Older browser JavaScript work-around for #136
-      if (!hasAnyCalc()) {
-        $("#editor").height(calcHeight());
-        $(document).on("resize", function () {
-          $("#editor").height(calcHeight);
-        });
-      }
-    });
-  </script>
+  {{> includes/scripts/scriptEditor.html }}
 </body>
 </html>


### PR DESCRIPTION
* IIFEs client side to prevent potential and future identifier collisions e.g. "Give a hoot, Don't Pollute" the global content scope unless we plan to support something there or someone else already does.
* Some more STYLEGUIDE.md conformance
* Some more white-space for readability
* Move all view page inline scripts to `.../includes/scripts` where they should be for possible reuse
* Always declare `type="text/javascript"` for some older browsers that don't default to JavaScript
* Always assume and declare `charset="UTF-8"` for served scripts... our inline scripts should always currently be UTF-8 ... applies to #200