### PR TITLE
Extend `npm install`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,11 @@ npm-debug.log
 node_modules
 
 data
+
+Gemfile.lock
 fakeS3
 dev/fakeS3
+
 cert
 aws.json
 prod.sh

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+gem 'bundler', '1.8.0'
+gem 'fakes3', '0.1.7'

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Repository | Reference | Recent Version
 [body-parser][body-parserGHUrl] | [Documentation][body-parserDOCUrl] | [![NPM version][body-parserNPMVersionImage]][body-parserNPMUrl]
 [bootstrap][bootstrapGHUrl] | [Documentation][bootstrapDOCUrl] | [![NPM version][bootstrapNPMVersionImage]][bootstrapNPMUrl]
 [bootstrap-markdown][bootstrap-markdownGHUrl] | [Documentation][bootstrap-markdownDOCUrl] | [![NPM version][bootstrap-markdownNPMVersionImage]][bootstrap-markdownNPMUrl]
+[bundler][bundlerGHUrl] | [Documentation][bundlerDOCUrl] | [![GEM version][bundlerGEMVersionImage]][bundlerGEMUrl]
 [compression][compressionGHUrl] | [Documentation][compressionDOCUrl] | [![NPM version][compressionNPMVersionImage]][compressionNPMUrl]
 [connect-mongo][connect-mongoGHUrl] | [Documentation][connect-mongoDOCUrl] | [![NPM version][connect-mongoNPMVersionImage]][connect-mongoNPMUrl]
 [cookie-parser][cookie-parserGHUrl] | [Documentation][cookie-parserDOCUrl] | [![NPM version][cookie-parserNPMVersionImage]][cookie-parserNPMUrl]
@@ -151,6 +152,11 @@ Outdated dependencies list can also be achieved with `$ npm --depth 0 outdated`
 [bootstrap-markdownDOCUrl]: http://toopay.github.io/bootstrap-markdown/
 [bootstrap-markdownNPMUrl]: https://www.npmjs.com/package/bootstrap-markdown
 [bootstrap-markdownNPMVersionImage]: https://img.shields.io/npm/v/bootstrap-markdown.svg?style=flat
+
+[bundlerGHUrl]: https://github.com/bundler/bundler
+[bundlerDOCUrl]: http://bundler.io/
+[bundlerGEMUrl]: http://rubygems.org/gems/bundler
+[bundlerGEMVersionImage]: http://img.shields.io/gem/v/bundler.svg?style=flat
 
 [compressionGHUrl]: https://github.com/expressjs/compression
 [compressionDOCUrl]: https://github.com/expressjs/compression/blob/master/README.md

--- a/dev/init.js
+++ b/dev/init.js
@@ -1,0 +1,147 @@
+'use strict';
+
+// Define some pseudo module globals
+var isPro = require('../libs/debug').isPro;
+var isDev = require('../libs/debug').isDev;
+var isDbg = require('../libs/debug').isDbg;
+
+//
+var exec = require('child_process').exec;
+var async = require('async');
+
+if (isDev || isDbg) {
+
+  var tasks = [];
+  var no = {};
+
+  tasks.push(function (aCallback) {
+    var cmd = 'node -v';
+    console.log('>> ' + cmd);
+
+    exec(cmd, function (aErr, aStdout, aStderr) {
+      if (aErr) {
+        console.error(aStderr);
+      } else {
+        console.log(aStdout);
+      }
+
+      aCallback();
+    });
+  });
+
+  tasks.push(function (aCallback) {
+    var cmd = 'npm -v';
+    console.log('>> ' + cmd);
+
+    exec(cmd, function (aErr, aStdout, aStderr) {
+      if (aErr) {
+        console.error(aStderr);
+      } else {
+        console.log(aStdout);
+      }
+
+      aCallback();
+    });
+  });
+
+  tasks.push(function (aCallback) {
+    var cmd = 'ruby -v';
+    console.log('>> ' + cmd);
+
+    exec(cmd, function (aErr, aStdout, aStderr) {
+      if (aErr) {
+        no.ruby = true;
+        console.error(aStderr);
+      } else {
+        console.log(aStdout);
+      }
+
+      aCallback();
+    });
+  });
+
+  tasks.push(function (aCallback) {
+    var cmd = 'bundler -v';
+
+    if (!no.ruby) {
+      console.log('>> ' + cmd);
+
+      exec(cmd, function (aErr, aStdout, aStderr) {
+        if (aErr) {
+          no.bundler = true;
+          console.error(aStderr);
+        } else {
+          console.log(aStdout);
+        }
+
+        aCallback();
+      });
+    } else {
+      aCallback();
+    }
+  });
+
+  tasks.push(function (aCallback) {
+    var cmd = 'bundler outdated';
+
+    if (!no.bundler) {
+      console.log('>> ' + cmd);
+
+      exec(cmd, function (aErr, aStdout, aStderr) {
+        if (aErr) {
+          no.bundle = true;
+          console.error(aStderr);
+        } else {
+          console.log(aStdout);
+        }
+
+        aCallback();
+      });
+    } else {
+      aCallback();
+    }
+  });
+
+  tasks.push(function (aCallback) {
+    var cmd = 'bundler install';
+
+    if (no.bundle) {
+      console.log('>> ' + cmd);
+
+      exec(cmd, function (aErr, aStdout, aStderr) {
+        if (aErr) {
+          console.error(aStderr);
+        } else {
+          console.log(aStdout);
+        }
+
+        aCallback();
+      });
+    } else {
+      aCallback();
+    }
+  });
+
+  tasks.push(function (aCallback) {
+    var cmd = 'npm --depth 0 outdated';
+    console.log('>> ' + cmd);
+
+    exec(cmd, function (aErr, aStdout, aStderr) {
+      if (aErr) {
+        console.error(aStderr);
+      } else {
+        console.log(aStdout);
+      }
+
+      aCallback();
+    });
+  });
+
+  async.series(tasks, function (aErr) {
+    if (aErr) {
+      console.error('There was an unexpected error.');
+    }
+
+    console.log('>\n');
+  });
+}

--- a/package.json
+++ b/package.json
@@ -74,10 +74,12 @@
     "openuserjs.org"
   ],
   "scripts": {
-    "start": "node app.js"
+    "start": "node app.js",
+    "postinstall": "node dev/init.js"
   },
   "engines": {
-    "node": ">=0.10.32",
+    "node": ">=0.10.32 <0.11.0",
     "npm": ">=1.4.28"
-  }
+  },
+  "private": true
 }


### PR DESCRIPTION
* Add in a simple, native, patterned, platform independent, check and install for dev/dbg environments. Applies to #249. Alternative is a shell script which can be platform-independent if using Git Bash for Win systems. Node and their dependencies have most recently proven than any build system is vulnerable to extreme failures... so these two proven, tried and true, methodologies are left.
* Advise restricting node engine to 0.10.x for dev/dbg... See #581
* Add *bundler* gem to handle fakes3 installation and corresponding `Gemfile`... Don't sync the `Gemfile.lock` e.g place in .gitignore ... *bundler* prompts if sudo is needed to install... static version like package.json
* Set our project to private so npm usage won't ever publish it accidentally... this of course can be discussed later if we want to publish to npmjs.com
* Update README.md for this dep