### PR TITLE
Export dbg and dev modes to views with mustache *(mu2)*

### DIFF
--- a/libs/muExpress.js
+++ b/libs/muExpress.js
@@ -13,7 +13,13 @@ mu.root = __dirname + '/../views';
 function renderFile(aRes, aPath, aOptions) {
   // If you need to render a file with a different content
   // type, do it directly on the response object
-  if (isDev || isDbg) { mu.clearCache(); }
+  if (isDev || isDbg) {
+    mu.clearCache();
+
+    aOptions.isDbg = isDbg;
+    aOptions.isDev = isDev;
+  }
+
   aRes.set('Content-Type', 'text/html; charset=UTF-8');
   mu.compileAndRender(aPath, aOptions).pipe(aRes);
 }
@@ -23,15 +29,19 @@ function renderFile(aRes, aPath, aOptions) {
 exports.renderFile = function (aApp) {
   var render = aApp.response.__proto__.render;
 
-  aApp.response.__proto__.render = function (aView, aOptions, aFn) { // TODO: Non-descript function parm
+  aApp.response.__proto__.render = function (aView, aOptions, aFn) {
     var self = this;
 
     if (!aFn && aApp.get('view engine') === 'html') {
-      aFn = function (aPath, aOptions) { renderFile(self, aPath, aOptions); };
+      aFn = function (aPath, aOptions) {
+        renderFile(self, aPath, aOptions);
+      };
     }
 
     render.call(self, aView, aOptions, aFn);
   };
 
-  return (function (aPath, aOptions, aFn) { aFn(aPath, aOptions); });
+  return (function (aPath, aOptions, aFn) {
+    aFn(aPath, aOptions);
+  });
 };

--- a/public/less/bootstrap/oujs-bootswatch.less
+++ b/public/less/bootstrap/oujs-bootswatch.less
@@ -181,3 +181,9 @@ body > .navbar {
   margin: 10px 0;
 }
 // /113f426
+
+
+.navbar-brand span.mode {
+  padding: 5px;
+  font-size: 12px;
+}

--- a/views/includes/header.html
+++ b/views/includes/header.html
@@ -2,7 +2,7 @@
   <div class="container-fluid">
     <div class="navbar-header">
       <button type="button" data-toggle="collapse" data-target=".navbar-collapse-top" class="navbar-toggle"><i class="fa fa-bars"></i></button>
-      <a href="/" class="navbar-brand" title="A Userscripts Repository">OpenUserJS</a>
+      <a href="/" class="navbar-brand" title="A Userscripts Repository">OpenUserJS<span class="mode">{{#isDbg}}dbg {{/isDbg}}{{#isDev}}dev{{/isDev}}</span></a>
     </div>
     <div class="navbar-collapse navbar-collapse-top collapse">
       <ul class="nav navbar-nav navbar-right">


### PR DESCRIPTION
* Add visible distinction for debug and development modes... using short entries in case font is blocked so it doesn't bust layout... applies to #429
* Assume pro as default... also pro can be kicked into debug mode which is one of the reasons this has been separated
* Some STYLEGUIDE.md conformance
* Remove line note... while `aFn` is still non-descript this is an exception for lack of better naming... try to avoid these though.
* This also is an additional perk for @TimidScript or others to reuse the `span` attribute for better site integration... consider this a sub-brand to maintain the integrity of the OUJS brand.