### PR TITLE
Update deprecated Google classic/standard auth scope to use Google+ scope

### DIFF
--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -59,12 +59,12 @@ function getRedirect(aReq) {
 exports.auth = function (aReq, aRes, aNext) {
   var authedUser = aReq.session.user;
   var strategy = aReq.body.auth || aReq.params.strategy;
-  var username = aReq.body.username || aReq.session.username || 
+  var username = aReq.body.username || aReq.session.username ||
     (authedUser ? authedUser.name : null);
   var authOpts = { failureRedirect: '/register?stratfail' };
   var passportKey = aReq._passport.instance._key;
 
-  // Yet another passport hack. 
+  // Yet another passport hack.
   // Initialize the passport session data only when we need it.
   if (!aReq.session[passportKey] && aReq._passport.session) {
     aReq.session[passportKey] = {};
@@ -83,7 +83,7 @@ exports.auth = function (aReq, aRes, aNext) {
     }
 
     if (strategy === 'google') {
-      authOpts.scope = ['https://www.googleapis.com/auth/userinfo.profile'];
+      authOpts.scope = ['https://www.googleapis.com/auth/plus.login'];
     }
     authenticate = passport.authenticate(strategy, authOpts);
 

--- a/views/includes/headerReminders.html
+++ b/views/includes/headerReminders.html
@@ -1,6 +1,6 @@
 <div class="reminders">
 {{^hideReminder}}
-  <div class="alert alert-warning alert-dismissible small fade in" role="alert">
+  <div class="alert alert-danger alert-dismissible small fade in" role="alert">
     <button type="button" class="close" data-dismiss="alert"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
     <p><i class="fa fa-fw fa-exclamation-triangle"></i> <b>REMINDER:</b> Don't miss out reading the <a class="alert-link" href="/announcements/Google_Authentication_Deprecation">Google Authentication Deprecation</a> with migration  announcement.</p>
   </div>


### PR DESCRIPTION
* Change on account here prompted for Google+ profile access and "circles" *(manually changed with the pencil to "only you")*... checks okay.
* Exact deprecation is described at https://developers.google.com/+/api/auth-migration#timetable ... attention point at OpenID deprecation which says to migrate to Google+ signin
* Upgrade reminder to final stage CSS coloring.

Closes #613 and applies to #484