### PR TITLE
EOL Google Auth for OpenID deprecation and migration announcement banner

### DIFF
--- a/libs/muExpress.js
+++ b/libs/muExpress.js
@@ -20,12 +20,13 @@ function renderFile(aRes, aPath, aOptions) {
     aOptions.isDev = isDev;
   }
 
-  // Hide the Google OAuth migration reminder for logged-in users
-  // that don't use Google for authentication
-  if (aOptions.authedUser && aOptions.authedUser
-      .strategies.indexOf('google') === -1) {
-    aOptions.hideReminder = true;
-  }
+  // Hide task for any reminder... See #484
+  // NOTE: This code structure and CSS is always active for future reminders
+  //   so please do not remove unless refactoring in a new issue as a whole.
+  // Example Code task and sync UI with banner text/link at `./includes/headerReminders`:
+  // if (aOptions.authedUser && aOptions.authedUser.strategies.indexOf('google') === -1) {
+  //   aOptions.hideThisReminder = true;
+  // }
 
   aRes.set('Content-Type', 'text/html; charset=UTF-8');
   mu.compileAndRender(aPath, aOptions).pipe(aRes);

--- a/views/includes/headerReminders.html
+++ b/views/includes/headerReminders.html
@@ -1,8 +1,10 @@
 <div class="reminders">
-{{^hideReminder}}
-  <div class="alert alert-danger alert-dismissible small fade in" role="alert">
+{{^hideThisReminder}}
+<!--
+  <div class="alert alert-info alert-dismissible small fade in" role="alert">
     <button type="button" class="close" data-dismiss="alert"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
-    <p><i class="fa fa-fw fa-exclamation-triangle"></i> <b>REMINDER:</b> Don't miss out reading the <a class="alert-link" href="/announcements/Google_Authentication_Deprecation">Google Authentication Deprecation</a> with migration  announcement.</p>
+    <p><i class="fa fa-fw fa-exclamation-triangle"></i> <b>REMINDER:</b> Don't miss out reading the <a class="alert-link" href="/">descriptive</a> announcement.</p>
   </div>
-{{/hideReminder}}
+  -->
+{{/hideThisReminder}}
 </div>


### PR DESCRIPTION
* This particular reminder is technically past due over at UTC so EOLing
* Leaving code structure in for other critical reminders that may pop up. Recommend leaving the comments in for possible future use since the code is always active in it's current state. Only exception to this should be **if** a complete refactor is done on the reminder structure.
* Neutralized to a template style UI comment and variable naming... in the future if it's "hideGoogleAuthMigrationReminder" *(instead of `hideThisReminder`) or whatever... use that for the `aOptions` variable in case there is more than one or user reminders via .user.js.

Should conclude #484