### PR TITLE
Add "All" filter to script issues

### DIFF
--- a/routes.js
+++ b/routes.js
@@ -83,7 +83,7 @@ module.exports = function (aApp) {
   aApp.route('/libs/src/:username/:scriptname').get(scriptStorage.sendScript); // Legacy
 
   // Issues routes
-  aApp.route('/:type(scripts|libs)/:username/:namespace?/:scriptname/issues/:open(closed)?').get(issue.list);
+  aApp.route('/:type(scripts|libs)/:username/:namespace?/:scriptname/issues/:open(open|closed|all)?').get(issue.list);
   aApp.route('/:type(scripts|libs)/:username/:namespace?/:scriptname/issue/new').get(authentication.validateUser, issue.open).post(authentication.validateUser, issue.open);
   aApp.route('/:type(scripts|libs)/:username/:namespace?/:scriptname/issues/:topic').get(issue.view).post(authentication.validateUser, issue.comment);
   aApp.route('/:type(scripts|libs)/:username/:namespace?/:scriptname/issues/:topic/:action(close|reopen)').get(authentication.validateUser, issue.changeStatus);

--- a/views/pages/scriptIssueListPage.html
+++ b/views/pages/scriptIssueListPage.html
@@ -48,8 +48,9 @@
         <div class="panel">
           <div class="panel-body">
             <ul class="nav nav-pills nav-justified">
-              <li class="{{#openIssuesOnly}}active{{/openIssuesOnly}}"><a href="{{{category.categoryPageUrl}}}">Open</a></li>
-              <li class="{{^openIssuesOnly}}active{{/openIssuesOnly}}"><a href="{{{category.categoryPageUrl}}}/closed">Closed</a></li>
+              <li class="{{^allIssues}}{{#openIssuesOnly}}active{{/openIssuesOnly}}{{/allIssues}}"><a href="{{{category.categoryPageUrl}}}/open">Open</a></li>
+              <li class="{{^allIssues}}{{^openIssuesOnly}}active{{/openIssuesOnly}}{{/allIssues}}"><a href="{{{category.categoryPageUrl}}}/closed">Closed</a></li>
+              <li class="{{#allIssues}}active{{/allIssues}}"><a href="{{{category.categoryPageUrl}}}/all">All</a></li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
* Create `.../all` and `.../open` issue route handling via existing `params` ... existing structure and currently needed for searching and script homepage count
* If `isOwner` show only open issues otherwise default to all issues for default route... allow forcing for any script issues with absolute route.
* Change corresponding UI markers to accomodate
* Some STYLEGUIDE.md conformance

Closes #615