### PR TITLE
Move and duplicate Raw Source button to Source Code pages

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -1281,6 +1281,8 @@ exports.editScript = function (aReq, aRes, aNext) {
       script.installNameSlug = installNameSlug;
       script.scriptPermalinkInstallPageUrl = 'https://' + aReq.get('host') +
         script.scriptInstallPageUrl;
+      script.scriptRawPageUrl = '/src/' + (isLib ? 'libs' : 'scripts') + '/'
+        + installNameSlug + (isLib ? '.js' : '.user.js#');
 
       // Page metadata
       pageMetadata(options);

--- a/views/includes/scriptPageHeader.html
+++ b/views/includes/scriptPageHeader.html
@@ -1,14 +1,16 @@
 <h2 class="page-heading">
   {{#isScriptPage}}
-  <a href="{{{script.scriptInstallPageUrl}}}" class="btn btn-info pull-right">
-    {{#script.isLib}}
-    <i class="fa fa-file-text-o"></i> Raw Source
-    {{/script.isLib}}
     {{^script.isLib}}
-    <i class="fa fa-download"></i> Install
+    <a href="{{{script.scriptInstallPageUrl}}}" class="btn btn-info pull-right">
+      <i class="fa fa-download"></i> Install
+    </a>
     {{/script.isLib}}
-  </a>
   {{/isScriptPage}}
+  {{#isScriptViewSourcePage}}
+    <a href="{{{script.scriptRawPageUrl}}}" class="btn btn-info pull-right">
+      <i class="fa fa-file-text-o"></i> Raw Source
+    </a>
+  {{/isScriptViewSourcePage}}
   {{#script.icon45Url}}
   <span class="page-heading-icon" {{#script.icon45Url}}data-icon-src="{{{script.icon45Url}}}"{{/script.icon45Url}}>
     {{#script.isLib}}<i class="fa fa-fw fa-file-excel-o"></i>{{/script.isLib}}{{^script.isLib}}<i class="fa fa-fw fa-file-code-o"></i>{{/script.isLib}}


### PR DESCRIPTION
* Should cut down on the number of scripts posted to libs that are UserScripts by removing any semblence of install button on main script homepage
* Allows raw source to be handled externally... I have been working with portable devices and I can't find any reason to not start out in edit mode with Ace other than this... this makes more logistical sense anyhow imho.
* Use empty URI fragment to ensure .user.js engine doesn't trigger install dialog for UserScripts... doesn't matter right now for libraries so omitting... could modify the mime-type but then other feature of updating without install count increment could be affected.

Applies to #150, #243 and closes #169