### PR TITLE
Fix missing protocol for *fakeS3* which is needed for *node* v0.12.x

### DIFF
--- a/controllers/scriptStorage.js
+++ b/controllers/scriptStorage.js
@@ -22,7 +22,7 @@ if (isPro) {
 } else {
   // You need to install (and ruby too): https://github.com/jubos/fake-s3
   // Then run the fakes3.sh script or: fakes3 -r fakeS3 -p 10001
-  var DEV_AWS_URL = process.env.DEV_AWS_URL || 'localhost:10001';
+  var DEV_AWS_URL = process.env.DEV_AWS_URL || 'http://localhost:10001';
   AWS.config.update({
     accessKeyId: 'fakeId',
     secretAccessKey: 'fakeKey',

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "postinstall": "node dev/init.js"
   },
   "engines": {
-    "node": ">=0.10.32 <0.11.0",
+    "node": ">=0.10.32 <0.11.0 || >=0.12.0 <=0.12.2",
     "npm": ">=1.4.28"
   },
   "private": true


### PR DESCRIPTION
* Removes the previous exception found with *fakeS3* and all importing/creation of scripts.
* Bump `./package.json` to reflect tested nodejs major versions... **do not** use 0.12.0 on nodejitsu due to previous deploy failures during 0.10.33 static testing

**NOTE**: Regression tested on 0.10.xx and appears okay... retested on local pro. There are some deprecation warnings that may not be able to be addressed until node host is upgraded in #425

Applies to #581