### PR TITLE
Some dep updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,32 +5,32 @@
   "main": "app",
   "dependencies": {
     "ace-builds": "git://github.com/ajaxorg/ace-builds#9d12839",
-    "async": "0.9.0",
-    "aws-sdk": "2.1.26",
-    "body-parser": "1.12.3",
+    "async": "1.0.0",
+    "aws-sdk": "2.1.30",
+    "body-parser": "1.12.4",
     "bootstrap": "3.3.4",
     "bootstrap-markdown": "2.8.0",
-    "compression": "1.4.3",
+    "compression": "1.4.4",
     "connect-mongo": "0.8.1",
-    "cookie-parser": "1.3.4",
-    "express": "4.12.3",
-    "express-minify": "0.1.3",
-    "express-session": "1.11.1",
+    "cookie-parser": "1.3.5",
+    "express": "4.12.4",
+    "express-minify": "0.1.4",
+    "express-session": "1.11.2",
     "font-awesome": "4.3.0",
     "formidable": "1.0.17",
     "github": "0.2.4",
-    "highlight.js": "8.5.0",
+    "highlight.js": "8.6.0",
     "jquery": "2.1.4",
     "jwt-simple": "0.3.0",
     "less-middleware": "2.0.1",
     "marked": "0.3.3",
-    "method-override": "2.3.2",
-    "moment": "2.10.2",
-    "mongoose": "4.0.2",
-    "morgan": "1.5.2",
+    "method-override": "2.3.3",
+    "moment": "2.10.3",
+    "mongoose": "4.0.3",
+    "morgan": "1.5.3",
     "mu2": "0.5.20",
     "octicons": "git://github.com/github/octicons.git#14ab7c3",
-    "passport": "0.2.1",
+    "passport": "0.2.2",
     "passport-amazon": "0.1.0",
     "passport-aol": "0.2.0",
     "passport-facebook": "2.0.0",
@@ -52,23 +52,15 @@
     "sanitize-html": "1.6.1",
     "select2": "3.5.2-browserify",
     "select2-bootstrap-css": "1.4.6",
-    "serve-favicon": "2.2.0",
+    "serve-favicon": "2.2.1",
     "underscore": "1.8.3"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/OpenUserJs/OpenUserJS.org.git"
   },
-  "licenses": [
-    {
-      "type": "GPL-3.0+",
-      "url": "https://raw.githubusercontent.com/OpenUserJs/OpenUserJS.org/master/LICENSE"
-    },
-    {
-      "type": "GFDL-1.3",
-      "url": "https://raw.githubusercontent.com/OpenUserJs/OpenUserJS.org/master/LICENSE"
-    }
-  ],
+  "license": "(GPL-3.0 AND GFDL-1.3)"
+  ,
   "subdomain": "openuserjs",
   "domains": [
     "openuserjs.org"


### PR DESCRIPTION
* Migrate to newer SPDX v2.x syntax in `package.json`

See also:
* [https://docs.npmjs.com/files/package.json#license](https://docs.npmjs.com/files/package.json#license) ... note deprecation of plural form
* [SPDX license expressions](http://wiki.spdx.org/view/LicenseExpressionFAQ)
* [SPDX license expressions Examples](http://wiki.spdx.org/view/FileNoticeExamples)

Note(s):
* Interesting that the newer specification doesn't seem to exist for custom MIT licensing terms which are part of that specification and a few other license types including GPL required Copyright information e.g. not fixed format with the `url` property seeming to be missing for pointing to the LICENSE content. Refer to local raw LICENSE.* files for exact text including `and later` revisions of GPL if ever encountered. In other words SPDX doesn't seem to account for this if a change comes through the pipe but LICENSE.* will always supersede.

Post #177 change for migration