### PR TITLE
Nodejitsu shutting down. Modifications for new host.

### DIFF
--- a/app.js
+++ b/app.js
@@ -46,6 +46,7 @@ var server = http.createServer(app);
 var secureServer = null;
 
 app.set('port', process.env.PORT || 8080);
+app.set('securePort', process.env.SECURE_PORT || null);
 
 // Connect to the database
 mongoose.connect(connectStr, dbOptions);
@@ -55,7 +56,7 @@ db.once('open', function () {});
 var sessionStore = new MongoStore({ mongooseConnection: db });
 
 // Force HTTPS
-if (app.get('port') === 443) {
+if (app.get('securePort')) {
   sslOptions = {
     key: fs.readFileSync('./keys/private.key'),
     cert: fs.readFileSync('./keys/cert.crt'),
@@ -74,8 +75,8 @@ if (app.get('port') === 443) {
     aNext();
   });
 
-  server.listen(80);
-  secureServer.listen(443);
+  server.listen(app.get('port'));
+  secureServer.listen(app.get('securePort'));
 } else {
   server.listen(app.get('port'));
 }

--- a/app.js
+++ b/app.js
@@ -57,8 +57,8 @@ var sessionStore = new MongoStore({ mongooseConnection: db });
 // Force HTTPS
 if (app.get('port') === 443) {
   sslOptions = {
-    key: fs.readFileSync('./keys/private.key')
-    cert: fs.readFileSync('./keys/cert.crt')
+    key: fs.readFileSync('./keys/private.key'),
+    cert: fs.readFileSync('./keys/cert.crt'),
     ca: fs.readFileSync('./keys/intermediate.crt')
   };
   secureServer = https.createServer(sslOptions, app);

--- a/app.js
+++ b/app.js
@@ -38,29 +38,46 @@ var sessionSecret = process.env.SESSION_SECRET || settings.secret;
 var db = mongoose.connection;
 var dbOptions = { server: { socketOptions: { keepAlive: 1 } } };
 
+var fs = require('fs');
+var http = require('http');
+var https = require('https');
+var sslOptions = null;
+var server = http.createServer(app);
+var secureServer = null;
+
 app.set('port', process.env.PORT || 8080);
 
 // Connect to the database
 mongoose.connect(connectStr, dbOptions);
 db.on('error', console.error.bind(console, 'connection error:'));
-db.once('open', function () {
-  app.listen(app.get('port'));
-});
+db.once('open', function () {});
 
 var sessionStore = new MongoStore({ mongooseConnection: db });
 
 // Force HTTPS
 if (app.get('port') === 443) {
+  sslOptions = {
+    key: fs.readFileSync('./keys/private.key')
+    cert: fs.readFileSync('./keys/cert.crt')
+    ca: fs.readFileSync('./keys/intermediate.crt')
+  };
+  secureServer = https.createServer(sslOptions, app);
+
   app.use(function (aReq, aRes, aNext) {
     aRes.setHeader('Strict-Transport-Security',
       'max-age=8640000; includeSubDomains');
 
-    if (aReq.headers['x-forwarded-proto'] !== 'https') {
+    if (!aReq.secure) {
       return aRes.redirect(301, 'https://' + aReq.headers.host + encodeURI(aReq.url));
     }
 
     aNext();
   });
+
+  server.listen(80);
+  secureServer.listen(443);
+} else {
+  server.listen(app.get('port'));
 }
 
 if (isDev || isDbg) {

--- a/controllers/scriptStorage.js
+++ b/controllers/scriptStorage.js
@@ -422,7 +422,7 @@ exports.webhook = function (aReq, aRes) {
   // Test for know GH webhook ips: https://api.github.com/meta
   if (!aReq.body.payload ||
     !/192\.30\.25[2-5]\.(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])$/
-    .test(aReq.headers['x-forwarded-for'] || aReq.connection.remoteAddress)) {
+    .test(aReq.connection.remoteAddress)) {
     return;
   }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "OpenUserJS.org",
   "description": "An open source user scripts repo built using Node.js",
-  "version": "0.1.8+0000000",
+  "version": "0.1.9",
   "main": "app",
   "dependencies": {
     "ace-builds": "git://github.com/ajaxorg/ace-builds#9d12839",
@@ -60,10 +60,6 @@
     "url": "https://github.com/OpenUserJs/OpenUserJS.org.git"
   },
   "license": "(GPL-3.0 AND GFDL-1.3)",
-  "subdomain": "openuserjs",
-  "domains": [
-    "openuserjs.org"
-  ],
   "scripts": {
     "start": "node app.js",
     "postinstall": "node dev/init.js"


### PR DESCRIPTION
Well the Joyent team that maintains Nodejitsu got purchased by Goddady to develop their website builder. The result is that Nodejitsu is shutting down in August. I've moved the site to a new host and made the necessary modifications to the code. The site is likely more portable as a result. [openuserjs.org](https://openuserjs.org/) is currently running on this branch.