### PR TITLE
Drop *node* 0.10.x project support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ This project uses [editor config](http://editorconfig.org/), please make sure to
 #### Prerequisites
 
 * [Git](http://git-scm.com/)
-* [node.js 0.10.33 or other newer stable release](http://nodejs.org/)
+* [node.js 0.12.0 or other newer stable release](http://nodejs.org/)
 * [MongoDB](http://www.mongodb.org/) (Optional.  The project is preconfigured to use a dev DB on [MongoLab](https://mongolab.com/).)
 * [Ruby](https://www.ruby-lang.org/) (required to run [FakeS3](https://github.com/jubos/fake-s3/))
 * [FakeS3](https://github.com/jubos/fake-s3) (required to store libraries/scripts without [AWS S3](http://aws.amazon.com/s3/)) handled by [bundler](https://github.com/bundler/bundler)
@@ -234,7 +234,7 @@ There are multiple ways to retrieve this however this appears to work best for m
 ``` sh-session
 $ git clone git://github.com/joyent/node.git
 $ cd node
-$ git checkout origin/v0.10.33-release
+$ git checkout origin/v0.12.5-release
 $ ./configure --prefix=/usr
 $ make
 $ sudo make install

--- a/package.json
+++ b/package.json
@@ -66,8 +66,8 @@
     "postinstall": "node dev/init.js"
   },
   "engines": {
-    "node": ">=0.10.32 <0.11.0 || >=0.12.0 <=0.12.4",
-    "npm": ">=1.4.28"
+    "node": ">=0.12.0 <=0.13.0",
+    "npm": ">=2.11.2"
   },
   "private": true
 }


### PR DESCRIPTION
* No longer regression testing against that version of *node* as new VPS appears quite stable
* Default to baseline *npm* version and up for project support
* Change CONTRIBUTING.md to reflect