### PR TITLE
Add QSP for sort parm `q` urls if present

### DIFF
--- a/views/includes/groupList.html
+++ b/views/includes/groupList.html
@@ -1,9 +1,9 @@
 <table class="table table-hover table-condensed">
   <thead>
     <tr>
-      <th><a href="?orderBy=name&orderDir={{orderDir.name}}">Name</a></th>
-      <th class="text-center"><a href="?orderBy=size&orderDir={{orderDir.size}}">Size</a></th>
-      <th class="text-center"><a href="?orderBy=rating&orderDir={{orderDir.rating}}">Rating</a></th>
+      <th><a href="?orderBy=name&orderDir={{orderDir.name}}{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}">Name</a></th>
+      <th class="text-center"><a href="?orderBy=size&orderDir={{orderDir.size}}{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}">Size</a></th>
+      <th class="text-center"><a href="?orderBy=rating&orderDir={{orderDir.rating}}{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}">Rating</a></th>
     </tr>
   </thead>
   <tbody>

--- a/views/includes/scriptList.html
+++ b/views/includes/scriptList.html
@@ -1,10 +1,10 @@
 <table class="table table-hover">
   <thead>
     <tr>
-      <th class="text-center"><a href="?orderBy=name&orderDir={{orderDir.name}}{{#librariesOnly}}&library=true{{/librariesOnly}}{{#isFlagged}}&flagged=true{{/isFlagged}}">Name</a></th>
-      {{^librariesOnly}}<th class="text-center td-fit"><a href="?orderBy=installs&orderDir={{orderDir.install}}{{#isFlagged}}&flagged=true{{/isFlagged}}">Installs</a></th>{{/librariesOnly}}
-      <th class="text-center td-fit"><a href="?orderBy=rating&orderDir={{orderDir.rating}}{{#librariesOnly}}&library=true{{/librariesOnly}}{{#isFlagged}}&flagged=true{{/isFlagged}}">Rating</a></th>
-      <th class="text-center td-fit"><a href="?orderBy=updated&orderDir={{orderDir.updated}}{{#librariesOnly}}&library=true{{/librariesOnly}}{{#isFlagged}}&flagged=true{{/isFlagged}}">Last Updated</a></th>
+      <th class="text-center"><a href="?orderBy=name&orderDir={{orderDir.name}}{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}{{#librariesOnly}}&library=true{{/librariesOnly}}{{#isFlagged}}&flagged=true{{/isFlagged}}">Name</a></th>
+      {{^librariesOnly}}<th class="text-center td-fit"><a href="?orderBy=installs&orderDir={{orderDir.install}}{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}{{#isFlagged}}&flagged=true{{/isFlagged}}">Installs</a></th>{{/librariesOnly}}
+      <th class="text-center td-fit"><a href="?orderBy=rating&orderDir={{orderDir.rating}}{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}{{#librariesOnly}}&library=true{{/librariesOnly}}{{#isFlagged}}&flagged=true{{/isFlagged}}">Rating</a></th>
+      <th class="text-center td-fit"><a href="?orderBy=updated&orderDir={{orderDir.updated}}{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}{{#librariesOnly}}&library=true{{/librariesOnly}}{{#isFlagged}}&flagged=true{{/isFlagged}}">Last Updated</a></th>
     </tr>
   </thead>
   <tbody>

--- a/views/includes/userList.html
+++ b/views/includes/userList.html
@@ -1,8 +1,8 @@
 <table class="table table-hover table-condensed">
   <thead>
     <tr>
-      <th><a href="?orderBy=name&orderDir={{orderDir.name}}{{#isFlagged}}&flagged=true{{/isFlagged}}">Name</a></th>
-      <th><a href="?orderBy=role&orderDir={{orderDir.role}}{{#isFlagged}}&flagged=true{{/isFlagged}}">Rank</a></th>
+      <th><a href="?orderBy=name&orderDir={{orderDir.name}}{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}{{#isFlagged}}&flagged=true{{/isFlagged}}">Name</a></th>
+      <th><a href="?orderBy=role&orderDir={{orderDir.role}}{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}{{#isFlagged}}&flagged=true{{/isFlagged}}">Rank</a></th>
     </tr>
   </thead>
   <tbody>


### PR DESCRIPTION
* Added for group list sorting
* Added for script list sorting
* Added for user list sorting

* Not applied to graveyard since that is #490 ... remainder of scripts/libraries/users "should" be okay.

See also:
* Initial report at https://openuserjs.org/discuss/faulty_search_order_by_...