### PR TITLE
Trap failed splits/mappings with prefixes and ReadOnly exceptions

### DIFF
--- a/controllers/scriptStorage.js
+++ b/controllers/scriptStorage.js
@@ -229,7 +229,12 @@ function parseMeta(aString, aNormalize) {
         }
       }
       if (!header[key] || aNormalize && unique[key]) {
-        header[key] = value || '';
+        try {
+          header[key] = value || '';
+        } catch (aE) {
+          // Ignore this key on read only exception fault and log... See #285 commit history
+          console.log('WARNING: Key name `@' + lineMatches[1] + '` failed in parseMeta');
+        }
       } else if (!aNormalize || header[key] !== (value || '')
           && !(header[key] instanceof Array && header[key].indexOf(value) > -1)) {
         if (!(header[key] instanceof Array)) {
@@ -239,6 +244,7 @@ function parseMeta(aString, aNormalize) {
       }
     }
   }
+
   return headers;
 }
 exports.parseMeta = parseMeta;


### PR DESCRIPTION
* TODO: Needs further diagnosis in real-time and eventually permanently fixed on completion of #285
* [oujs - Meta View](https://openuserjs.org/scripts/Marti/oujs_-_Meta_View) **not** exhibiting this behavior... so appears to be a difference in current V8 *node* versus browser JavaScript parse
* Not sure when this occurred as there are scripts uploaded currently that utilizes the localizations of `@description` and `@name` but is responsible for some of the server restarts