### PR TITLE
Add absent MIME Content type for PEG.js grammar files

### DIFF
--- a/app.js
+++ b/app.js
@@ -98,6 +98,11 @@ app.use(bodyParser.json({
 app.use(compression());
 app.use(methodOverride('X-HTTP-Method-Override'));
 
+// Add absent from server MIME Content Type for PEG Grammar files
+express.static.mime.define({
+  'text/javascript':  ['pegjs']
+});
+
 // Order is very important here (i.e mess with at your own risk)
 app.use(passport.initialize());
 app.use(session({


### PR DESCRIPTION
* This allows the browser to view these instead of downloading
* May also prevent some warnings from security sites
* Using generic JavaScript MIME type as that is what my editor is saying it is on auto-detect... PEG.js is very closely related to JavaScript so should be okay.

Applies to #285