### PR TITLE
Remove multiline comment for `block` since starting point syntax found

### DIFF
--- a/public/pegjs/blockOpenUserJS.pegjs
+++ b/public/pegjs/blockOpenUserJS.pegjs
@@ -10,10 +10,6 @@ Test the generated parser with some input for PEG.js site at http://pegjs.org/on
 
 */
 
-// Uncomment to parse an entire metadata block for PEG.js site.
-// e.g. for testing/development only
-
-/*
 block =
   '// ==OpenUserJS==\n'
   lines:line*
@@ -21,8 +17,6 @@ block =
   {
     return lines;
   }
-*/
-
 
 line =
   '// @'


### PR DESCRIPTION
* Works .user.js side

See also:
* https://github.com/OpenUserJs/OpenUserJS.org/pull/670#issuecomment-122723748