### PR TITLE
Trim up the duplicated `keyword`s to `key`s.

### DIFF
--- a/public/pegjs/blockOpenUserJS.pegjs
+++ b/public/pegjs/blockOpenUserJS.pegjs
@@ -46,8 +46,7 @@ keyphrase1 =
       key: key,
       value: value,
 
-      unique: true,
-      keyword: key
+      unique: true
     };
   }
 
@@ -61,8 +60,6 @@ keysphrase1 =
   {
     return {
       key: key,
-      value: value,
-
-      keyword: key
+      value: value
     };
   }

--- a/public/pegjs/blockUserScript.pegjs
+++ b/public/pegjs/blockUserScript.pegjs
@@ -108,13 +108,10 @@ keyphrase0 =
       'noframes'
     )
   {
-    var keyUpmixed = upmix(key);
-
     return {
-      key: keyUpmixed,
+      key: upmix(key),
 
-      unique: true,
-      keyword: keyUpmixed
+      unique: true
     };
   }
 
@@ -135,14 +132,11 @@ keyphrase1 =
   whitespace
   value: non_newline
   {
-    var keyUpmixed = upmix(key);
-
     return {
-      key: keyUpmixed,
+      key: upmix(key),
       value: value,
 
-      unique: true,
-      keyword: keyUpmixed
+      unique: true
     };
   }
 
@@ -174,8 +168,7 @@ keyphraseLocalized =
         key: keyUpmixed,
         value: value,
 
-        unique: true,
-        keyword: keyUpmixed
+        unique: true
       });
   }
 
@@ -198,13 +191,9 @@ keysphrase1 =
   whitespace
   value: non_newline
   {
-    var keyUpmixed = upmix(key);
-
     return {
-      key: keyUpmixed,
-      value: value,
-
-      keyword: keyUpmixed
+      key: upmix(key),
+      value: value
     };
   }
 
@@ -218,13 +207,9 @@ keysphrase2 =
   whitespace
   value2: non_newline
   {
-    var keyUpmixed = upmix(key);
-
     return {
-      key: keyUpmixed,
+      key: upmix(key),
       value1: value1,
-      value2: value2,
-
-      keyword: keyUpmixed
+      value2: value2
     };
   }


### PR DESCRIPTION
* Programmatically can be done relatively quickly and easily as shown at https://github.com/Martii/UserScripts/commit/6b0b250ae77d01868ffa2a2aed2b5e2025d9fa9f#diff-354eefebbd6788b4205f512137901131R78

**NOTES**
* Remember to clear your cache otherwise you'll get the older grammar files if following
* Have had another idea with starting points too... so don't get too comfy with coding with the grammar files yet. :)

Applies to #285