### PR TITLE
Fix for no `@name` scripts

### DIFF
--- a/controllers/scriptStorage.js
+++ b/controllers/scriptStorage.js
@@ -343,7 +343,7 @@ exports.storeScript = function (aUser, aMeta, aBuf, aCallback, aUpdate) {
   if (!aMeta) { return aCallback(null); }
 
   if (!isLibrary) {
-    scriptName = cleanFilename(aMeta.name, '');
+    scriptName = (typeof aMeta.name === 'string' ? cleanFilename(aMeta.name, '') : null);
 
     // Can't install a script without a @name (maybe replace with random value)
     if (!scriptName) { return aCallback(null); }

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -878,7 +878,7 @@ exports.userGitHubImportScriptPage = function (aReq, aRes, aNext) {
           options.script = aScript;
           aCallback(null);
         } else {
-          aCallback('Error while uploading script.');
+          aCallback('Error while importing script.');
         }
       };
 
@@ -1137,7 +1137,7 @@ exports.submitSource = function (aReq, aRes, aNext) {
       scriptStorage.storeScript(aUser, aMeta, aSource, function (aScript) {
         var redirectUrl = encodeURI(aScript ? (aScript.isLib ? '/libs/'
           + aScript.installName.replace(jsRegex, '') : '/scripts/'
-          + aScript.installName.replace(userjsRegex, '')) : aReq.body.url);
+          + aScript.installName.replace(userjsRegex, '')) : decodeURI(aReq.body.url));
 
         if (!aScript || !aReq.body.original) {
           return aRes.redirect(redirectUrl);


### PR DESCRIPTION
* Crashes the server when removing or never existing `@name` but localized ones exist
* Not entirely sure why one needs to `encodedURI` and the other `decodeURI` but redirect has issue ... possibly a current *node* issue
* Change text to import since it's not uploading a script technically

Additionally applies to #200, #226 edge case, and a bit from #655 detection