### PR TITLE
Add a `Member since` to the script stats

### DIFF
--- a/libs/modelParser.js
+++ b/libs/modelParser.js
@@ -63,8 +63,10 @@ moment.locale('en-tiny', {
 
 var parseDateProperty = function (aObj, aKey) {
   var date = aObj[aKey];
-  aObj[aKey + 'ISOFormat'] = date.toISOString();
-  aObj[aKey + 'Humanized'] = moment(date).locale('en-tiny').calendar();
+  if (aObj[aKey]) {
+    aObj[aKey + 'ISOFormat'] = date.toISOString();
+    aObj[aKey + 'Humanized'] = moment(date).locale('en-tiny').calendar();
+  }
 };
 
 /**
@@ -266,6 +268,9 @@ var parseUser = function (aUserData) {
 
   // Strategies
   user.userStrategies = user.strategies;
+
+  // Dates
+  parseDateProperty(user, '_since'); // Virtual
 
   return user;
 };

--- a/models/user.js
+++ b/models/user.js
@@ -28,6 +28,10 @@ var userSchema = new Schema({
   sessionIds: [String]
 });
 
+userSchema.virtual('_since').get(function () {
+  return this._id.getTimestamp();
+});
+
 var User = mongoose.model('User', userSchema);
 
 exports.User = User;

--- a/views/includes/userStatsPanel.html
+++ b/views/includes/userStatsPanel.html
@@ -8,6 +8,8 @@
   </div>
   <div class="panel-body">
     <dl class="dl-horizontal">
+      <dt>Member since</dt>
+      <dd><time datetime="{{user._sinceISOFormat}}" title="{{user._since}}">{{user._sinceHumanized}}</time></dd>
       <dt>Number of scripts</dt>
       <dd>{{stats.totalScripts}}</dd>
       <dt>Number of libraries</dt>


### PR DESCRIPTION
* Use a virtual property on the User Schema with the `_id` to pluck the "joined" *(a.k.a. document creation date/time stamp)*
* This is occasionally needed for Adminstration
* This will also show how to do this in our current system with other Models... will eventually need a variant of this on `Script`

**NOTE**
* Had to bullet proof `parseDateProperty` because it was called twice and the first round it was `undefined`... so don't want it parsed since the methods won't exist on `undefined`

Enhancement of #460