### PR TITLE
Add script creation submission date in the UI

### DIFF
--- a/libs/modelParser.js
+++ b/libs/modelParser.js
@@ -112,7 +112,7 @@ var parseScript = function (aScriptData) {
   if (!aScriptData) {
     return;
   }
-  var script = aScriptData.toObject ? aScriptData.toObject() : aScriptData;
+  var script = aScriptData.toObject ? aScriptData.toObject({ virtuals: true }) : aScriptData;
 
   // Temporaries
   var htmlStub = null;
@@ -210,6 +210,7 @@ var parseScript = function (aScriptData) {
 
   // Dates
   parseDateProperty(script, 'updated');
+  parseDateProperty(script, '_since'); // Virtual
 
   return script;
 };

--- a/models/script.js
+++ b/models/script.js
@@ -34,6 +34,10 @@ var scriptSchema = new Schema({
   _authorId: Schema.Types.ObjectId
 });
 
+scriptSchema.virtual('_since').get(function () {
+  return this._id.getTimestamp();
+});
+
 var Script = mongoose.model('Script', scriptSchema);
 
 exports.Script = Script;

--- a/views/pages/scriptPage.html
+++ b/views/pages/scriptPage.html
@@ -23,8 +23,9 @@
             {{/script.isLib}}
 
             <div class="script-meta">
-              {{#script.meta.version}}<p><i class="fa fa-fw fa-tag"></i> <b>Version:</b> <code>{{script.meta.version}}</code> uploaded <time class="script-updated" datetime="{{script.updatedISOFormat}}" title="{{script.updated}}">{{script.updatedHumanized}}</time></p>{{/script.meta.version}}
-              {{^script.meta.version}}<p><i class="fa fa-fw fa-clock-o"></i> <b>Updated:</b> <time class="script-updated" datetime="{{script.updatedISOFormat}}" title="{{script.updated}}">{{script.updatedHumanized}}</time></p>{{/script.meta.version}}
+              <p><i class="fa fa-fw fa-clock-o"></i> <b>Published:</b> <time datetime="{{script._sinceISOFormat}}" title="{{script._since}}">{{script._sinceHumanized}}</time></p>
+              {{#script.meta.version}}<p><i class="fa fa-fw fa-history"></i> <b>Version:</b> <code>{{script.meta.version}}</code> updated <time class="script-updated" datetime="{{script.updatedISOFormat}}" title="{{script.updated}}">{{script.updatedHumanized}}</time></p>{{/script.meta.version}}
+              {{^script.meta.version}}<p><i class="fa fa-fw fa-history"></i> <b>Updated:</b> <time class="script-updated" datetime="{{script.updatedISOFormat}}" title="{{script.updated}}">{{script.updatedHumanized}}</time></p>{{/script.meta.version}}
               {{#script.meta.description}}<p><i class="fa fa-fw fa-info"></i> <b>Summary:</b> {{script.meta.description}}</p>{{/script.meta.description}}
               {{#script.hasGroups}}
                 <span>


### PR DESCRIPTION
* Needs virtuals enable for this in `toObject`
* Changed the wording ever so slightly on Version to abstract it... not every script is uploaded... some are imported, etc... e.g. abstract it in general to minimize conversation gaps... not to mention it matches wording in script lists column.
* Use clock icon for publish and history icon for update from *font-awesome*

Closes #683