### PR TITLE
Hotfix for a potential security issue

### DIFF
--- a/views/includes/scriptAuthorToolsPanel.html
+++ b/views/includes/scriptAuthorToolsPanel.html
@@ -11,7 +11,7 @@
 
     <hr>
 
-    <h4>Installs per Version <small>since <time>2 Sept 2014</time></small></h4>
+    <h4>Installs per Version <small>effective <time title='Tue Sep 2 2014'>Sep '14</time></small></h4>
 
     <p><code>{{script.meta.version}}{{^script.meta.version}}Current{{/script.meta.version}}</code> <span class="label label-default">{{script.installsSinceUpdate}} installs</span></p>
   </div>


### PR DESCRIPTION
* Attempt to minimize the impact on what appears to be like a race condition with *mongoose* db saving... this alters the current behavior of collaboration by spawning a new script on the collaborators account if tampered with
* Change the text tip a bit to be more like the rest of the site by emulating current *moment* date stamp... the previous text tip was extremely confusing... applies to #346
* Option 2 has currently been selected... check the version before resetting the `Installs per Version` ... applies to #346