### PR TITLE
Trim up the published vs updated

### DIFF
--- a/libs/modelParser.js
+++ b/libs/modelParser.js
@@ -212,6 +212,10 @@ var parseScript = function (aScriptData) {
   parseDateProperty(script, 'updated');
   parseDateProperty(script, '_since'); // Virtual
 
+  if (script.updated.toString() !== script._since.toString()) {
+    script.isUpdated = true;
+  }
+
   return script;
 };
 parseModelFnMap.Script = parseScript;

--- a/views/pages/scriptPage.html
+++ b/views/pages/scriptPage.html
@@ -24,8 +24,14 @@
 
             <div class="script-meta">
               <p><i class="fa fa-fw fa-clock-o"></i> <b>Published:</b> <time datetime="{{script._sinceISOFormat}}" title="{{script._since}}">{{script._sinceHumanized}}</time></p>
-              {{#script.meta.version}}<p><i class="fa fa-fw fa-history"></i> <b>Version:</b> <code>{{script.meta.version}}</code> updated <time class="script-updated" datetime="{{script.updatedISOFormat}}" title="{{script.updated}}">{{script.updatedHumanized}}</time></p>{{/script.meta.version}}
-              {{^script.meta.version}}<p><i class="fa fa-fw fa-history"></i> <b>Updated:</b> <time class="script-updated" datetime="{{script.updatedISOFormat}}" title="{{script.updated}}">{{script.updatedHumanized}}</time></p>{{/script.meta.version}}
+              {{#script.meta.version}}
+                <p><i class="fa fa-fw fa-history"></i> <b>Version:</b> <code>{{script.meta.version}}</code>{{#script.isUpdated}} updated <time class="script-updated" datetime="{{script.updatedISOFormat}}" title="{{script.updated}}">{{script.updatedHumanized}}</time>{{/script.isUpdated}}</p>
+              {{/script.meta.version}}
+              {{^script.meta.version}}
+                {{#script.isUpdated}}
+                  <p><i class="fa fa-fw fa-history"></i> <b>Updated:</b> <time class="script-updated" datetime="{{script.updatedISOFormat}}" title="{{script.updated}}">{{script.updatedHumanized}}</time></p>
+                {{/script.isUpdated}}
+              {{/script.meta.version}}
               {{#script.meta.description}}<p><i class="fa fa-fw fa-info"></i> <b>Summary:</b> {{script.meta.description}}</p>{{/script.meta.description}}
               {{#script.hasGroups}}
                 <span>


### PR DESCRIPTION
* More visible difference on aging scripts... granularity is set to 1 second so there might be an overlap if the ms are close to the turnover point good Unit Test for the server too
* Line split the view a litle as it was getting way too long
Applies to #683