### PR TITLE
Some more tweaks on `./dev/init.js`

### DIFF
--- a/dev/init.js
+++ b/dev/init.js
@@ -44,11 +44,37 @@ var tasks = [
 
     exec(cmd, function (aErr, aStdout, aStderr) {
       if (aErr) {
+        if (aErr.code === 127) {
+//           aStdouts.push('$ ' + cmd + '\n' + chalk.gray(aStdout));
+          aCallback(null, false, aStdouts);
+          return;
+        } else {
+          aCallback(aErr);
+          return;
+        }
+      }
+
+//       aStdouts.push('$ ' + cmd + '\n' + chalk.gray(aStdout));
+      aCallback(null, true, aStdouts);
+    });
+  },
+  function (aSkip, aStdouts, aCallback) {
+    var cmd = 'sudo gem install bundler -v 1.10.6';
+
+    if (aSkip) {
+      aCallback(null, aStdouts);
+      return;
+    }
+
+    console.log(chalk.cyan('Installing *bundler* gem as global...'));
+
+    exec(cmd, function (aErr, aStdout, aStderr) {
+      if (aErr) {
         aCallback(aErr);
         return;
       }
 
-      aStdouts.push('$ ' + cmd + '\n' + chalk.gray(aStdout));
+//       aStdouts.push('$ ' + cmd + '\n' + chalk.gray(aStdout));
       aCallback(null, aStdouts);
     });
   },
@@ -58,7 +84,7 @@ var tasks = [
     exec(cmd, function (aErr, aStdout, aStderr) {
       if (aErr) {
         if (aErr.code === 7) {
-          aStdouts.push('$ ' + cmd + '\n' + chalk.gray(aStdout));
+//           aStdouts.push('$ ' + cmd + '\n' + chalk.gray(aStdout));
           aCallback(null, false, aStdouts);
           return;
         } else {
@@ -67,7 +93,7 @@ var tasks = [
         }
       }
 
-      aStdouts.push('$ ' + cmd + '\n' + chalk.gray(aStdout));
+//       aStdouts.push('$ ' + cmd + '\n' + chalk.gray(aStdout));
       aCallback(null, true, aStdouts);
     });
   },
@@ -79,6 +105,21 @@ var tasks = [
       return;
     }
 
+    console.log(chalk.cyan('Installing bundled gem(s) as global...'));
+
+    exec(cmd, function (aErr, aStdout, aStderr) {
+      if (aErr) {
+        aCallback(aErr);
+        return;
+      }
+
+//       aStdouts.push('$ ' + cmd + '\n' + chalk.gray(aStdout));
+      aCallback(null, aStdouts);
+    });
+  },
+  function (aStdouts, aCallback) {
+    var cmd = 'gem list';
+
     exec(cmd, function (aErr, aStdout, aStderr) {
       if (aErr) {
         aCallback(aErr);
@@ -90,7 +131,7 @@ var tasks = [
     });
   },
   function (aStdouts, aCallback) {
-    var cmd = 'gem list';
+    var cmd = 'gem outdated';
 
     exec(cmd, function (aErr, aStdout, aStderr) {
       if (aErr) {
@@ -141,7 +182,7 @@ async.waterfall(tasks, function (aErr, aResults) {
     return;
   }
 
-  aResults.push(chalk.green('Complete'));
+  aResults.push(chalk.cyan('Completed checking project dependencies'));
 
   console.log(aResults.join('\n'));
 });


### PR DESCRIPTION
* Auto install with authentication *bundler* if not present and include project specific gems
* Don't output automatic installs successes because they will be duplicated with `$ gem list`... but did leave them in as a comment in case one cares to have that much output
* Still showing `$ gem list` in case one wants to clean up... see below note
* Add `$ gem outdated` to mimic `npm` outdated functionality
* Keeping *bundler* and bundled gem deps globals for VPS to minimize storage

**NOTE**
* `$ gem cleanup`, `$ gem cleanup bundler`, and/or `$ gem cleanup fakes3` are **not run** in case another ruby enabled project needs them... e.g. all of these routines are additive.

Applies to #249