### PR TITLE
Apply sort parm to URI for Graveyard

### DIFF
--- a/controllers/remove.js
+++ b/controllers/remove.js
@@ -44,9 +44,9 @@ exports.rm = function (aReq, aRes, aNext) {
       });
     }
 
-    // Simple error check for string null and reserved phrase
+    // Simple error check for string null
     reason = reason.trim();
-    if (reason === '' || /^User removed$/i.test(reason)) {
+    if (reason === '') {
       return statusCodePage(aReq, aRes, aNext, {
         statusCode: 403,
         statusMessage: 'Invalid reason for removal.'

--- a/libs/modelParser.js
+++ b/libs/modelParser.js
@@ -533,7 +533,15 @@ var parseRemovedItem = function (aRemovedItemData) {
   parseDateProperty(removedItem, 'removed');
 
   // User
-  removedItem.remover = parseUser({ name: removedItem.removerName });
+  removedItem.remover = parseUser({
+    name: removedItem.removerName,
+    automated: removedItem.removerAutomated
+  });
+
+  // Reason
+  removedItem.reason = removedItem.reason ?
+    removedItem.reason :
+      (removedItem.removerAutomated ? removedItem.model + ' removed' : null);
 
   // Content
   var parseModelFn = parseModelFnMap[removedItem.model];

--- a/libs/remove.js
+++ b/libs/remove.js
@@ -49,7 +49,7 @@ function removeable(aModel, aContent, aUser, aCallback) {
 }
 exports.removeable = removeable;
 
-function remove(aModel, aContent, aUser, aReason, aCallback) {
+function remove(aModel, aContent, aUser, aReason, aAutomated, aCallback) {
   var removeModel = new Remove({
     'model': aModel.modelName,
     'content': aContent.toObject(),
@@ -57,6 +57,7 @@ function remove(aModel, aContent, aUser, aReason, aCallback) {
     'reason': aReason,
     'removerName': aUser.name,
     'removerRole': aUser.role,
+    'removerAutomated': aAutomated,
     '_removerId': aUser._id
   });
 
@@ -67,10 +68,12 @@ function remove(aModel, aContent, aUser, aReason, aCallback) {
 
 exports.remove = function (aModel, aContent, aUser, aReason, aCallback) {
   removeable(aModel, aContent, aUser, function (aCanRemove, aAuthor) {
-    if (!aCanRemove) { return aCallback(false); }
+    if (!aCanRemove) {
+      return aCallback(false);
+    }
 
     if (aModel.modelName !== 'User') {
-      remove(aModel, aContent, aUser, aReason, aCallback);
+      remove(aModel, aContent, aUser, aReason, false, aCallback);
     } else {
       // Remove all the user's content
       async.each(modelNames, function (aModelName, aCallback) {
@@ -78,11 +81,11 @@ exports.remove = function (aModel, aContent, aUser, aReason, aCallback) {
         model.find({ _authorId: aContent._id },
           function (aErr, aContentArr) {
             async.each(aContentArr, function (aContent, innerCb) {
-              remove(model, aContent, aUser, 'User removed', innerCb);
+              remove(model, aContent, aUser, '', true, innerCb);
             }, aCallback);
           });
       }, function () {
-        remove(aModel, aContent, aUser, aReason, aCallback);
+        remove(aModel, aContent, aUser, aReason, false, aCallback);
       });
     }
   });

--- a/models/remove.js
+++ b/models/remove.js
@@ -16,6 +16,7 @@ var removeSchema = new Schema({
   reason: String,
   removerName: String,
   removerRole: Number,
+  removerAutomated: Boolean,
   _removerId: Schema.Types.ObjectId
 });
 

--- a/public/css/common.css
+++ b/public/css/common.css
@@ -291,3 +291,7 @@ a.panel-heading {
   text-align: center;
   width: 1.28571429em;
 }
+
+.reason-automated {
+  opacity: 0.25;
+}

--- a/views/includes/removedItemList.html
+++ b/views/includes/removedItemList.html
@@ -1,11 +1,11 @@
 <table class="table table-hover table-condensed">
   <thead>
     <tr>
-      <th class="text-center td-fit"><a href="?orderBy=model&orderDir={{orderDir.model}}">Type</a></th>
+      <th class="text-center td-fit"><a href="?orderBy=model&orderDir={{orderDir.model}}{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}">Type</a></th>
       <th>Item</th>
       <th>Reason</th>
-      <th class="text-center td-fit"><a href="?orderBy=removerName&orderDir={{orderDir.removerName}}">Removed By</a></th>
-      <th class="text-center td-fit"><a href="?orderBy=removed&orderDir={{orderDir.removed}}">Date</a></th>
+      <th class="text-center td-fit"><a href="?orderBy=removerName&orderDir={{orderDir.removerName}}{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}">Removed By</a></th>
+      <th class="text-center td-fit"><a href="?orderBy=removed&orderDir={{orderDir.removed}}{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}">Date</a></th>
     </tr>
   </thead>
   <tbody>
@@ -18,7 +18,7 @@
         <p><a href="{{{url}}}" class="tr-link-a">{{item.description}}</a></p>
       </td>
       <td>
-        <p>{{reason}}</p>
+        <p{{#remover.automated}} class="reason-automated"{{/remover.automated}}>{{reason}}</p>
       </td>
       <td class="td-fit">
         <p>

--- a/views/pages/removedItemListPage.html
+++ b/views/pages/removedItemListPage.html
@@ -30,9 +30,14 @@
         {{> includes/searchBarPanel.html }}
         <h3>Filters</h3>
         <div class="list-group">
-          <a href="?q=Script" class="list-group-item">Scripts</a>
-          <a href="?q=User" class="list-group-item">Users</a>
-          <a href="?q=" class="list-group-item">All Types</a>
+          <a href="./removed" class="list-group-item"><i class="fa fa-fw fa-times"></i> Clear search</a>
+          <a href="?q=User" class="list-group-item"><i class="fa fa-fw fa-search"></i> Users</a>
+          <a href="?q=Script" class="list-group-item"><i class="fa fa-fw fa-search"></i> Scripts</a>
+          <a href="?q=Comment" class="list-group-item"><i class="fa fa-fw fa-search"></i> Comments</a>
+          <a href="?q=Discussion" class="list-group-item"><i class="fa fa-fw fa-search"></i> Discussion</a>
+          <a href="?q=Flag" class="list-group-item"><i class="fa fa-fw fa-search"></i> Flags</a>
+          <a href="?q=Group" class="list-group-item"><i class="fa fa-fw fa-search"></i> Groups</a>
+          <a href="?q=Vote" class="list-group-item"><i class="fa fa-fw fa-search"></i> Votes</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
* Done previously in #654 for public sortings
* Add some *font-awesome* icons to the graveyard
* Transform "All Types" to the correct nomenclature of "Clear Filters"
* Change `href` to use parent plus `/removed` e.g. `./removed` static
* Made User removal reason virtual instead of hard-coded... useful for Search filters e.g. reason is now blank when system generated... still don't allow a blank reason from a real author.. post fix for #261 and pull #513. This allows no reserved phrases other than string empty.
* Some STYLEGUIDE.md conformance
* DB remove model **migrated** as far back as "User removed" existed
* Added some common needed Filters and reordered similar to GH... not all are implemented yet

Closes #526