### PR TITLE
Reestablish the model filters

### DIFF
--- a/controllers/moderation.js
+++ b/controllers/moderation.js
@@ -66,6 +66,9 @@ exports.removedItemListPage = function (aReq, aRes, aNext) {
     });
   }
 
+  //
+  options.byModel = aReq.query.byModel !== undefined ? aReq.query.byModel : null;
+
   // Page metadata
   pageMetadata(options, 'Graveyard');
 
@@ -77,8 +80,37 @@ exports.removedItemListPage = function (aReq, aRes, aNext) {
   // removedItemListQuery
   var removedItemListQuery = Remove.find();
 
+  // removedItemListQuery: byModel
+  if (options.byModel) {
+    modelQuery.findOrDefaultIfNull(removedItemListQuery, 'model', options.byModel, null);
+  }
+
   // removedItemListQuery: Defaults
-  modelQuery.applyRemovedItemListQueryDefaults(removedItemListQuery, options, aReq);
+  switch (options.byModel) {
+    case 'User':
+      modelQuery.applyRemovedItemUserListQueryDefaults(removedItemListQuery, options, aReq);
+      break;
+    case 'Script':
+      modelQuery.applyRemovedItemScriptListQueryDefaults(removedItemListQuery, options, aReq);
+      break;
+    case 'Comment':
+      modelQuery.applyRemovedItemCommentListQueryDefaults(removedItemListQuery, options, aReq);
+      break;
+    case 'Discussion':
+      modelQuery.applyRemovedItemDiscussionListQueryDefaults(removedItemListQuery, options, aReq);
+      break;
+    case 'Flag':
+      modelQuery.applyRemovedItemFlagListQueryDefaults(removedItemListQuery, options, aReq);
+      break;
+    case 'Group':
+      modelQuery.applyRemovedItemGroupListQueryDefaults(removedItemListQuery, options, aReq);
+      break;
+    case 'Vote':
+      modelQuery.applyRemovedItemVoteListQueryDefaults(removedItemListQuery, options, aReq);
+      break;
+    default:
+      modelQuery.applyRemovedItemListQueryDefaults(removedItemListQuery, options, aReq);
+  }
 
   // removedItemListQuery: Pagination
   var pagination = options.pagination; // is set in modelQuery.apply___ListQueryDefaults

--- a/libs/modelQuery.js
+++ b/libs/modelQuery.js
@@ -125,7 +125,7 @@ var parseUserSearchQuery = function (aUserListQuery, aQuery) {
     fullWordMatchFields: []
   });
 };
-exports.parseCommentSearchQuery = parseCommentSearchQuery;
+exports.parseUserSearchQuery = parseUserSearchQuery;
 
 var parseRemovedItemSearchQuery = function (aRemovedItemListQuery, aQuery) {
   parseModelListSearchQuery(aRemovedItemListQuery, aQuery, {
@@ -140,7 +140,7 @@ var parseRemovedItemSearchQuery = function (aRemovedItemListQuery, aQuery) {
     fullWordMatchFields: ['model']
   });
 };
-exports.parseCommentSearchQuery = parseCommentSearchQuery;
+exports.parseRemovedItemSearchQuery = parseRemovedItemSearchQuery;
 
 exports.applyDiscussionCategoryFilter = function (aDiscussionListQuery, aOptions, aCatergorySlug) {
   if (aCatergorySlug === 'all') {
@@ -279,6 +279,104 @@ exports.applyUserListQueryDefaults = function (aUserListQuery, aOptions, aReq) {
     searchBarPlaceholder: 'Search Users',
     filterFlaggedItems: true
   });
+};
+
+var removedItemUserListQueryDefaults = {
+  defaultSort: '-removed',
+  parseSearchQueryFn: parseRemovedItemSearchQuery,
+  searchBarPlaceholder: 'Search Removed Items in Users',
+  searchBarFormHiddenVariables: [
+    { name: 'byModel', value: 'User' }
+  ],
+  filterFlaggedItems: false
+}
+exports.removedItemUserListQueryDefaults = removedItemUserListQueryDefaults;
+exports.applyRemovedItemUserListQueryDefaults = function (aRemovedItemUserListQuery, aOptions, aReq) {
+  applyModelListQueryDefaults(aRemovedItemUserListQuery, aOptions, aReq, removedItemUserListQueryDefaults);
+};
+
+var removedItemScriptListQueryDefaults = {
+  defaultSort: '-removed',
+  parseSearchQueryFn: parseRemovedItemSearchQuery,
+  searchBarPlaceholder: 'Search Removed Items in Scripts',
+  searchBarFormHiddenVariables: [
+    { name: 'byModel', value: 'Script' }
+  ],
+  filterFlaggedItems: false
+}
+exports.removedItemScriptListQueryDefaults = removedItemScriptListQueryDefaults;
+exports.applyRemovedItemScriptListQueryDefaults = function (aRemovedItemScriptListQuery, aOptions, aReq) {
+  applyModelListQueryDefaults(aRemovedItemScriptListQuery, aOptions, aReq, removedItemScriptListQueryDefaults);
+};
+
+var removedItemCommentListQueryDefaults = {
+  defaultSort: '-removed',
+  parseSearchQueryFn: parseRemovedItemSearchQuery,
+  searchBarPlaceholder: 'Search Removed Items in Comments',
+  searchBarFormHiddenVariables: [
+    { name: 'byModel', value: 'Comment' }
+  ],
+  filterFlaggedItems: false
+}
+exports.removedItemCommentListQueryDefaults = removedItemCommentListQueryDefaults;
+exports.applyRemovedItemCommentListQueryDefaults = function (aRemovedItemCommentListQuery, aOptions, aReq) {
+  applyModelListQueryDefaults(aRemovedItemCommentListQuery, aOptions, aReq, removedItemCommentListQueryDefaults);
+};
+
+var removedItemDiscussionListQueryDefaults = {
+  defaultSort: '-removed',
+  parseSearchQueryFn: parseRemovedItemSearchQuery,
+  searchBarPlaceholder: 'Search Removed Items in Discussions',
+  searchBarFormHiddenVariables: [
+    { name: 'byModel', value: 'Discussion' }
+  ],
+  filterFlaggedItems: false
+}
+exports.removedItemDiscussionListQueryDefaults = removedItemDiscussionListQueryDefaults;
+exports.applyRemovedItemDiscussionListQueryDefaults = function (aRemovedItemDiscussionListQuery, aOptions, aReq) {
+  applyModelListQueryDefaults(aRemovedItemDiscussionListQuery, aOptions, aReq, removedItemDiscussionListQueryDefaults);
+};
+
+var removedItemFlagListQueryDefaults = {
+  defaultSort: '-removed',
+  parseSearchQueryFn: parseRemovedItemSearchQuery,
+  searchBarPlaceholder: 'Search Removed Items in Flags',
+  searchBarFormHiddenVariables: [
+    { name: 'byModel', value: 'Flag' }
+  ],
+  filterFlaggedItems: false
+}
+exports.removedItemFlagListQueryDefaults = removedItemFlagListQueryDefaults;
+exports.applyRemovedItemFlagListQueryDefaults = function (aRemovedItemFlagListQuery, aOptions, aReq) {
+  applyModelListQueryDefaults(aRemovedItemFlagListQuery, aOptions, aReq, removedItemFlagListQueryDefaults);
+};
+
+var removedItemGroupListQueryDefaults = {
+  defaultSort: '-removed',
+  parseSearchQueryFn: parseRemovedItemSearchQuery,
+  searchBarPlaceholder: 'Search Removed Items in Groups',
+  searchBarFormHiddenVariables: [
+    { name: 'byModel', value: 'Group' }
+  ],
+  filterFlaggedItems: false
+}
+exports.removedItemGroupListQueryDefaults = removedItemGroupListQueryDefaults;
+exports.applyRemovedItemGroupListQueryDefaults = function (aRemovedItemGroupListQuery, aOptions, aReq) {
+  applyModelListQueryDefaults(aRemovedItemGroupListQuery, aOptions, aReq, removedItemGroupListQueryDefaults);
+};
+
+var removedItemVoteListQueryDefaults = {
+  defaultSort: '-removed',
+  parseSearchQueryFn: parseRemovedItemSearchQuery,
+  searchBarPlaceholder: 'Search Removed Items in Votes',
+  searchBarFormHiddenVariables: [
+    { name: 'byModel', value: 'Vote' }
+  ],
+  filterFlaggedItems: false
+}
+exports.removedItemVoteListQueryDefaults = removedItemVoteListQueryDefaults;
+exports.applyRemovedItemVoteListQueryDefaults = function (aRemovedItemVoteListQuery, aOptions, aReq) {
+  applyModelListQueryDefaults(aRemovedItemVoteListQuery, aOptions, aReq, removedItemVoteListQueryDefaults);
 };
 
 exports.applyRemovedItemListQueryDefaults = function (aRemovedItemListQuery, aOptions, aReq) {

--- a/views/includes/removedItemList.html
+++ b/views/includes/removedItemList.html
@@ -1,11 +1,11 @@
 <table class="table table-hover table-condensed">
   <thead>
     <tr>
-      <th class="text-center td-fit"><a href="?orderBy=model&orderDir={{orderDir.model}}{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}">Type</a></th>
+      <th class="text-center td-fit"><a href="?orderBy=model&orderDir={{orderDir.model}}{{#byModel}}&byModel={{byModel}}{{/byModel}}{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}">Model</a></th>
       <th>Item</th>
       <th>Reason</th>
-      <th class="text-center td-fit"><a href="?orderBy=removerName&orderDir={{orderDir.removerName}}{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}">Removed By</a></th>
-      <th class="text-center td-fit"><a href="?orderBy=removed&orderDir={{orderDir.removed}}{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}">Date</a></th>
+      <th class="text-center td-fit"><a href="?orderBy=removerName&orderDir={{orderDir.removerName}}{{#byModel}}&byModel={{byModel}}{{/byModel}}{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}">Removed By</a></th>
+      <th class="text-center td-fit"><a href="?orderBy=removed&orderDir={{orderDir.removed}}{{#byModel}}&byModel={{byModel}}{{/byModel}}{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}">Date</a></th>
     </tr>
   </thead>
   <tbody>

--- a/views/pages/removedItemListPage.html
+++ b/views/pages/removedItemListPage.html
@@ -30,15 +30,16 @@
         {{> includes/searchBarPanel.html }}
         <h3>Filters</h3>
         <div class="list-group">
-          <a href="./removed" class="list-group-item"><i class="fa fa-fw fa-times"></i> Clear search</a>
-          <a href="?q=User" class="list-group-item"><i class="fa fa-fw fa-search"></i> Users</a>
-          <a href="?q=Script" class="list-group-item"><i class="fa fa-fw fa-search"></i> Scripts</a>
-          <a href="?q=Comment" class="list-group-item"><i class="fa fa-fw fa-search"></i> Comments</a>
-          <a href="?q=Discussion" class="list-group-item"><i class="fa fa-fw fa-search"></i> Discussion</a>
-          <a href="?q=Flag" class="list-group-item"><i class="fa fa-fw fa-search"></i> Flags</a>
-          <a href="?q=Group" class="list-group-item"><i class="fa fa-fw fa-search"></i> Groups</a>
-          <a href="?q=Vote" class="list-group-item"><i class="fa fa-fw fa-search"></i> Votes</a>
+          <a href="./removed{{#searchBarValue}}?q={{searchBarValue}}{{/searchBarValue}}" class="list-group-item"><i class="fa fa-fw fa-times"></i> Clear Filter</a>
+          <a href="?byModel=User{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}" class="list-group-item"><i class="fa fa-fw fa-user"></i> User</a>
+          <a href="?byModel=Script{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}" class="list-group-item"><i class="fa fa-fw fa-file"></i> Script</a>
+          <a href="?byModel=Comment{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}" class="list-group-item"><i class="fa fa-fw fa-comment"></i> Comment</a>
+          <a href="?byModel=Discussion{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}" class="list-group-item"><i class="fa fa-fw fa-commenting"></i> Discussion</a>
+          <a href="?byModel=Flag{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}" class="list-group-item"><i class="fa fa-fw fa-flag"></i> Flag</a>
+          <a href="?byModel=Group{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}" class="list-group-item"><i class="fa fa-fw fa-tag"></i> Group</a>
+          <a href="?byModel=Vote{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}" class="list-group-item"><i class="fa fa-fw fa-signal"></i> Vote</a>
         </div>
+
       </div>
     </div>
   </div>


### PR DESCRIPTION
* This is about the medium average point between methodologies of Zren, Jerone, SizzleMcTwizzle and myself that can be managed at the moment... I tinkered with naming the QSP `filterBy`... Item, Reason, Removed By, and Date will never be filtered imho so I ended up with a merge of `byModel`.
* Fixed a bug on `exports.`...
* Renamed the column from `Type` to `Model` since that's probably what is going to be in here... although `strategy` model probably won't but the `orderBy` QSP is already using `model`

Applies to #490