### PR TITLE
Some more misc visual effects

### DIFF
--- a/controllers/moderation.js
+++ b/controllers/moderation.js
@@ -115,7 +115,6 @@ exports.removedItemListPage = function (aReq, aRes, aNext) {
       break;
     default:
       modelQuery.applyRemovedItemListQueryDefaults(removedItemListQuery, options, aReq);
-      options.filterNull = true;
   }
 
   // removedItemListQuery: Pagination

--- a/views/includes/header.html
+++ b/views/includes/header.html
@@ -8,8 +8,8 @@
       <ul class="nav navbar-nav navbar-right">
         <li><a href="/" title="Scripts"><span class="visible-xs-inline"><i class="fa fa-file-code-o"></i> </span>Scripts</a></li>
         <li><a href="/?library=true" title="Script Libraries"><span class="visible-xs-inline"><i class="fa fa-file-excel-o"></i> </span>Libraries</a></li>
-        <li><a href="/groups" title="Script Groups"><span class="visible-xs-inline"><i class="fa fa-folder"></i> </span>Groups</a></li>
-        <li><a href="/forum"><span class="visible-xs-inline"><i class="fa fa-comment"></i> </span>Discussions</a></li>
+        <li><a href="/groups" title="Script Groups"><span class="visible-xs-inline"><i class="fa fa-tag"></i> </span>Groups</a></li>
+        <li><a href="/forum"><span class="visible-xs-inline"><i class="fa fa-commenting"></i> </span>Discussions</a></li>
         <li><a href="/users"><span class="visible-xs-inline"><i class="fa fa-user"></i> </span>Users</a></li>
         {{#authedUser}}
         {{#authedUser.isMod}}

--- a/views/pages/removedItemListPage.html
+++ b/views/pages/removedItemListPage.html
@@ -30,7 +30,7 @@
         {{> includes/searchBarPanel.html }}
         <h3>Filters</h3>
         <div class="list-group">
-          <a href="./removed{{#searchBarValue}}?q={{searchBarValue}}{{/searchBarValue}}" class="list-group-item{{#filterNull}} active{{/filterNull}}"><i class="fa fa-fw fa-times"></i> Clear Filter</a>
+          <a href="./removed{{#searchBarValue}}?q={{searchBarValue}}{{/searchBarValue}}" class="list-group-item list-group-item-info"><i class="fa fa-fw fa-times"></i> Clear Filter</a>
           <a href="?byModel=User{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}" class="list-group-item{{#filterUser}} active{{/filterUser}}"><i class="fa fa-fw fa-user"></i> User</a>
           <a href="?byModel=Script{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}" class="list-group-item{{#filterScript}} active{{/filterScript}}"><i class="fa fa-fw fa-file"></i> Script</a>
           <a href="?byModel=Comment{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}" class="list-group-item{{#filterComment}} active{{/filterComment}}"><i class="fa fa-fw fa-comment"></i> Comment</a>

--- a/views/pages/scriptPage.html
+++ b/views/pages/scriptPage.html
@@ -35,7 +35,7 @@
               {{#script.meta.description}}<p><i class="fa fa-fw fa-info"></i> <b>Summary:</b> {{script.meta.description}}</p>{{/script.meta.description}}
               {{#script.hasGroups}}
                 <span>
-                  <i class="fa fa-fw fa-tags"></i> <b>Groups:</b>
+                  <i class="fa fa-fw fa-tag"></i> <b>Groups:</b>
                   <ul class="list-inline inline-block">
                   {{#script.groups}}
                     <li><a href="{{{groupPageUrl}}}">{{name}}</a></li>


### PR DESCRIPTION
* Don't select Clear Filter at removed items in case someone gets clever and modifies the url to a non-existent model filter
* Give the Clear Filter at removed items a little coloring just for informational purposes with an applicable *bootstrap* class
* Match some of the *font-awesome* icons in a few other places in xs views and normal views ... using singular icons always but text can be plural if applicable
* @sizzlemctwizzle ... Would like to turn rating into the `fa-heartbeat` to indicate the pulse however that is currently blocking assigned in #262 as a vote thing. Would be a better distinction between installs and that I believe.

Applies to #490