### PR TITLE
Downgrade *mongoose* due to production connection failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "marked": "0.3.5",
     "method-override": "2.3.5",
     "moment": "2.10.6",
-    "mongoose": "4.1.3",
+    "mongoose": "4.1.1",
     "morgan": "1.6.1",
     "mu2": "0.5.20",
     "octicons": "2.4.1",


### PR DESCRIPTION
* Hopefully this fixes this... not present in dev environment

``` sh-session
connection error: { [MongoError: no valid seed servers in list] name: 'MongoError', message: 'no valid seed servers in list' }
.write(string, encoding, offset, length) is deprecated. Use write(string[, offset[, length]][, encoding]) instead.
(node) warning: possible EventEmitter memory leak detected. 11 connected listeners added. Use emitter.setMaxListeners() to increase limit.
Trace
    at MongoStore.addListener (events.js:179:15)
    at MongoStore.once (events.js:204:8)
    at MongoStore.getCollection (/home/oujs/OpenUserJS.org/node_modules/connect-mongo/lib/connect-mongo.js:219:16)
    at MongoStore.get (/home/oujs/OpenUserJS.org/node_modules/connect-mongo/lib/connect-mongo.js:285:10)
    at session (/home/oujs/OpenUserJS.org/node_modules/express-session/index.js:404:11)
    at Layer.handle [as handle_request] (/home/oujs/OpenUserJS.org/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/home/oujs/OpenUserJS.org/node_modules/express/lib/router/index.js:312:13)
    at /home/oujs/OpenUserJS.org/node_modules/express/lib/router/index.js:280:7
    at Function.process_params (/home/oujs/OpenUserJS.org/node_modules/express/lib/router/index.js:330:12)
    at next (/home/oujs/OpenUserJS.org/node_modules/express/lib/router/index.js:271:10)
    at initialize (/home/oujs/OpenUserJS.org/node_modules/passport/lib/middleware/initialize.js:62:5)
    at Layer.handle [as handle_request] (/home/oujs/OpenUserJS.org/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/home/oujs/OpenUserJS.org/node_modules/express/lib/router/index.js:312:13)
    at /home/oujs/OpenUserJS.org/node_modules/express/lib/router/index.js:280:7
    at Function.process_params (/home/oujs/OpenUserJS.org/node_modules/express/lib/router/index.js:330:12)
    at next (/home/oujs/OpenUserJS.org/node_modules/express/lib/router/index.js:271:10)
```