### PR TITLE
Localization of metadata blocks

### DIFF
--- a/libs/modelParser.js
+++ b/libs/modelParser.js
@@ -116,6 +116,7 @@ var parseScript = function (aScriptData) {
   var script = aScriptData.toObject ? aScriptData.toObject({ virtuals: true }) : aScriptData;
 
   // Intermediates
+  var description = null;
   var icon = null;
   var supportURL = null;
 
@@ -127,47 +128,41 @@ var parseScript = function (aScriptData) {
     script.author = parseUser({ name: script.author });
   }
 
-  // Icons
-  icon = findMeta(script.meta, 'icon');
-  if (icon) {
-    // TODO: `@icon` has been unique but may not be in early scripts in the DB.
-    // Should be fixed on migration so this can be modified
-    if (_.isString(icon)) {
-      script.icon16Url = icon;
-      script.icon45Url = icon;
-    } else if (_.isArray(icon) && !_.isEmpty(icon)) { // NOTE: Should never be empty
-      script.icon16Url = icon[icon.length - 1];
-      script.icon45Url = icon[icon.length - 1];
-    }
+  // Description default
+  description = findMeta(script.meta, 'UserScript.description');
+  if (description) {
+    description.forEach(function (aElement, aIndex, aArray) {
+      if (!description[aIndex].key) {
+        script.description = aElement.value;
+      }
+    });
   }
 
-  icon = findMeta(script.meta, 'icon64');
+  // Icons
+  icon = findMeta(script.meta, 'UserScript.icon.0.value');
   if (icon) {
+    script.icon16Url = icon;
+    script.icon45Url = icon;
+  }
+
+  icon = findMeta(script.meta, 'UserScript.icon64.0.value');
+  if (icon) {
+    // Local downmix
     script.icon45Url = icon;
   }
 
   // Support Url
-  supportURL = findMeta(script.meta, 'supportURL');
+  supportURL = findMeta(script.meta, 'UserScript.supportURL.0.value');
   if (supportURL) {
-    script.hasSupport = true;
-    if (_.isString(supportURL)) {
-      htmlStub = '<a href="' + supportURL + '"></a>';
-      if (htmlStub === sanitizeHtml(htmlStub, htmlWhitelistLink)) {
-        script.support = [{
-          url: supportURL,
-          text: decodeURI(supportURL),
-          hasNoFollow: !/^(?:https?:\/\/)?openuserjs\.org/i.test(supportURL)
-        }];
-      }
-    } else if (_.isArray(supportURL) && !_.isEmpty(supportURL)) { // NOTE: Should never be empty
-      htmlStub = '<a href="' + supportURL[supportURL - 1] + '"></a>';
-      if (htmlStub === sanitizeHtml(htmlStub, htmlWhitelistLink)) {
-        script.support = [{
-          url:  supportURL[supportURL.length - 1],
-          text: decodeURI(supportURL[supportURL.length - 1]),
-          hasNoFollow:  !/^(?:https?:\/\/)?openuserjs\.org/i.test(supportURL[supportURL.length - 1])
-        }];
-      }
+    htmlStub = '<a href="' + supportURL + '"></a>';
+    if (htmlStub === sanitizeHtml(htmlStub, htmlWhitelistLink)) {
+      script.hasSupport = true;
+
+      script.support = [{
+        url: supportURL,
+        text: decodeURI(supportURL),
+        hasNoFollow: !/^(?:https?:\/\/)?openuserjs\.org/i.test(supportURL)
+      }];
     }
   }
 

--- a/libs/modelQuery.js
+++ b/libs/modelQuery.js
@@ -113,8 +113,8 @@ var parseModelListSearchQuery = function (aModelListQuery, aQuery, aSearchOption
 
 var parseScriptSearchQuery = function (aScriptListQuery, aQuery) {
   parseModelListSearchQuery(aScriptListQuery, aQuery, {
-    partialWordMatchFields: ['name', 'author', 'about', 'meta.description'],
-    fullWordMatchFields: ['meta.include', 'meta.match']
+    partialWordMatchFields: ['name', 'author', 'about', 'meta.UserScript.description.value'],
+    fullWordMatchFields: ['meta.UserScript.include.value', 'meta.UserScript.match.value']
   });
 };
 exports.parseScriptSearchQuery = parseScriptSearchQuery;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "OpenUserJS.org",
   "description": "An open source user scripts repo built using Node.js",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "main": "app",
   "dependencies": {
     "ace-builds": "git://github.com/ajaxorg/ace-builds#0982db4",
@@ -50,6 +50,7 @@
     "passport-twitter": "1.0.3",
     "passport-windowslive": "1.0.1",
     "passport-yahoo": "0.3.0",
+    "pegjs": "0.8.0",
     "request": "2.60.0",
     "sanitize-html": "1.8.0",
     "select2": "3.5.2-browserify",

--- a/public/pegjs/blockUserScript.pegjs
+++ b/public/pegjs/blockUserScript.pegjs
@@ -110,7 +110,7 @@ item0 =
   {
     return {
       unique: true,
-      
+
       key: upmix(keyword)
     };
   }
@@ -125,6 +125,7 @@ item1 =
       'namespace' /
       'installURL' /
       'iconURL' /
+      'icon64' /
       'icon' /
       'downloadURL' /
       'defaulticon'

--- a/views/includes/scriptList.html
+++ b/views/includes/scriptList.html
@@ -15,11 +15,11 @@
           {{#isLib}}<i class="fa fa-fw fa-file-excel-o"></i>{{/isLib}}{{^isLib}}<i class="fa fa-fw fa-file-code-o"></i>{{/isLib}}
         </span>
         <a href="{{{scriptPageUrl}}}" class="tr-link-a"><b>{{name}}</b></a>
-        {{#meta.version}}
-        <span class="script-version label label-default">{{meta.version}}</span>
-        {{/meta.version}}
+        {{#meta.UserScript.version}}
+        <span class="script-version label label-default">{{value}}</span>
+        {{/meta.UserScript.version}}
         <span class="inline-block">by <a href="{{{author.userPageUrl}}}">{{author.name}}</a></span>
-        <p>{{meta.description}}</p>
+        {{#description}}<p>{{description}}</p>{{/description}}
       </td>
       {{^librariesOnly}}
       <td class="text-center td-fit">

--- a/views/pages/newScriptPage.html
+++ b/views/pages/newScriptPage.html
@@ -18,54 +18,53 @@
       <div class="col-xs-12">
         <div class="col-md-4">
           {{#newUserJS}}
-          <h2><i class="fa fa-tags"></i> Script Metadata</h2>
+          <h2><i class="octicon octicon-key"></i> Script Metadata</h2>
           <div class="panel panel-default">
             <div class="panel-body">
-              <p>You may read about most UserScript metadata blocks on the <a href="http://wiki.greasespot.net/Metadata_Block">Greasespot wiki</a> and at the <a href="https://sourceforge.net/p/greasemonkey/wiki/Metadata_Block/">Greasemonkey on SourceForge wiki</a>.</p>
+              <p>You may read about most UserScript metadata block keys on the <a href="http://wiki.greasespot.net/Metadata_Block">Greasespot wiki</a> and at the <a href="https://sourceforge.net/p/greasemonkey/wiki/Metadata_Block/">Greasemonkey on SourceForge wiki</a>. Some recommended ones are listed below with their respective metadata block names.</p>
             </div>
           </div>
-          <h3>OpenUserJS.org Supported</h3>
+          <h3>UserScript Block</h3>
           <div class="list-group script-metadata-definitions">
             <div class="list-group-item">
-              <h4 class="list-group-item-heading"><code>@description This script even does the laundry!</code></h4>
+              <h5 class="list-group-item-heading"><code>@name My Script</code></h5>
+              <p class="list-group-item-text"><strong>Default non-localized is required.</strong> Last value is used.</p>
+            </div>
+            <div class="list-group-item">
+              <h5 class="list-group-item-heading"><code>@description This script even does the laundry!</code></h5>
               <p class="list-group-item-text">Specially formatted on the script page. Last value shown.</p>
             </div>
 
             <div class="list-group-item">
-              <h4 class="list-group-item-heading"><code>@copyright Year, Author (Author Website)</code></h4>
+              <h5 class="list-group-item-heading"><code>@copyright Year, Author (Author Website)</code></h5>
               <p class="list-group-item-text">Specially formatted on the script page. All values shown in reverse order.</p>
             </div>
             <div class="list-group-item">
-              <h4 class="list-group-item-heading"><code>@icon url</code></h4>
+              <h5 class="list-group-item-heading"><code>@icon url</code></h5>
               <p class="list-group-item-text">A url or data url. Resolution should be near 48px by 48px, Used in the script list page at 16px and on the script page at ~45px. Last value is shown.</p>
             </div>
             <div class="list-group-item">
-              <h4 class="list-group-item-heading"><code>@license License Type; License Homepage</code></h4>
+              <h5 class="list-group-item-heading"><code>@license License Type; License Homepage</code></h5>
               <p class="list-group-item-text">Specially formatted on the script page. All values shown in reverse order. If absent MIT License (Expat) is implied. See <a href="/about/Terms-of-Service#licensing">licensing terms</a> for specifics.</p>
             </div>
             <div class="list-group-item">
-              <h4 class="list-group-item-heading"><code>@homepageURL url</code></h4>
+              <h5 class="list-group-item-heading"><code>@homepageURL url</code></h5>
               <p class="list-group-item-text">A url of http, https or mailto protocol. Specially formatted on the script page. All values shown in reverse order.</p>
             </div>
             <div class="list-group-item">
-              <h4 class="list-group-item-heading"><code>@supportURL url</code></h4>
+              <h5 class="list-group-item-heading"><code>@supportURL url</code></h5>
               <p class="list-group-item-text">A url of http, https or mailto protocol. Specially formatted on the script page. Last value shown.</p>
             </div>
-            <div class="list-group-item">
-              <h4 class="list-group-item-heading"><code>@oujs:author {{#authedUser}}{{authedUser.name}}{{/authedUser}}{{^authedUser}}username{{/authedUser}}</code></h4>
-              <p class="list-group-item-text">The author of the script. Required to enable <a href="#collaboration">Collaboration</a>. Last value shown. This key may be subject to change.</p>
-            </div>
-            <div class="list-group-item">
-              <h4 class="list-group-item-heading"><code>@oujs:collaborator username</code></h4>
-              <p class="list-group-item-text">May be defined multiple times. Required for <a href="#collaboration">Collaboration</a>. All values shown in reverse order. This key may be subject to change.</p>
-            </div>
           </div>
-
-          <a name="collaboration"></a>
-          <h3>Collaboration</h3>
-          <div class="panel panel-default">
-            <div class="panel-body">
-              <p>To allow other users to upload modified versions of your script to your account, add <code>@oujs:author {{#authedUser}}{{authedUser.name}}{{/authedUser}}{{^authedUser}}username{{/authedUser}}</code> to the metadata of your script, along with <code>@oujs:collaborator username</code> for every user you wish to give write access. Only the real author of the script may modify these metadata keys. Collaborators may not use GitHub integration to update the script. Add them as collaborators to the GitHub repo instead.</p>
+          <h3>OpenUserJS Block</h3>
+          <div class="list-group script-metadata-definitions">
+            <div class="list-group-item">
+              <h5 class="list-group-item-heading"><code>@author {{#authedUser}}{{authedUser.name}}{{/authedUser}}{{^authedUser}}username{{/authedUser}}</code></h5>
+              <p class="list-group-item-text">The author of the script. Required to enable <a href="#collaboration">Collaboration</a>. Last value shown.</p>
+            </div>
+            <div class="list-group-item">
+              <h5 class="list-group-item-heading"><code>@collaborator username</code></h5>
+              <p class="list-group-item-text">May be defined multiple times. Required for <a href="#collaboration">Collaboration</a>. All values shown in reverse order.</p>
             </div>
           </div>
           {{/newUserJS}}
@@ -74,7 +73,7 @@
           <div class="panel panel-default">
             <div class="panel-body">
               <h3>OpenUserJS.org Supported</h3>
-              <p>Any UserScript on OpenUserJS.org that <code>//@require</code>'s libraries from OpenUserJS.org will link to the library on the UserScript page.</p>
+              <p>Any UserScript on OpenUserJS.org that <code>// @require</code>'s libraries from OpenUserJS.org will link to the library on the UserScript page.</p>
             </div>
           </div>
           {{/newJSLibrary}}
@@ -118,7 +117,7 @@
             <div class="list-group-item">
               <h4 class="list-group-item-heading"><i class="octicon octicon-fw octicon-repo-forked"></i> Fork An Existing Script</h4>
               <p class="list-group-item-text">
-                While logged in, click the fork button on any script's main page, or view a script's source and "Submit Code as Fork".
+                While logged in view a script's source and click "Submit Code as Fork".
               </p>
             </div>
             <a href="{{{authedUser.userGitHubRepoListPageUrl}}}" class="list-group-item">
@@ -149,6 +148,19 @@
               <p>After adding the webhook, push a change to GitHub to make sure it's working.</p>
             </div>
           </div>
+
+          {{#newUserJS}}
+          <a name="collaboration"></a>
+          <h3>Collaboration</h3>
+          <div class="panel panel-default">
+            <div class="panel-body">
+              <p>To allow other users to upload modified versions of your script to your account from this site create an OpenUserJS metadata block and add the necessary keys... one for you yourself and for every existing user you wish to give write access as demonstrated here:<pre><code>// ==OpenUserJS==</code><br /><code>// @author {{#authedUser}}{{authedUser.name}}{{/authedUser}}{{^authedUser}}username{{/authedUser}}</code><br /><code>// @collaborator username</code><br /><code>// ==/OpenUserJS==</code></pre> Only the real author of the script may modify these metadata keys.</p>
+              <p>Collaborators on this site may not use GitHub integration to update the script. Add them as collaborators to the GitHub repository instead.</p>
+              <p>If the webhook is enabled on the GitHub repository it will clobber any changes here on this site.</p>
+            </div>
+          </div>
+          {{/newUserJS}}
+
         </div>
       </div>
     </div>

--- a/views/pages/scriptPage.html
+++ b/views/pages/scriptPage.html
@@ -24,15 +24,15 @@
 
             <div class="script-meta">
               <p><i class="fa fa-fw fa-clock-o"></i> <b>Published:</b> <time datetime="{{script._sinceISOFormat}}" title="{{script._since}}">{{script._sinceHumanized}}</time></p>
-              {{#script.meta.version}}
-                <p><i class="fa fa-fw fa-history"></i> <b>Version:</b> <code>{{script.meta.version}}</code>{{#script.isUpdated}} updated <time class="script-updated" datetime="{{script.updatedISOFormat}}" title="{{script.updated}}">{{script.updatedHumanized}}</time>{{/script.isUpdated}}</p>
-              {{/script.meta.version}}
-              {{^script.meta.version}}
+              {{#script.meta.UserScript.version}}
+                <p><i class="fa fa-fw fa-history"></i> <b>Version:</b> <code>{{value}}</code>{{#script.isUpdated}} updated <time class="script-updated" datetime="{{script.updatedISOFormat}}" title="{{script.updated}}">{{script.updatedHumanized}}</time>{{/script.isUpdated}}</p>
+              {{/script.meta.UserScript.version}}
+              {{^script.meta.UserScript.version}}
                 {{#script.isUpdated}}
                   <p><i class="fa fa-fw fa-history"></i> <b>Updated:</b> <time class="script-updated" datetime="{{script.updatedISOFormat}}" title="{{script.updated}}">{{script.updatedHumanized}}</time></p>
                 {{/script.isUpdated}}
-              {{/script.meta.version}}
-              {{#script.meta.description}}<p><i class="fa fa-fw fa-info"></i> <b>Summary:</b> {{script.meta.description}}</p>{{/script.meta.description}}
+              {{/script.meta.UserScript.version}}
+              {{#script.description}}<p><i class="fa fa-fw fa-info"></i> <b>Summary:</b> {{script.description}}</p>{{/script.description}}
               {{#script.hasGroups}}
                 <span>
                   <i class="fa fa-fw fa-tag"></i> <b>Groups:</b>


### PR DESCRIPTION
Second attempt... needed the other boogs fixed first plus found one and missed UI metas

* Use *pegjs* synchronously... I do have a portion of the routine for asynchronous *(done first)* but *(sync)* seems safer in the event of a production failure
* Establish the `OpenUserJS` metadata block and migrate all collaboration there
* Store localized `@name` and `@description`... not currently in use but available
* Some, but not all, line lengths in affected files wrapped according to STYLEGUIDE.md *(very partial in this redo)*
* If no script description don't create the `p` tag on script lists
* ~~Some stray trailing commas removed~~ Will mitigate this later
* ~~Some string constants shortened for error messages.. type 400 is Bad Request by standards and we shouldn't need to say that again.~~ Will mitigate this later
* Some DOC/UI changes to match

**NOTE**: Still needs *mongoose* DB migration otherwise all the meta values used don't show up

* Bumping project version... e.g. once the *mongoose* *(DB data)* migration occurs there is no going back to a prior project version otherwise there will be possible DB corruption/failures *(most notably the meta.js route)* in older commit HEADS

Applies to #285

---

After some slumber and rechecks the modified migration routine should be able to knock things out on production... however I will need to take it offline later this evening to do this.