### PR TITLE
*sanitize-html* now supports wildcard glob for `allowedAttributes`

### DIFF
--- a/libs/htmlWhitelistPost.json
+++ b/libs/htmlWhitelistPost.json
@@ -76,7 +76,7 @@
       "itemscope",
       "itemtype"
     ],
-    "all": [
+    "*": [
       "abbr",
       "accept",
       "accept-charset",

--- a/libs/markdown.js
+++ b/libs/markdown.js
@@ -18,20 +18,6 @@ var blockRenderers = [
   'paragraph',
   'table'
 ];
-var allWhitelistAttrs = htmlWhitelistPost.allowedAttributes.all;
-
-// Whitelist a bunch of attributes for all tags
-// Doing this until we have an upstream fix
-htmlWhitelistPost.allowedTags.forEach(function (aTag) {
-  var otherAttrs = htmlWhitelistPost.allowedAttributes[aTag];
-
-  htmlWhitelistPost.allowedAttributes[aTag] = allWhitelistAttrs;
-  if (otherAttrs) {
-    htmlWhitelistPost.allowedAttributes[aTag] = htmlWhitelistPost
-      .allowedAttributes[aTag].concat(otherAttrs);
-  }
-});
-delete htmlWhitelistPost.allowedAttributes.all;
 
 // Transform exact Github Flavored Markdown generated style tags to bootstrap custom classes
 // to allow the sanitizer to whitelist on th and td tags for table alignment

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "passport-yahoo": "0.3.0",
     "pegjs": "0.9.0",
     "request": "2.61.0",
-    "sanitize-html": "1.9.0",
+    "sanitize-html": "1.10.0",
     "select2": "3.5.2-browserify",
     "select2-bootstrap-css": "1.4.6",
     "serve-favicon": "2.3.0",


### PR DESCRIPTION
* Alter affected JSON by transforming `all` to `*` and removing code pertaining to `all`

Historical refs:
* #192

Tested on dev CI and referenced comment on local pro okay