### PR TITLE
Place the preferred engines at their bottom-most supported values

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,8 +68,8 @@
     "postinstall": "node dev/init.js"
   },
   "engines": {
-    "node": ">=0.12.0 <0.13.0",
-    "npm": ">=2.11.2"
+    "node": ">=0.12.7 <0.13.0",
+    "npm": ">=2.11.3"
   },
   "private": true
 }


### PR DESCRIPTION
* These will change in the next few months or so during the continued merging of *io.js* and *node* into it's final product
* *npm*3 is showing promise however may have some speed issues but *npm*2 is in LTS *(I assume that means limited technical support for that acronym but not 100% sure)*