### PR TITLE
Don't stringify on production for response

### DIFF
--- a/libs/repoManager.js
+++ b/libs/repoManager.js
@@ -39,7 +39,7 @@ function fetchRaw(aHost, aPath, aCallback) {
     function (aRes) {
 
       if (isDbg) {
-        console.log(JSON.stringify(aRes, null, ' '));
+        console.log(aRes);
       }
 
       var bufs = [];


### PR DESCRIPTION
``` sh-session
< POST /github/hook 200 6.583 ms - -
< /home/oujs/OpenUserJS.org1/libs/repoManager.js:42
<         console.log(JSON.stringify(aRes, null, ' '));
<                          ^
< TypeError: Converting circular structure to JSON
<     at Object.stringify (native)
<     at ClientRequest.<anonymous> (/home/oujs/OpenUserJS.org1/libs/repoManager.js:42:26)
<     at ClientRequest.g (events.js:199:16)
<     at ClientRequest.emit (events.js:107:17)
<     at HTTPParser.parserOnIncomingClient [as onIncoming] (_http_client.js:426:21)
<     at HTTPParser.parserOnHeadersComplete (_http_common.js:111:23)
<     at TLSSocket.socketOnData (_http_client.js:317:20)
<     at TLSSocket.emit (events.js:107:17)
<     at readableAddChunk (_stream_readable.js:163:16)
<     at TLSSocket.Readable.push (_stream_readable.js:126:10)
<     at TCP.onread (net.js:538:20)

```

Applies to #678