### PR TITLE
**Try** requesting UTF-16 and let GH do the transformation so *node* …

### DIFF
--- a/libs/repoManager.js
+++ b/libs/repoManager.js
@@ -31,7 +31,10 @@ function fetchRaw(aHost, aPath, aCallback) {
     path: aPath,
     method: 'GET',
     headers: {
-      'User-Agent': 'Node.js'
+      'User-Agent': 'Node.js',
+
+      // See #678
+      'Accept-Charset': 'UTF-16'
     }
   };
 


### PR DESCRIPTION
…keeps things consistent *hopefully*

* Using uppercase as mentioned at https://github.com/OpenUserJs/OpenUserJS.org/issues/198#issue-36413334

Applies to #678

Related to:
* #348 discovery
* #200
* #198