### PR TITLE
Try out StringDecoder

### DIFF
--- a/controllers/scriptStorage.js
+++ b/controllers/scriptStorage.js
@@ -340,8 +340,14 @@ exports.getMeta = function (aChunks, aCallback) {
   var blocksContent = {};
   var blocks = {};
 
+  // Define a local instance of this since it is node native
+  var StringDecoder = require('string_decoder').StringDecoder;
+
+  // Always enforce UTF-8
+  var decoder = new StringDecoder('utf8');
+
   for (; i < aChunks.length; ++i) {
-    str += aChunks[i];
+    str += decoder.write([aChunks[i]]);
 
     for (parser in parsers) {
       rHeaderContent = new RegExp(


### PR DESCRIPTION
* Casting to Array for chunk... this will keep the routine mostly the same... it does work on dev without creating the Array though mentioned in [the docs](https://nodejs.org/docs/latest-v0.12.x/api/string_decoder.html)
* Since the `require()` is __*node* native__ using a local instance... if 3 or more appears in this file make it module global
* Tested okay with Write/Edit, Upload and Import... webhook will need to be tested live on production

Applies to #678