### PR TITLE
Trying forced UTF8 in `toString`

### DIFF
--- a/controllers/scriptStorage.js
+++ b/controllers/scriptStorage.js
@@ -341,7 +341,7 @@ exports.getMeta = function (aChunks, aCallback) {
   var blocks = {};
 
   for (; i < aChunks.length; ++i) {
-    str += aChunks[i];
+    str += aChunks[i].toString('utf8');
 
     for (parser in parsers) {
       rHeaderContent = new RegExp(


### PR DESCRIPTION
* Since it appears that `Chunks` is an array of `Buffers` still have to cycle through.
* This may not cover the junk Unicode... but trying

Applies to #678