### PR TITLE
Correctly use Buffer length instead of String length for "Chunking"

### DIFF
--- a/controllers/scriptStorage.js
+++ b/controllers/scriptStorage.js
@@ -342,10 +342,10 @@ exports.getMeta = function (aBufs, aCallback) {
   var blocks = {};
 
   for (; i < aBufs.length; ++i) {
-    // Convert the current Buffer to a `String` and accumulate it's `String` totalLength
-    len += aBufs[i].toString('utf8').length; // NOTE: Watchpoint
+    // Accumulate the indexed Buffer length to use with `totalLength` parameter
+    len += aBufs[i].length;
 
-    // Read from the start of the Buffers to the `String` length end-point
+    // Read from the start of the Buffers to the Buffers length end-point
     // See also #678
     str = Buffer.concat(aBufs, len).toString('utf8');
 


### PR DESCRIPTION
* Thanks to *node* maintainer for the clarification at nodejs/node#3219 of Buffer length versus character length
* Retested on a User Script that contained a lot of Unicode characters in a comment at the beginning then the metadata blocks at the EOF... String.length fails to upload... Buffer length passes on upload with two "chunks"

Applies to #678