### PR TITLE
Add inverse filter list

### DIFF
--- a/controllers/group.js
+++ b/controllers/group.js
@@ -254,7 +254,7 @@ exports.view = function (aReq, aRes, aNext) {
 
       // Empty list
       options.scriptListIsEmptyMessage = 'No scripts.';
-      if (options.isFlagged) {
+      if (!!options.isFlagged) {
         if (options.librariesOnly) {
           options.scriptListIsEmptyMessage = 'No flagged libraries.';
         } else {

--- a/controllers/index.js
+++ b/controllers/index.js
@@ -116,7 +116,7 @@ exports.home = function (aReq, aRes) {
 
     // Empty list
     options.scriptListIsEmptyMessage = 'No scripts.';
-    if (options.isFlagged) {
+    if (!!options.isFlagged) {
       if (options.librariesOnly) {
         options.scriptListIsEmptyMessage = 'No flagged libraries.';
       } else {
@@ -134,13 +134,13 @@ exports.home = function (aReq, aRes) {
 
     // Heading
     if (options.librariesOnly) {
-      options.pageHeading = options.isFlagged ? 'Flagged Libraries' : 'Libraries';
+      options.pageHeading = !!options.isFlagged ? 'Flagged Libraries' : 'Libraries';
     } else {
-      options.pageHeading = options.isFlagged ? 'Flagged Scripts' : 'Scripts';
+      options.pageHeading = !!options.isFlagged ? 'Flagged Scripts' : 'Scripts';
     }
 
     // Page metadata
-    if (options.isFlagged) {
+    if (!!options.isFlagged) {
       if (options.librariesOnly) {
         pageMetadata(options, ['Flagged Libraries', 'Moderation']);
       } else {
@@ -155,7 +155,7 @@ exports.home = function (aReq, aRes) {
 
     async.parallel([
       function (aCallback) {
-        if (!options.isFlagged || !options.isAdmin) {  // NOTE: Watchpoint
+        if (!!!options.isFlagged || !options.isAdmin) {  // NOTE: Watchpoint
           aCallback();
           return;
         }

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -223,17 +223,17 @@ exports.userListPage = function (aReq, aRes, aNext) {
 
     // Empty list
     options.userListIsEmptyMessage = 'No users.';
-    if (options.isFlagged) {
+    if (!!options.isFlagged) {
       options.userListIsEmptyMessage = 'No flagged users.';
     } else if (options.searchBarValue) {
       options.userListIsEmptyMessage = 'We couldn\'t find any users by this name.';
     }
 
     // Heading
-    options.pageHeading = options.isFlagged ? 'Flagged Users' : 'Users';
+    options.pageHeading = !!options.isFlagged ? 'Flagged Users' : 'Users';
 
     // Page metadata
-    if (options.isFlagged) {
+    if (!!options.isFlagged) {
       pageMetadata(options, ['Flagged Users', 'Moderation']);
     }
   }
@@ -248,7 +248,7 @@ exports.userListPage = function (aReq, aRes, aNext) {
 
     async.parallel([
       function (aCallback) {
-        if (!options.isFlagged || !options.isAdmin) {  // NOTE: Watchpoint
+        if (!!!options.isFlagged || !options.isAdmin) {  // NOTE: Watchpoint
           aCallback();
           return;
         }
@@ -524,7 +524,7 @@ exports.userScriptListPage = function (aReq, aRes, aNext) {
 
       // Empty list
       options.scriptListIsEmptyMessage = 'No scripts.';
-      if (options.isFlagged) {
+      if (!!options.isFlagged) {
         if (options.librariesOnly) {
           options.scriptListIsEmptyMessage = 'No flagged libraries.';
         } else {
@@ -547,7 +547,7 @@ exports.userScriptListPage = function (aReq, aRes, aNext) {
 
       async.parallel([
         function (aCallback) {
-          if (!options.isFlagged || !options.isAdmin) {  // NOTE: Watchpoint
+          if (!!!options.isFlagged || !options.isAdmin) {  // NOTE: Watchpoint
             aCallback();
             return;
           }

--- a/views/includes/flagAdminToolFlaggedFilters.html
+++ b/views/includes/flagAdminToolFlaggedFilters.html
@@ -1,0 +1,6 @@
+<h3>Filters</h3>
+<div class="list-group">
+  <a class="list-group-item list-group-item-info" href="?flagged=none{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}"><i class="fa fa-fw fa-times"></i> Clear Filter</a>
+  <a class="list-group-item{{#filterCritical}} active{{/filterCritical}}" href="?flagged=critical{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}"><i class="fa fa-fw fa-flag-o"></i> Critical Flags</a>
+  <a class="list-group-item{{#filterAbsolute}} active{{/filterAbsolute}}" href="?flagged=absolute{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}"><i class="fa fa-fw fa-flag"></i> Absolute Flags</a>
+</div>

--- a/views/includes/scriptList.html
+++ b/views/includes/scriptList.html
@@ -1,10 +1,10 @@
 <table class="table table-hover">
   <thead>
     <tr>
-      <th class="text-center"><a href="?orderBy=name&orderDir={{orderDir.name}}{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}{{#librariesOnly}}&library=true{{/librariesOnly}}{{#isFlagged}}&flagged=true{{/isFlagged}}">Name</a></th>
-      {{^librariesOnly}}<th class="text-center td-fit"><a href="?orderBy=installs&orderDir={{orderDir.install}}{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}{{#isFlagged}}&flagged=true{{/isFlagged}}">Installs</a></th>{{/librariesOnly}}
-      <th class="text-center td-fit"><a href="?orderBy=rating&orderDir={{orderDir.rating}}{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}{{#librariesOnly}}&library=true{{/librariesOnly}}{{#isFlagged}}&flagged=true{{/isFlagged}}">Rating</a></th>
-      <th class="text-center td-fit"><a href="?orderBy=updated&orderDir={{orderDir.updated}}{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}{{#librariesOnly}}&library=true{{/librariesOnly}}{{#isFlagged}}&flagged=true{{/isFlagged}}">Last Updated</a></th>
+      <th class="text-center"><a href="?orderBy=name&orderDir={{orderDir.name}}{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}{{#librariesOnly}}&library=true{{/librariesOnly}}{{#isFlagged}}&flagged={{isFlagged}}{{/isFlagged}}">Name</a></th>
+      {{^librariesOnly}}<th class="text-center td-fit"><a href="?orderBy=installs&orderDir={{orderDir.install}}{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}{{#isFlagged}}&flagged={{isFlagged}}{{/isFlagged}}">Installs</a></th>{{/librariesOnly}}
+      <th class="text-center td-fit"><a href="?orderBy=rating&orderDir={{orderDir.rating}}{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}{{#librariesOnly}}&library=true{{/librariesOnly}}{{#isFlagged}}&flagged={{isFlagged}}{{/isFlagged}}">Rating</a></th>
+      <th class="text-center td-fit"><a href="?orderBy=updated&orderDir={{orderDir.updated}}{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}{{#librariesOnly}}&library=true{{/librariesOnly}}{{#isFlagged}}&flagged={{isFlagged}}{{/isFlagged}}">Last Updated</a></th>
       {{#hasFlagged}}
       <th>Flagged</th>
       {{/hasFlagged}}

--- a/views/includes/userList.html
+++ b/views/includes/userList.html
@@ -1,8 +1,8 @@
 <table class="table table-hover table-condensed">
   <thead>
     <tr>
-      <th><a href="?orderBy=name&orderDir={{orderDir.name}}{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}{{#isFlagged}}&flagged=true{{/isFlagged}}">Name</a></th>
-      <th class="td-fit"><a href="?orderBy=role&orderDir={{orderDir.role}}{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}{{#isFlagged}}&flagged=true{{/isFlagged}}">Rank</a></th>
+      <th><a href="?orderBy=name&orderDir={{orderDir.name}}{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}{{#isFlagged}}&flagged={{isFlagged}}{{/isFlagged}}">Name</a></th>
+      <th class="td-fit"><a href="?orderBy=role&orderDir={{orderDir.role}}{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}{{#isFlagged}}&flagged={{isFlagged}}{{/isFlagged}}">Rank</a></th>
       {{#hasFlagged}}
       <th>Flagged</th>
       {{/hasFlagged}}

--- a/views/pages/modPage.html
+++ b/views/pages/modPage.html
@@ -12,13 +12,13 @@
         <h3>Flagged Items</h3>
         <p>These are items over their threshold.</p>
         <div class="list-group">
-          <a href="/?flagged=true" class="list-group-item">
+          <a href="/?flagged={{#isAdmin}}critical{{/isAdmin}}{{^isAdmin}}true{{/isAdmin}}" class="list-group-item">
             <i class="fa fa-fw fa-file-code-o"></i> <i class="fa fa-fw fa-flag"></i> Flagged Scripts
           </a>
-          <a href="/?library=true&flagged=true" class="list-group-item">
+          <a href="/?library=true&flagged={{#isAdmin}}critical{{/isAdmin}}{{^isAdmin}}true{{/isAdmin}}" class="list-group-item">
             <i class="fa fa-fw fa-file-excel-o"></i> <i class="fa fa-fw fa-flag"></i> Flagged Libraries
           </a>
-          <a href="/users?flagged=true" class="list-group-item">
+          <a href="/users?flagged={{#isAdmin}}critical{{/isAdmin}}{{^isAdmin}}true{{/isAdmin}}" class="list-group-item">
             <i class="fa fa-fw fa-user"></i> <i class="fa fa-fw fa-flag"></i> Flagged Users
           </a>
         </div>

--- a/views/pages/scriptListPage.html
+++ b/views/pages/scriptListPage.html
@@ -28,6 +28,11 @@
       </div>
       <div class="col-sm-4">
         {{> includes/searchBarPanel.html }}
+        {{#isFlagged}}
+          {{#isAdmin}}
+            {{> includes/flagAdminToolFlaggedFilters.html }}
+          {{/isAdmin}}
+        {{/isFlagged}}
         {{> includes/popularGroupsPanel.html }}
         {{> includes/announcementsPanel.html }}
       </div>

--- a/views/pages/userListPage.html
+++ b/views/pages/userListPage.html
@@ -28,6 +28,11 @@
       </div>
       <div class="col-sm-4">
         {{> includes/searchBarPanel.html }}
+        {{#isFlagged}}
+          {{#isAdmin}}
+            {{> includes/flagAdminToolFlaggedFilters.html }}
+          {{/isAdmin}}
+        {{/isFlagged}}
       </div>
     </div>
   </div>

--- a/views/pages/userScriptListPage.html
+++ b/views/pages/userScriptListPage.html
@@ -30,6 +30,11 @@
       </div>
       <div class="container-fluid col-sm-4">
         {{> includes/searchBarPanel.html }}
+        {{#isFlagged}}
+          {{#isAdmin}}
+            {{> includes/flagAdminToolFlaggedFilters.html }}
+          {{/isAdmin}}
+        {{/isFlagged}}
         {{> includes/userStatsPanel.html }}
       </div>
     </div>


### PR DESCRIPTION
* Convert `flagged` to a multi-state QSP instead of **just** `true`/`false` for the inverse filter ... depends on role
* Coerce conditionals to indicate that one is testing `true`/`false` but the value is not necessarily expected to be those
* Modify affected views
* Create a sub view e.g. includes view to reuse some view code for the "Filters"

**NOTES**
* More to go but this is the stepping stone for Option 4a

Applies to #641

Tested on dev and local pro