### PR TITLE
Enable the missing `library` QSP on User home pages

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -474,6 +474,8 @@ exports.userScriptListPage = function (aReq, aRes, aNext) {
     var user = options.user = modelParser.parseUser(aUserData);
     options.isYou = authedUser && user && authedUser._id == user._id;
 
+    options.librariesOnly = aReq.query.library !== undefined;
+
     // Page metadata
     pageMetadata(options, [user.name, 'Users']);
     options.isUserScriptListPage = true;
@@ -490,14 +492,25 @@ exports.userScriptListPage = function (aReq, aRes, aNext) {
     // scriptListQuery: author=user
     scriptListQuery.find({ _authorId: user._id });
 
+
     // scriptListQuery: Defaults
-    modelQuery.applyScriptListQueryDefaults(scriptListQuery, options, aReq);
+    if (options.librariesOnly) {
+      // scriptListQuery: isLib
+      modelQuery.findOrDefaultToNull(scriptListQuery, 'isLib', options.librariesOnly, false);
+
+      // Libraries
+      modelQuery.applyLibraryListQueryDefaults(scriptListQuery, options, aReq);
+    } else {
+      // Scripts (all including libraries)
+      modelQuery.applyScriptListQueryDefaults(scriptListQuery, options, aReq);
+    }
 
     // scriptListQuery: Pagination
     var pagination = options.pagination; // is set in modelQuery.apply___ListQueryDefaults
 
     // SearchBar
-    options.searchBarPlaceholder = 'Search Scripts from ' + user.name;
+    options.searchBarPlaceholder = 'Search ' +
+      (options.librariesOnly ? 'Libraries' : 'Scripts') + ' from ' + user.name;
     options.searchBarFormAction = '';
 
     //--- Tasks

--- a/libs/modelQuery.js
+++ b/libs/modelQuery.js
@@ -306,7 +306,7 @@ exports.applyGroupListQueryDefaults = function (aGroupListQuery, aOptions, aReq)
 var scriptListQueryDefaults = {
   defaultSort: '-rating -installs -updated',
   parseSearchQueryFn: parseScriptSearchQuery,
-  searchBarPlaceholder: 'Search Scripts',
+  searchBarPlaceholder: 'Search Userscripts',
   searchBarFormAction: '/',
   filterFlaggedItems: true
 };

--- a/public/xml/opensearch-userscripts.xml
+++ b/public/xml/opensearch-userscripts.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
-  <Description>Search OpenUserJS Scripts</Description>
-  <ShortName>OpenUserJS Scripts</ShortName>
+  <Description>Search OpenUserJS Userscripts</Description>
+  <ShortName>OpenUserJS Userscripts</ShortName>
   <Url type="text/html"
        method="get"
        template="https://openuserjs.org/?q={searchTerms}" />

--- a/views/includes/head.html
+++ b/views/includes/head.html
@@ -8,7 +8,7 @@
 <!-- Open Search -->
 <link href="/xml/opensearch-groups.xml" type="application/opensearchdescription+xml" rel="search" title="OpenUserJS Groups">
 <link href="/xml/opensearch-libraries.xml" type="application/opensearchdescription+xml" rel="search" title="OpenUserJS Libraries">
-<link href="/xml/opensearch-scripts.xml" type="application/opensearchdescription+xml" rel="search" title="OpenUserJS Scripts">
+<link href="/xml/opensearch-userscripts.xml" type="application/opensearchdescription+xml" rel="search" title="OpenUserJS Userscripts">
 <link href="/xml/opensearch-users.xml" type="application/opensearchdescription+xml" rel="search" title="OpenUserJS Users">
 
 <!-- CSS -->

--- a/views/includes/header.html
+++ b/views/includes/header.html
@@ -2,13 +2,13 @@
   <div class="container-fluid">
     <div class="navbar-header">
       <button type="button" data-toggle="collapse" data-target=".navbar-collapse-top" class="navbar-toggle"><i class="fa fa-bars"></i></button>
-      <a href="/" class="navbar-brand" title="A Userscripts Repository">OpenUserJS<span class="mode">{{#isDbg}}dbg {{/isDbg}}{{#isDev}}dev{{/isDev}}</span></a>
+      <a href="/" class="navbar-brand" title="A Presentational Userscripts Repository">OpenUserJS<span class="mode">{{#isDbg}}dbg {{/isDbg}}{{#isDev}}dev{{/isDev}}</span></a>
     </div>
     <div class="navbar-collapse navbar-collapse-top collapse">
       <ul class="nav navbar-nav navbar-right">
-        <li><a href="/" title="Scripts"><span class="visible-xs-inline"><i class="fa fa-file-code-o"></i> </span>Scripts</a></li>
-        <li><a href="/?library=true" title="Script Libraries"><span class="visible-xs-inline"><i class="fa fa-file-excel-o"></i> </span>Libraries</a></li>
-        <li><a href="/groups" title="Script Groups"><span class="visible-xs-inline"><i class="fa fa-tag"></i> </span>Groups</a></li>
+        <li><a href="/" title="Userscripts"><span class="visible-xs-inline"><i class="fa fa-file-code-o"></i> </span>Userscripts</a></li>
+        <li><a href="/?library=true" title="Libraries"><span class="visible-xs-inline"><i class="fa fa-file-excel-o"></i> </span>Libraries</a></li>
+        <li><a href="/groups" title="Userscript Groups"><span class="visible-xs-inline"><i class="fa fa-tag"></i> </span>Groups</a></li>
         <li><a href="/forum"><span class="visible-xs-inline"><i class="fa fa-commenting"></i> </span>Discussions</a></li>
         <li><a href="/users"><span class="visible-xs-inline"><i class="fa fa-user"></i> </span>Users</a></li>
         {{#authedUser}}


### PR DESCRIPTION
* User script lists by default still show both Userscripts and Libraries as designed
* The overall flow of the project has been to separate Userscripts from Libraries unless on a Users home page... putting this a little clearer will help other understand... also won't hurt our SEO rating and will help clarify when people try to upload a library script instead of Userscript.
* Groups only handle Userscripts so denote that in the tooltip
* This is breaking from USO tradition but I think it's time to give that some rest

Needed for maintaining the logic of QSP's *(some hidden)* with #643 and loosely #547 and post #383, #372, #254 and probably more