### PR TITLE
Finish enabling hidden QSP in User Script List pages

### DIFF
--- a/controllers/index.js
+++ b/controllers/index.js
@@ -136,7 +136,7 @@ exports.home = function (aReq, aRes) {
     if (options.librariesOnly) {
       options.pageHeading = !!options.isFlagged ? 'Flagged Libraries' : 'Libraries';
     } else {
-      options.pageHeading = !!options.isFlagged ? 'Flagged Scripts' : 'Scripts';
+      options.pageHeading = !!options.isFlagged ? 'Flagged Userscripts' : 'Scripts';
     }
 
     // Page metadata
@@ -144,7 +144,7 @@ exports.home = function (aReq, aRes) {
       if (options.librariesOnly) {
         pageMetadata(options, ['Flagged Libraries', 'Moderation']);
       } else {
-        pageMetadata(options, ['Flagged Scripts', 'Moderation']);
+        pageMetadata(options, ['Flagged Userscripts', 'Moderation']);
       }
     }
   }

--- a/views/includes/flagAdminToolFlaggedFilters.html
+++ b/views/includes/flagAdminToolFlaggedFilters.html
@@ -1,6 +1,13 @@
 <h3>Filters</h3>
 <div class="list-group">
-  <a class="list-group-item list-group-item-info" href="?flagged=none{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}{{#librariesOnly}}&library=true{{/librariesOnly}}"><i class="fa fa-fw fa-times"></i> Clear Filter</a>
-  <a class="list-group-item{{#filterCritical}} active{{/filterCritical}}" href="?flagged=critical{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}{{#librariesOnly}}&library=true{{/librariesOnly}}"><i class="fa fa-fw fa-flag-o"></i> Critical Flags</a>
-  <a class="list-group-item{{#filterAbsolute}} active{{/filterAbsolute}}" href="?flagged=absolute{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}{{#librariesOnly}}&library=true{{/librariesOnly}}"><i class="fa fa-fw fa-flag"></i> Absolute Flags</a>
+  {{#isUserScriptListPage}}
+    <a class="list-group-item list-group-item-info" href="?flagged=none{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}{{#includeLibraries}}&library=true{{/includeLibraries}}{{#excludeLibraries}}&library=false{{/excludeLibraries}}"><i class="fa fa-fw fa-times"></i> Clear Filter</a>
+    <a class="list-group-item{{#filterCritical}} active{{/filterCritical}}" href="?flagged=critical{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}{{#includeLibraries}}&library=true{{/includeLibraries}}{{#excludeLibraries}}&library=false{{/excludeLibraries}}"><i class="fa fa-fw fa-flag-o"></i> Critical Flags</a>
+    <a class="list-group-item{{#filterAbsolute}} active{{/filterAbsolute}}" href="?flagged=absolute{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}{{#includeLibraries}}&library=true{{/includeLibraries}}{{#excludeLibraries}}&library=false{{/excludeLibraries}}"><i class="fa fa-fw fa-flag"></i> Absolute Flags</a>
+  {{/isUserScriptListPage}}
+  {{^isUserScriptListPage}}
+    <a class="list-group-item list-group-item-info" href="?flagged=none{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}{{#librariesOnly}}&library=true{{/librariesOnly}}"><i class="fa fa-fw fa-times"></i> Clear Filter</a>
+    <a class="list-group-item{{#filterCritical}} active{{/filterCritical}}" href="?flagged=critical{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}{{#librariesOnly}}&library=true{{/librariesOnly}}"><i class="fa fa-fw fa-flag-o"></i> Critical Flags</a>
+    <a class="list-group-item{{#filterAbsolute}} active{{/filterAbsolute}}" href="?flagged=absolute{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}{{#librariesOnly}}&library=true{{/librariesOnly}}"><i class="fa fa-fw fa-flag"></i> Absolute Flags</a>
+  {{/isUserScriptListPage}}
 </div>

--- a/views/pages/modPage.html
+++ b/views/pages/modPage.html
@@ -13,7 +13,7 @@
         <p>These are items over their threshold.</p>
         <div class="list-group">
           <a href="/?flagged={{#isAdmin}}critical{{/isAdmin}}{{^isAdmin}}true{{/isAdmin}}" class="list-group-item">
-            <i class="fa fa-fw fa-file-code-o"></i> <i class="fa fa-fw fa-flag"></i> Flagged Scripts
+            <i class="fa fa-fw fa-file-code-o"></i> <i class="fa fa-fw fa-flag"></i> Flagged Userscripts
           </a>
           <a href="/?library=true&flagged={{#isAdmin}}critical{{/isAdmin}}{{^isAdmin}}true{{/isAdmin}}" class="list-group-item">
             <i class="fa fa-fw fa-file-excel-o"></i> <i class="fa fa-fw fa-flag"></i> Flagged Libraries


### PR DESCRIPTION
* Turns `library` into a tri-state, but only on User Script List pages
* Missed a few labels too in #777
* Commented it as much as I can for clarity for those not familiar with multi-state QSP's
* Kept the view duplicated for clarity... does make twice the management task but this should be low-maintenance e.g. won't change much

Post #643