### PR TITLE
Some missed `Scripts` to `Userscripts`

### DIFF
--- a/controllers/index.js
+++ b/controllers/index.js
@@ -136,7 +136,7 @@ exports.home = function (aReq, aRes) {
     if (options.librariesOnly) {
       options.pageHeading = !!options.isFlagged ? 'Flagged Libraries' : 'Libraries';
     } else {
-      options.pageHeading = !!options.isFlagged ? 'Flagged Userscripts' : 'Scripts';
+      options.pageHeading = !!options.isFlagged ? 'Flagged Userscripts' : 'Userscripts';
     }
 
     // Page metadata

--- a/controllers/issue.js
+++ b/controllers/issue.js
@@ -92,7 +92,7 @@ exports.list = function (aReq, aRes, aNext) {
       [
         (options.allIssues ? 'All' : (open ? 'Open' : 'Closed')) + ' Issues',
         script.name,
-        (script.isLib ? 'Libraries' : 'Scripts')
+        (script.isLib ? 'Libraries' : 'Userscripts')
       ],
       category.description);
 

--- a/controllers/script.js
+++ b/controllers/script.js
@@ -317,7 +317,7 @@ exports.view = function (aReq, aRes, aNext) {
   }, function (aErr, aScriptData) {
     function preRender() {
       if (script.groups) {
-        pageMetadata(options, ['About', script.name, (script.isLib ? 'Libraries' : 'Scripts')],
+        pageMetadata(options, ['About', script.name, (script.isLib ? 'Libraries' : 'Userscripts')],
           script.description, _.pluck(script.groups, 'name'));
       }
     }
@@ -363,7 +363,7 @@ exports.view = function (aReq, aRes, aNext) {
       script.scriptInstallPageUrl;
 
     // Page metadata
-    pageMetadata(options, ['About', script.name, (script.isLib ? 'Libraries' : 'Scripts')],
+    pageMetadata(options, ['About', script.name, (script.isLib ? 'Libraries' : 'Userscripts')],
       script.description);
     options.isScriptPage = true;
 
@@ -423,7 +423,7 @@ exports.edit = function (aReq, aRes, aNext) {
     // Page metadata
     var script = options.script = modelParser.parseScript(aScriptData);
     options.isOwner = authedUser && authedUser._id == script._authorId;
-    pageMetadata(options, ['Edit', script.name, (script.isLib ? 'Libraries' : 'Scripts')],
+    pageMetadata(options, ['Edit', script.name, (script.isLib ? 'Libraries' : 'Userscripts')],
       script.name);
 
     // If authed user is not the script author.

--- a/views/includes/userStatsPanel.html
+++ b/views/includes/userStatsPanel.html
@@ -10,7 +10,7 @@
     <dl class="dl-horizontal">
       <dt>Member since</dt>
       <dd><time datetime="{{user._sinceISOFormat}}" title="{{user._since}}">{{user._sinceHumanized}}</time></dd>
-      <dt>Number of scripts</dt>
+      <dt>Number of userscripts</dt>
       <dd>{{stats.totalScripts}}</dd>
       <dt>Number of libraries</dt>
       <dd>{{stats.totalLibs}}</dd>

--- a/views/pages/scriptPage.html
+++ b/views/pages/scriptPage.html
@@ -86,7 +86,7 @@
         {{#script.isUsed}}
         <div class="panel panel-default">
           <div class="panel-body">
-            <h4>Scripts Using This Library</h4>
+            <h4>Userscripts Using This Library</h4>
             <ul>
             {{#script.usedBy}}
               <li>


### PR DESCRIPTION
* Internal code should be okay with `Script`... notice thats not plural

Applies to #643 

---

Hope this is all of them... lots of these buggahs.