### PR TITLE
Added reason to any current flagging with a *bootstrap* modal

### DIFF
--- a/controllers/remove.js
+++ b/controllers/remove.js
@@ -16,23 +16,24 @@ var statusCodePage = require('../libs/templateHelpers').statusCodePage;
 
 // Simple controller to remove content and save it in the graveyard
 exports.rm = function (aReq, aRes, aNext) {
-  var type = aReq.params[0];
-  var path = aReq.params[1];
-  var authedUser = aReq.session.user;
-
   var form = null;
 
   // Check to make sure multipart form data submission header is present
   if (!/multipart\/form-data/.test(aReq.headers['content-type'])) {
-      return statusCodePage(aReq, aRes, aNext, {
-        statusCode: 400,
-        statusMessage: 'Missing required header.'
-      });
+    return statusCodePage(aReq, aRes, aNext, {
+      statusCode: 400,
+      statusMessage: 'Missing required header.'
+    });
   }
 
   form = new formidable.IncomingForm();
   form.parse(aReq, function (aErr, aFields) {
     var reason = aFields.reason;
+
+    var type = aReq.params[0];
+    var path = aReq.params[1];
+
+    var authedUser = aReq.session.user;
 
     // Check to make sure form submission has this name available.
     // This occurs either when no reason is supplied,

--- a/controllers/script.js
+++ b/controllers/script.js
@@ -224,8 +224,6 @@ var getScriptPageTasks = function (aOptions) {
 
   // Setup the flagging UI
   tasks.push(function (aCallback) {
-    var flagUrl = '/flag' + (script.isLib ? '/libs/' : '/scripts/') + script.installNameSlug;
-
     // Can't flag when not logged in or when user owns the script.
     if (!authedUser || aOptions.isOwner) {
       aCallback();
@@ -235,13 +233,11 @@ var getScriptPageTasks = function (aOptions) {
     flagLib.flaggable(Script, script, authedUser,
       function (aCanFlag, aAuthor, aFlag) {
         if (aFlag) {
-          flagUrl += '/unflag';
           aOptions.flagged = true;
           aOptions.canFlag = true;
         } else {
           aOptions.canFlag = aCanFlag;
         }
-        aOptions.flagUrl = flagUrl;
 
         aCallback();
       });
@@ -549,27 +545,6 @@ exports.vote = function (aReq, aRes, aNext) {
           aVoteModel.save(saveScript);
         }
       );
-    }
-  );
-};
-
-// Script flagging
-exports.flag = function (aReq, aRes, aNext) {
-  var isLib = aReq.params.isLib;
-  var installName = scriptStorage.getInstallName(aReq);
-  var unflag = aReq.params.unflag;
-
-  Script.findOne({ installName:  scriptStorage
-      .caseSensitive(installName + (isLib ? '.js' : '.user.js')) },
-    function (aErr, aScript) {
-      var fn = flagLib[unflag && unflag === 'unflag' ? 'unflag' : 'flag'];
-      if (aErr || !aScript) {
-        return aNext();
-      }
-
-      fn(Script, aScript, aReq.session.user, function (aFlagged) { // NOTE: Inline function here
-        aRes.redirect((isLib ? '/libs/' : '/scripts/') + encodeURI(installName));
-      });
     }
   );
 };

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -60,8 +60,6 @@ var setupUserModerationUITask = function (aOptions) {
   aOptions.flags = '\u2013';
 
   return function (aCallback) {
-    var flagUrl = '/flag/users/' + user.name;
-
     // Can't flag when not logged in or when is authedUser.
     if (!authedUser || aOptions.isYou) {
       aCallback();
@@ -69,13 +67,11 @@ var setupUserModerationUITask = function (aOptions) {
     }
     flagLib.flaggable(User, user, authedUser, function (aCanFlag, aAuthor, aFlag) {
       if (aFlag) {
-        flagUrl += '/unflag';
         aOptions.flagged = true;
         aOptions.canFlag = true;
       } else {
         aOptions.canFlag = aCanFlag;
       }
-      aOptions.flagUrl = flagUrl;
 
       removeLib.removeable(User, user, authedUser, function (aCanRemove, aAuthor) {
         aOptions.canRemove = aCanRemove;
@@ -1498,19 +1494,4 @@ exports.editScript = function (aReq, aRes, aNext) {
       aRes.render('pages/scriptViewSourcePage', options);
     });
   }
-};
-
-// route to flag a user
-exports.flag = function (aReq, aRes, aNext) {
-  var username = aReq.params.username;
-  var unflag = aReq.params.unflag;
-
-  User.findOne({ name: username }, function (aErr, aUser) {
-    var fn = flagLib[unflag && unflag === 'unflag' ? 'unflag' : 'flag'];
-    if (aErr || !aUser) { return aNext(); }
-
-    fn(User, aUser, aReq.session.user, function (aFlagged) { // NOTE: Inline function here
-      aRes.redirect('/users/' + encodeURI(username));
-    });
-  });
 };

--- a/libs/flag.js
+++ b/libs/flag.js
@@ -139,11 +139,12 @@ function saveContent(aModel, aContent, aAuthor, aFlags, aCallback) {
 }
 exports.saveContent = saveContent;
 
-function flag(aModel, aContent, aUser, aAuthor, aCallback) {
+function flag(aModel, aContent, aUser, aAuthor, aReason, aCallback) {
   var flag = new Flag({
     'model': aModel.modelName,
     '_contentId': aContent._id,
-    '_userId': aUser._id
+    '_userId': aUser._id,
+    'reason': aReason
   });
 
   flag.save(function (aErr, aFlag) {
@@ -159,22 +160,28 @@ function flag(aModel, aContent, aUser, aAuthor, aCallback) {
       aContent.flags.absolute = 0;
     }
 
-    if (!aContent.flagged) { aContent.flagged = false; }
+    if (!aContent.flagged) {
+      aContent.flagged = false;
+    }
 
     saveContent(aModel, aContent, aAuthor, aUser.role < 4 ? 2 : 1, aCallback);
   });
 }
 
-exports.flag = function (aModel, aContent, aUser, aCallback) {
+exports.flag = function (aModel, aContent, aUser, aReason, aCallback) {
   flaggable(aModel, aContent, aUser, function (aCanFlag, aAuthor) {
-    if (!aCanFlag) { return aCallback(false); }
+    if (!aCanFlag) {
+      return aCallback(false);
+    }
 
-    flag(aModel, aContent, aUser, aAuthor, aCallback);
+    flag(aModel, aContent, aUser, aAuthor, aReason, aCallback);
   });
 };
 
-exports.unflag = function (aModel, aContent, aUser, aCallback) {
-  if (!aUser) { return aCallback(null); }
+exports.unflag = function (aModel, aContent, aUser, aReason, aCallback) {
+  if (!aUser) {
+    return aCallback(null);
+  }
 
   getFlag(aModel, aContent, aUser, function (aFlag) {
     if (!aFlag) {
@@ -193,7 +200,9 @@ exports.unflag = function (aModel, aContent, aUser, aCallback) {
       aContent.flags.absolute = 0;
     }
 
-    if (!aContent.flagged) { aContent.flagged = false; }
+    if (!aContent.flagged) {
+      aContent.flagged = false;
+    }
 
     function removeFlag(aAuthor) {
       aFlag.remove(function (aErr) {

--- a/libs/modelParser.js
+++ b/libs/modelParser.js
@@ -216,6 +216,7 @@ var parseScript = function (aScriptData) {
 
   // Urls: Moderation
   script.scriptRemovePageUrl = '/remove' + (script.isLib ? '/libs/' : '/scripts/') + script.installNameSlug;
+  script.scriptFlagPageUrl = '/flag' + (script.isLib ? '/libs/' : '/scripts/') + script.installNameSlug;
 
   // Dates
   parseDateProperty(script, 'updated');
@@ -268,6 +269,7 @@ var parseUser = function (aUserData) {
   user.userEditProfilePageUrl = user.userPageUrl + '/profile/edit';
   user.userUpdatePageUrl = user.userPageUrl + '/update';
   user.userRemovePageUrl = '/remove/users/' + user.name;
+  user.userFlagPageUrl = '/flag/users/' + user.name;
 
   // Funcs
   user.githubUserId = function () {

--- a/routes.js
+++ b/routes.js
@@ -11,6 +11,7 @@ var authentication = require('./controllers/auth');
 var admin = require('./controllers/admin');
 var user = require('./controllers/user');
 var script = require('./controllers/script');
+var flag = require('./controllers/flag');
 var remove = require('./controllers/remove');
 var moderation = require('./controllers/moderation');
 var group = require('./controllers/group');
@@ -110,10 +111,7 @@ module.exports = function (aApp) {
   aApp.route('/vote/libs/:username/:scriptname/:vote').get(authentication.validateUser, script.lib(script.vote));
 
   // Flag routes
-  // TODO: Single flag route + POST
-  aApp.route('/flag/users/:username/:unflag?').get(user.flag);
-  aApp.route('/flag/scripts/:username/:scriptname/:unflag?').get(script.flag);
-  aApp.route('/flag/libs/:username/:scriptname/:unflag?').get(script.lib(script.flag));
+  aApp.route(/^\/flag\/(users|scripts|libs)\/((.+?)(?:\/(.+))?)$/).post(flag.flag);
 
   // Remove route
   aApp.route(/^\/remove\/(.+?)\/(.+)$/).post(remove.rm);

--- a/views/includes/scriptModals.html
+++ b/views/includes/scriptModals.html
@@ -9,8 +9,10 @@
         <p>Are you sure you want to flag this script for potential inspection by a Moderator?</p>
       </div>
       <div class="modal-footer">
-        <form action="{{{flagUrl}}}" method="get">
+        <form action="{{{script.scriptFlagPageUrl}}}" method="post" enctype="multipart/form-data">
+          <input type="text" class="form-control" name="reason" placeholder="Reason for removal.">
           <button type="button" class="btn btn-default" data-dismiss="modal"><i class="fa fa-fw fa-close"></i> Close</button>
+          <input type="hidden" name="flag" value="true">
           <button type="submit" class="btn btn-danger{{^canFlag}} disabled{{/canFlag}}"><i class="fa fa-fw fa-flag"></i> Flag</button>
         </form>
       </div>

--- a/views/includes/scriptUserToolsPanel.html
+++ b/views/includes/scriptUserToolsPanel.html
@@ -12,12 +12,19 @@
       </div>
     </div>
     <ul class="nav nav-pills nav-justified">
-      {{#flagged}}
-        <li><a rel="nofollow" href="{{{flagUrl}}}" class="{{^canFlag}}disabled{{/canFlag}}"><i class="fa fa-flag"></i> Unflag</a></li>
-      {{/flagged}}
-      {{^flagged}}
-        <li><a rel="nofollow" href="#" data-toggle="modal" data-target="#flagScriptModal" class="{{^canFlag}}disabled{{/canFlag}}"><i class="fa fa-flag-o"></i> Flag</a></li>
-      {{/flagged}}
+      <li>
+        <div class="text-center">
+          {{#flagged}}
+          <form action="{{{script.scriptFlagPageUrl}}}" method="post" enctype="multipart/form-data">
+            <input type="hidden" name="flag" value="false">
+            <button class="btn btn-link" type="submit" class="{{^canFlag}} disabled{{/canFlag}}"><i class="fa fa-fw fa-flag"></i> Unflag</button>
+          </form>
+          {{/flagged}}
+          {{^flagged}}
+          <a rel="nofollow" href="#" data-toggle="modal" data-target="#flagScriptModal" class="{{^canFlag}}disabled{{/canFlag}}"><i class="fa fa-flag-o"></i> Flag</a>
+          {{/flagged}}
+        </div>
+      </li>
     </ul>
   </div>
 </div>

--- a/views/includes/userModals.html
+++ b/views/includes/userModals.html
@@ -9,8 +9,10 @@
         <p>Are you sure you want to flag this user for potential inspection by a Moderator?</p>
       </div>
       <div class="modal-footer">
-        <form action="{{{flagUrl}}}" method="get">
+        <form action="{{{user.userFlagPageUrl}}}" method="post" enctype="multipart/form-data">
+          <input type="text" class="form-control" name="reason" placeholder="Reason for removal.">
           <button type="button" class="btn btn-default" data-dismiss="modal"><i class="fa fa-fw fa-close"></i> Close</button>
+          <input type="hidden" name="flag" value="true">
           <button type="submit" class="btn btn-danger{{^canFlag}} disabled{{/canFlag}}"><i class="fa fa-fw fa-flag"></i> Flag</button>
         </form>
       </div>

--- a/views/includes/userUserToolsPanel.html
+++ b/views/includes/userUserToolsPanel.html
@@ -1,12 +1,19 @@
 <div class="panel panel-default">
   <div class="panel-body">
     <ul class="nav nav-pills nav-justified">
-      {{#flagged}}
-        <li><a rel="nofollow" href="{{{flagUrl}}}" class="{{^canFlag}}disabled{{/canFlag}}"><i class="fa fa-flag"></i> Unflag</a></li>
-      {{/flagged}}
-      {{^flagged}}
-        <li><a rel="nofollow" href="#" data-toggle="modal" data-target="#flagUserModal" class="{{^canFlag}}disabled{{/canFlag}}"><i class="fa fa-flag-o"></i> Flag</a></li>
-      {{/flagged}}
+      <li>
+        <div class="text-center">
+        {{#flagged}}
+          <form action="{{{user.userFlagPageUrl}}}" method="post" enctype="multipart/form-data">
+            <input type="hidden" name="flag" value="false">
+            <button class="btn btn-link" type="submit" class="{{^canFlag}} disabled{{/canFlag}}"><i class="fa fa-fw fa-flag"></i> Unflag</button>
+          </form>
+        {{/flagged}}
+        {{^flagged}}
+          <a rel="nofollow" href="#" data-toggle="modal" data-target="#flagUserModal" class="{{^canFlag}}disabled{{/canFlag}}"><i class="fa fa-flag-o"></i> Flag</a>
+        {{/flagged}}
+        </div>
+      </li>
     </ul>
   </div>
 </div>


### PR DESCRIPTION
* Change route to use regex and a POST... removed TODO note on it... **NOTE** `nav-pills` UI issue with form buttons... so making `Flag` and `Unflag` in their own div tag as intended
* Establish a controller function to flag/unflag
* Removed now dead code... aOptions and exports
* Cleaned up remove controller function code a little bit to be more symmetrical... post #510, #513, #514 with parent of #261 e.g. e0929ca...e1e3f7e excluding #511
* Some STYLEGUIDE.md conformance
* Don't `return` some assumed `undefined`s in `aNext()`s and `statusCodePage()`

Applies to #775