### PR TITLE
Show sorted updated announcements along with created

### DIFF
--- a/controllers/index.js
+++ b/controllers/index.js
@@ -83,7 +83,7 @@ exports.home = function (aReq, aRes) {
   var announcementsDiscussionListQuery = Discussion.find();
   announcementsDiscussionListQuery
     .and({category: options.announcementsCategory.slug})
-    .sort('-created')
+    .sort('-updated')
     .limit(5);
 
   //--- Tasks

--- a/views/includes/announcementsPanel.html
+++ b/views/includes/announcementsPanel.html
@@ -22,6 +22,9 @@
             <td class="text-center td-fit">
               <time datetime="{{createdISOFormat}}" title="{{created}}">{{createdHumanized}}</time>
             </td>
+            <td class="text-center td-fit">
+              <time datetime="{{updatedISOFormat}}" title="{{updated}}">{{updatedHumanized}}</time>
+            </td>
           </tr>
           {{/announcementsDiscussionList}}
         </tbody>


### PR DESCRIPTION
* Doesn't really make much sense that the announcements panel is the only fixed list with creation date and older announcements. New replies never show if a new comment is added... some ppl actually read these only on the main page.
* If anyone is worried about spammers they'll get axed if excessive replies in which case it would still show the number of replies as greatly increased on the visible and quite hidden on the non-listed discussions

Post #185