### PR TITLE
Ensure UTF-8 in the output stream for script source

### DIFF
--- a/controllers/scriptStorage.js
+++ b/controllers/scriptStorage.js
@@ -163,6 +163,7 @@ exports.sendScript = function (aReq, aRes, aNext) {
     // Disable *express-minify* for this response
     aRes._skip = true;
 
+    aStream.setEncoding('utf8');
     aStream.pipe(aRes);
 
     // Don't count installs on raw source route


### PR DESCRIPTION
* Fixes a bug where ANSI *(and probably any other encoding types)* is served from uploaded scripts
* Apparently the header CHARSET is somewhat ignored in *node* output streams

Applies to #200 and wherever file uploading was first added... no issue for that in a search