### PR TITLE
Follow GH example for component URI encoding on branch name

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -1108,7 +1108,7 @@ exports.userGitHubRepoPage = function (aReq, aRes, aNext) {
       function (aRepo, aCallback) {
         options.repo = aRepo;
         options.repoAsEncoded = {
-          default_branch: encodeURI(options.repo.default_branch)
+          default_branch: encodeURIComponent(options.repo.default_branch)
         };
 
         github.gitdata.getJavascriptBlobs({


### PR DESCRIPTION
Example:
* https://github.com/Martii/UserScriptsTesting/branches displays `this&that` with a href of [`this/Martii/UserScriptsTesting/tree/this%26that`](https://github.com/Martii/UserScriptsTesting/tree/this%26that)... note that `&` does still currently work if not percent encoded but symmetry is what is being looked for here in our code base. It is notable that [`/Martii/UserScriptsTesting/tree/this&that`](https://github.com/Martii/UserScriptsTesting/tree/this&that) also works... but don't know for how long. Luckily a repo branch can't be made of `?` *(at least in git-gui)* so we wouldn't have that issue... but if it did at any point... we could have an issue.

Loosely applies to #200