### PR TITLE
Clean up document controller

### DIFF
--- a/views/pages/documentPage.html
+++ b/views/pages/documentPage.html
@@ -48,7 +48,7 @@
             </div>
             <div class="panel-body">
               <ul class="list-group">
-                {{#files}}<li class="list-group-item"><a href="{{{href}}}">{{textContent}}</a></li>{{/files}}</li>
+                {{#fileList}}<li class="list-group-item"><a href="{{{href}}}">{{textContent}}</a></li>{{/fileList}}</li>
               </ul>
             </div>
           </div>


### PR DESCRIPTION
* Parallel works too and in this node version appears as fast as waterfall so defaulting to _template.js styling
* Renamed one view identifier to match current naming standards
* Filled in the render/prerender in case we ever do some of that here

Originally applies to #262 ... not part of https://github.com/OpenUserJs/OpenUserJS.org/issues/262#issuecomment-57592127