### PR TITLE
Do some console ops for visual tracking in authentication routine

### DIFF
--- a/libs/githubClient.js
+++ b/libs/githubClient.js
@@ -11,6 +11,7 @@ var _ = require("underscore");
 var async = require('async');
 var util = require('util');
 var request = require('request');
+var chalk = require('chalk');
 
 // Client
 var github = new GitHubApi({
@@ -30,9 +31,9 @@ Strategy.findOne({ name: 'github' }, function (aErr, aStrat) {
       key: aStrat.id,
       secret: aStrat.key,
     });
-    console.log('GitHub client authenticated');
+    console.log(chalk.green('GitHub client authenticated'));
   } else {
-    console.warn('GitHub client NOT authenticated. Will have a lower Rate Limit.');
+    console.warn(chalk.yellow('GitHub client NOT authenticated. Will have a lower Rate Limit.'));
   }
 
 });


### PR DESCRIPTION
* Also trying out *chalk* dep to see if the VPS pro logs can handle this without too much visual interference... nicer in development and debug modes... if not will remove.

Applies to Code Migrations, #430,  and https://github.com/jaredhanson/passport/issues/400#issuecomment-144612814

Still getting `username is taken` with *passport*@0.3.2 and *passport-github*@1.0.0
but **not** *passport*@0.2.2 with *passport-github*@0.1.5