### PR TITLE
Repair so error on `npm -ls` becomes a warning

### DIFF
--- a/controllers/admin.js
+++ b/controllers/admin.js
@@ -337,11 +337,14 @@ exports.adminNpmListView = function (aReq, aRes, aNext) {
 
   exec('npm ls --json', function (aErr, aStdout, aStderr) {
     if (aErr) {
-      aRes.status(501).send({ status: 501, message: 'Not implemented.' });
-      return;
+      console.warn(aErr);
     }
 
-    aRes.json(JSON.parse(aStdout));
+    try {
+      aRes.json(JSON.parse(aStdout));
+    } catch (aE) {
+      aRes.status(520).send({ status: 520, message: 'Unknown error.' });
+    }
   });
 };
 


### PR DESCRIPTION
* Added `try...catch` just in case it's a fatal error

**NOTES**

``` sh-session
problems": [

    "peer dep missing: kerberos@~0.0, required by mongodb-core@1.2.21"

],
```

... this shows up in the stdout as being the "error" along with the full compliment of packages installed ... see #832 and parent #318

*(never would have guessed this on nodejitsu... glad we aren't there anymore)*