### PR TITLE
Add *kerberos* dep even though we don't use it

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Repository | Reference | Recent Version
 [highlight.js][highlight.jsGHUrl] | [Documentation][highlight.jsDOCUrl] | [![NPM version][highlight.jsNPMVersionImage]][highlight.jsNPMUrl]
 [jquery][jQueryGHUrl] | [Documentation][jQueryDOCUrl] | [![NPM version][jQueryNPMVersionImage]][jQueryNPMUrl]
 [jwt-simple][jwt-simpleGHUrl] | [Documentation][jwt-simpleDOCUrl] | [![NPM version][jwt-simpleNPMVersionImage]][jwt-simpleNPMUrl]
+[kerberos][kerberosGHUrl] | [Documentation][kerberosDOCUrl] | [![NPM version][kerberosNPMVersionImage]][kerberosNPMUrl]
 [less-middleware][less-middlewareGHUrl][&#x00b9;][lessGHUrl] | [Documentation][less-middlewareDOCUrl][&#x00b9;][lessDOCUrl] | [![NPM version][less-middlewareNPMVersionImage]][less-middlewareNPMUrl]
 [marked][markedGHUrl] | [Documentation][markedDOCUrl] | [![NPM version][markedNPMVersionImage]][markedNPMUrl]
 [method-override][method-overrideGHUrl] | [Documentation][method-overrideDOCUrl] | [![NPM version][method-overrideNPMVersionImage]][method-overrideNPMUrl]
@@ -228,6 +229,11 @@ Outdated dependencies list can also be achieved with `$ npm --depth 0 outdated`
 [jwt-simpleNPMVersionImage]: https://img.shields.io/npm/v/jwt-simple.svg?style=flat
 [jwt-simpleGHUrl]: https://github.com/hokaccha/node-jwt-simple
 [jwt-simpleDOCUrl]: https://github.com/hokaccha/node-jwt-simple/blob/master/README.md
+
+[kerberosNPMUrl]: https://www.npmjs.com/package/kerberos
+[kerberosNPMVersionImage]: https://img.shields.io/npm/v/kerberos.svg?style=flat
+[kerberosGHUrl]: https://github.com/christkv/kerberos
+[kerberosDOCUrl]: https://github.com/christkv/kerberos/blob/master/README.md
 
 [less-middlewareGHUrl]: https://github.com/emberfeather/less.js-middleware
 [less-middlewareDOCUrl]: https://github.com/emberfeather/less.js-middleware/blob/master/readme.md

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "highlight.js": "8.9.1",
     "jquery": "2.1.4",
     "jwt-simple": "0.3.1",
+    "kerberos": "0.0.17",
     "less-middleware": "2.0.1",
     "marked": "0.3.5",
     "method-override": "2.3.5",


### PR DESCRIPTION
* This removes the warning/error on `npm install`

Ref:
* https://github.com/mongodb/node-mongodb-native/blob/2db9984f5972ff1916f46f1aab025373444aa39d/README.md#diagnosing-on-unix ... not quite what I was expecting but will still need followup when we get to *node*@6.x LTS

Applies to #832 and may need further mitigation on *node* LTS upgrade next year.

Closes kcbanner/connect-mongo#203 *(not sure if this will close automatically but need the reference anyhow)*