### PR TITLE
Move *kerberos* to optional dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "highlight.js": "8.9.1",
     "jquery": "2.1.4",
     "jwt-simple": "0.3.1",
-    "kerberos": "0.0.17",
     "less-middleware": "2.0.1",
     "marked": "0.3.5",
     "method-override": "2.3.5",
@@ -57,6 +56,9 @@
     "select2-bootstrap-css": "1.4.6",
     "serve-favicon": "2.3.0",
     "underscore": "1.8.3"
+  },
+  "optionalDependencies": {
+    "kerberos": "0.0.17"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
* While this still seems hacky with MongoDB support backend structures we can possibly minimize the impact here for future top-level "dep hell" by making this optional... too bad [`peerDependencies`](https://docs.npmjs.com/files/package.json#peerdependencies) with *npm*@3.x made a change where it does **not** download it... seems like they ought to make a new property name in *npm* to handle this situation.

Post fix for #834