### PR TITLE
Fix highlighting in fenced quote

### DIFF
--- a/views/includes/documents/Frequently-Asked-Questions.md
+++ b/views/includes/documents/Frequently-Asked-Questions.md
@@ -6,7 +6,7 @@ In this FAQ here are some of the most common questions and answers asked, some m
 
 A: Place two line breaks in between your quote and reply like this:
 
-```
+``` md
 > Something to be quoted
 
 This is my reply


### PR DESCRIPTION
* Speaking of the syntax highlight issue mentioned in this DOC... add `md` to it so it doesn't make `to`, `is`, and `my` bolded

Post fix for #741