### PR TITLE
Patch the most common false "hit" with auto-linking

### DIFF
--- a/libs/markdown.js
+++ b/libs/markdown.js
@@ -61,7 +61,7 @@ function sanitize(aHtml) {
 blockRenderers.forEach(function (aType) {
   renderer[aType] = function () {
     return sanitize(marked.Renderer.prototype[aType].apply(renderer, arguments)
-      .replace(/(^|\s|>)@([^\s\\\/:*?\'\"<>|#;@=&]+)/gm,
+      .replace(/(^|\s|(?:[^c][^o][^d][^e])>)@([^\s\\\/:*?\'\"<>|#;@=&]+)/gm,
       '$1<a href="/users/$2">@$2</a>'));
   };
 });


### PR DESCRIPTION
* This is definitely **not** the final solution as this only covers single line `code` and not multi-line
* HTML `pre` blocks seem unaffected

Applies to #735