### PR TITLE
Try bumping up the reconnect retries and interval for MongoDB

### DIFF
--- a/app.js
+++ b/app.js
@@ -36,7 +36,15 @@ var settings = require('./models/settings.json');
 var connectStr = process.env.CONNECT_STRING || settings.connect;
 var sessionSecret = process.env.SESSION_SECRET || settings.secret;
 var db = mongoose.connection;
-var dbOptions = { server: { socketOptions: { keepAlive: 1 } } };
+var dbOptions = {
+  server: {
+    socketOptions: {
+      keepAlive: 1
+    },
+    reconnectTries: 60,
+    reconnectInterval: 4000
+  }
+};
 
 var fs = require('fs');
 var http = require('http');


### PR DESCRIPTION
* Every couple of days we get disconnected and the below refs offer a possible suggestion
* Doubling the default `server.reconnectTries` and quadrupling the wait time for `reconnectInterval` *(4 seconds shouldn't be too bad instead of the default of 1)*

Refs:
* http://mongodb.github.io/node-mongodb-native/2.0/api/Server.html
* Automattic/mongoose#3588