### PR TITLE
Change some defaults with MongoDB and stderr

### DIFF
--- a/app.js
+++ b/app.js
@@ -45,13 +45,32 @@ var settings = require('./models/settings.json');
 var connectStr = process.env.CONNECT_STRING || settings.connect;
 var sessionSecret = process.env.SESSION_SECRET || settings.secret;
 var db = mongoose.connection;
+
 var dbOptions = {
   server: {
+    poolSize: 5,
     socketOptions: {
-      keepAlive: 1
+      autoReconnect: false,
+      noDelay: true,
+      keepAlive: 1,
+      connectTimeoutMS: 0,
+      socketTimeoutMS: 0
     },
-    reconnectTries: 60,
-    reconnectInterval: 4000
+    reconnectTries: 30,
+    reconnectInterval: 1000
+  }
+};
+
+if (isPro) {
+  dbOptions.replset = {
+    secondaryAcceptableLatencyMS: 15,
+    poolSize: 5,
+    socketOptions: {
+      noDelay: true,
+      keepAlive: 0,
+      connectTimeoutMS: 0,
+      socketTimeoutMS: 0
+    }
   }
 };
 

--- a/controllers/scriptStorage.js
+++ b/controllers/scriptStorage.js
@@ -174,13 +174,16 @@ exports.getSource = function (aReq, aCallback) {
 
       if (!aScript) {
         aCallback(null);
-        console.warn('no script found' );
+        if (isDbg) {
+          console.warn('no script found yet' );
+        }
         return;
       }
 
       s3Object = s3.getObject({ Bucket: bucketName, Key: installNameBase + (isLib ? '.js' : '.user.js') }).createReadStream().
         on('error', function () {
-          if (isPro) {
+          // TODO: #486
+          if (isDbg) {
             console.error('S3 Key Not Found ' + installNameBase + (isLib ? '.js' : '.user.js'));
           }
 


### PR DESCRIPTION
* Set some DB options to their assumed defaults from http://mongodb.github.io/node-mongodb-native/2.0/api/Server.html ... relates to https://github.com/christkv/mongodb-core/issues/66#issuecomment-165052045
* Set some replset defaults to their assumed defaults from http://mongodb.github.io/node-mongodb-native/2.0/api/ReplSet.html ... relates to https://github.com/Automattic/mongoose/issues/3588#issuecomment-163668346
* Move/change a stderr message to debug mode of *node*... clear up the logs a bit since script source may not be found just yet. This only happens on pro so far and probably deals with streams not ready yet. Applies to #430
* Move S3 source not found stderr to debug mode of *node*... known issue of #486. Applies to #430

**NOTES**
* This will be a test whereas unless it's a huge bug I can't take pro down for at least 3 days, give or take to see if this helps or hinders from #845 backout.