### PR TITLE
Change some more defaults with MongoDB

### DIFF
--- a/app.js
+++ b/app.js
@@ -46,33 +46,32 @@ var connectStr = process.env.CONNECT_STRING || settings.connect;
 var sessionSecret = process.env.SESSION_SECRET || settings.secret;
 var db = mongoose.connection;
 
-var dbOptions = {
-  server: {
+var dbOptions = {};
+if (isPro) {
+  dbOptions.replset = {
     poolSize: 5,
     socketOptions: {
       autoReconnect: false,
       noDelay: true,
-      keepAlive: 1,
-      connectTimeoutMS: 0,
+      keepAlive: 1,  // NOTE: Unclear why this was non-zero early on
+      connectTimeoutMS: 60 * 1000,
       socketTimeoutMS: 0
     },
     reconnectTries: 30,
     reconnectInterval: 1000
   }
-};
-
-if (isPro) {
-  dbOptions.replset = {
+} else {
+  dbOptions.server = {
     secondaryAcceptableLatencyMS: 15,
     poolSize: 5,
     socketOptions: {
       noDelay: true,
       keepAlive: 0,
-      connectTimeoutMS: 0,
+      connectTimeoutMS: 60 * 1000,
       socketTimeoutMS: 0
     }
   }
-};
+}
 
 var fs = require('fs');
 var http = require('http');


### PR DESCRIPTION
* Change logic to only use `replset` on production ... as per https://github.com/Automattic/mongoose/issues/3588#issuecomment-165279213 from @chrisckchang
* Default to single connection on development with `server` ... as per https://github.com/Automattic/mongoose/issues/3588#issuecomment-165279213 from @chrisckchang
* Change `connectTimeoutMS` to 60 seconds instead of presumed inherited OS value from https://github.com/christkv/mongodb-core/issues/66#issuecomment-165052045 by @christkv and overridden with @chrisckchang recommendation previously mentioned in commit summary.
* Added NOTE on non-standard keepAlive value that was in before I started twiddling with this... this was on dev and pro pre replica/sharding set.

Applies to #845, #851, #852, Automattic/mongoose#3588 and loosely christkv/mongodb-core#66

Refs:
* https://github.com/Automattic/mongoose/issues/3588#issuecomment-165716347