### PR TITLE
Create a drop down menu on the install button

### DIFF
--- a/public/css/common.css
+++ b/public/css/common.css
@@ -307,3 +307,8 @@ ul.flaggedList {
   list-style-type: none;
   padding-left: 0;
 }
+
+/* A *bootstrap* fix for drop-down menus on buttons */
+.navbar {
+  position: static;
+}

--- a/views/includes/head.html
+++ b/views/includes/head.html
@@ -15,8 +15,8 @@
 <link rel="stylesheet" type="text/css" media="all" href='/redist/npm/font-awesome/css/font-awesome.min.css'>
 <link rel="stylesheet" type="text/css" media="all" href='/redist/npm/octicons/octicons/octicons.css'>
 <link rel="stylesheet" type="text/css" media="all" href="/less/bootstrap/oujs.css">
-<link rel="stylesheet" type="text/css" media="all" href="/css/common.css">
 <link rel="stylesheet" type="text/css" media="all" href="/redist/npm/highlight.js/styles/github.css">
+<link rel="stylesheet" type="text/css" media="all" href="/css/common.css">
 
 {{^isDev}}
 <!-- Google Analytics -->

--- a/views/includes/scriptPageHeader.html
+++ b/views/includes/scriptPageHeader.html
@@ -1,14 +1,23 @@
 <h2 class="page-heading">
   {{#isScriptPage}}
     {{^script.isLib}}
-    <a href="{{{script.scriptInstallPageUrl}}}" class="btn btn-info pull-right">
-      <i class="fa fa-download"></i> Install
-    </a>
+    <div class="btn-group pull-right">
+      <a href="{{{script.scriptInstallPageUrl}}}" class="btn btn-info">
+        <i class="fa fa-download"></i> Install
+      </a>
+      <button type="button" class="btn btn-info dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <span class="caret"></span>
+        <span class="sr-only">Toggle Dropdown</span>
+      </button>
+      <ul class="dropdown-menu">
+        <li><a href="/about/Userscript-Beginners-HOWTO"><em class="fa fa-fw fa-file-text-o"></em> Userscript Beginners HOWTO</a></li>
+      </ul>
+    </div>
     {{/script.isLib}}
   {{/isScriptPage}}
   {{#isScriptViewSourcePage}}
     <a href="{{{script.scriptRawPageUrl}}}" class="btn btn-info pull-right">
-      <i class="fa fa-file-text-o"></i> Raw Source
+      <i class="fa fa-file-{{#script.isLib}}excel{{/script.isLib}}{{^script.isLib}}code{{/script.isLib}}-o"></i> Raw Source
     </a>
   {{/isScriptViewSourcePage}}
   {{#script.icon45Url}}


### PR DESCRIPTION
* Initial fill is with Userscript Beginners HOWTO ... occasionally someone isn't installing a .user.js engine first and then asks the question... since they are next to install link point to the docs.
* Intial base UI structure of expansion of the install button for #432
* Move `common.css` to last for final cascading style overrides
* Icon symmetry with Raw Source icons to symbolize correct type