### PR TITLE
Allow some minification through the source urls

### DIFF
--- a/app.js
+++ b/app.js
@@ -223,6 +223,15 @@ if (minify && !isDbg) {
   app.use(minify());
 }
 
+app.use(function(aReq, aRes, aNext) {
+  if (/\.(user|meta)\.js$/.test(aReq.url)) {
+    aRes._uglifyOutput = {
+      comments: true
+    };
+  }
+  aNext();
+});
+
 app.use(lessMiddleware(__dirname + '/public', {
   render: {
     compress: false,

--- a/libs/modelParser.js
+++ b/libs/modelParser.js
@@ -195,6 +195,7 @@ var parseScript = function (aScriptData) {
   // Urls: Public
   script.scriptPageUrl = getScriptPageUrl(script);
   script.scriptInstallPageUrl = getScriptInstallPageUrl(script);
+  script.scriptInstallPageXUrl = script.scriptInstallPageUrl.replace(/(\.user)?\.js/, '');
   script.scriptViewSourcePageUrl = getScriptViewSourcePageUrl(script);
 
   // Urls: Issues

--- a/views/includes/scriptPageHeader.html
+++ b/views/includes/scriptPageHeader.html
@@ -10,6 +10,8 @@
         <span class="sr-only">Toggle Dropdown</span>
       </button>
       <ul class="dropdown-menu">
+        <li><a href="{{{script.scriptInstallPageXUrl}}}.min.user.js">&hellip; with minification <span class="label label-warning">EXPERIMENTAL</span></a></li>
+        <li role="separator" class="divider"></li>
         <li><a href="/about/Userscript-Beginners-HOWTO"><em class="fa fa-fw fa-file-text-o"></em> Userscript Beginners HOWTO</a></li>
       </ul>
     </div>


### PR DESCRIPTION
* **EXPERIMENTAL**  ES5 minification via url ... Uses same routes but `.min` prefix on extension. If ES6 is encountered it should just not minify.

**NOTES**
* ES6 minification isn't supported/stable yet but will probably request an experimental branch on *express-minify* or something else
* This is on a trial basis to see how much interest and possible clobbering happens... *uglifyjs2* claims stable support with ES5 ... this will test that. Authors should recommend debugging against original source but with a notation that minified may or may not work.
* #819 followup with renaming external urls
* Debug mode of course won't use *express-minify* currently so nothing should happen on these routes.. this is being reevaluated.

* BUG fix for libraries sharing same S3 storage space when ending in a reserved extension from script name
* BUG fix for the regular expression allowing some urls without 404

Applies to #432