### PR TITLE
**EXPERIMENTAL** ES5 minification via url for libs ... Uses same rout…

### DIFF
--- a/app.js
+++ b/app.js
@@ -224,7 +224,9 @@ if (minify && !isDbg) {
 }
 
 app.use(function(aReq, aRes, aNext) {
-  if (/\.(user|meta)\.js$/.test(aReq.url)) {
+  var pathname = aReq._parsedUrl.pathname;
+
+  if (/(\.user|\.meta)?\.js$/.test(pathname) && /^\/(install|src)\//.test(pathname)) {
     aRes._uglifyOutput = {
       comments: true
     };

--- a/controllers/scriptStorage.js
+++ b/controllers/scriptStorage.js
@@ -218,8 +218,8 @@ exports.sendScript = function (aReq, aRes, aNext) {
     // Send the script
     aRes.set('Content-Type', 'text/javascript; charset=UTF-8');
 
-    // Disable *express-minify* for responses that don't contain `.min.` extension
-    if (!/\.min\.user\.js$/.test(aReq.url)) {
+    // Disable *express-minify* for response that don't contain `.min.` extension
+    if (!/\.min(\.user)?\.js$/.test(aReq._parsedUrl.pathname)) {
       aRes._skip = true;
     }
 


### PR DESCRIPTION
…es but .min prefix on extension. If ES6 is encountered it should just not minify.

* Pluralization fix on comment
* Will add url to library homepage after trial... haven't thought that far ahead on that part of the UI.

Followup for #858 and applies to #432