### PR TITLE
UI fixes for experimental minification

### DIFF
--- a/public/less/bootstrap/oujs-bootswatch.less
+++ b/public/less/bootstrap/oujs-bootswatch.less
@@ -192,3 +192,7 @@ body > .navbar {
   padding: 5px;
   font-size: 12px;
 }
+
+.dropdown-menu {
+  font-family: @font-family-sans-serif;
+}

--- a/views/includes/scriptPageHeader.html
+++ b/views/includes/scriptPageHeader.html
@@ -10,7 +10,7 @@
         <span class="sr-only">Toggle Dropdown</span>
       </button>
       <ul class="dropdown-menu">
-        <li><a href="{{{script.scriptInstallPageXUrl}}}.min.user.js">&hellip; with minification <span class="label label-warning">EXPERIMENTAL</span></a></li>
+        <li><a href="{{{script.scriptInstallPageXUrl}}}.min.user.js"><i class="fa fa-fw fa-download"></i> Install with minification <span class="label label-warning">EXPERIMENTAL</span></a></li>
         <li role="separator" class="divider"></li>
         <li><a href="/about/Userscript-Beginners-HOWTO"><em class="fa fa-fw fa-file-text-o"></em> Userscript Beginners HOWTO</a></li>
       </ul>


### PR DESCRIPTION
* Stop inheriting SquadaOne for all dropdown-menu's ... font is too heavy since it's a narrow font even with lowering the `font-weight`
* Change the text to be a little less fragmented in the DOM
* Use the same icon instead of hellip HTML entity

Applies to #432