### PR TITLE
Add HTML5 Copy to Clipboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Repository | Reference | Recent Version
 [bootstrap][bootstrapGHUrl] | [Documentation][bootstrapDOCUrl] | [![NPM version][bootstrapNPMVersionImage]][bootstrapNPMUrl]
 [bootstrap-markdown][bootstrap-markdownGHUrl] | [Documentation][bootstrap-markdownDOCUrl] | [![NPM version][bootstrap-markdownNPMVersionImage]][bootstrap-markdownNPMUrl]
 [chalk][chalkGHUrl] | [Documentation][chalkDOCUrl] | [![NPM version][chalkNPMVersionImage]][chalkNPMUrl]
+[clipboard][clipboardGHUrl] | [Documentation][clipboardDOCUrl] | [![NPM version][clipboardNPMVersionImage]][clipboardNPMUrl]
 [compression][compressionGHUrl] | [Documentation][compressionDOCUrl] | [![NPM version][compressionNPMVersionImage]][compressionNPMUrl]
 [connect-mongo][connect-mongoGHUrl] | [Documentation][connect-mongoDOCUrl] | [![NPM version][connect-mongoNPMVersionImage]][connect-mongoNPMUrl]
 [cookie-parser][cookie-parserGHUrl] | [Documentation][cookie-parserDOCUrl] | [![NPM version][cookie-parserNPMVersionImage]][cookie-parserNPMUrl]
@@ -159,6 +160,11 @@ Outdated dependencies list can also be achieved with `$ npm --depth 0 outdated`
 [chalkDOCUrl]: https://github.com/chalk/chalk/blob/master/readme.md
 [chalkNPMUrl]: https://www.npmjs.com/package/chalk
 [chalkNPMVersionImage]: https://img.shields.io/npm/v/chalk.svg?style=flat
+
+[clipboardGHUrl]: https://github.com/zenorocha/clipboard.js
+[clipboardDOCUrl]: https://github.com/zenorocha/clipboard.js/blob/master/readme.md
+[clipboardNPMUrl]: https://www.npmjs.com/package/clipboard
+[clipboardNPMVersionImage]: https://img.shields.io/npm/v/clipboard.svg?style=flat
 
 [compressionGHUrl]: https://github.com/expressjs/compression
 [compressionDOCUrl]: https://github.com/expressjs/compression/blob/master/README.md

--- a/controllers/script.js
+++ b/controllers/script.js
@@ -380,6 +380,8 @@ exports.view = function (aReq, aRes, aNext) {
       script.installNameSlug = installNameBase;
       script.scriptPermalinkInstallPageUrl = 'https://' + aReq.get('host') +
         script.scriptInstallPageUrl;
+      script.scriptPermalinkInstallPageXUrl = 'https://' + aReq.get('host') +
+        script.scriptInstallPageXUrl;
 
       // Page metadata
       pageMetadata(options, ['About', script.name, (script.isLib ? 'Libraries' : 'Userscripts')],

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -1642,6 +1642,8 @@ exports.editScript = function (aReq, aRes, aNext) {
         script.installNameSlug = installNameBase;
         script.scriptPermalinkInstallPageUrl = 'https://' + aReq.get('host') +
           script.scriptInstallPageUrl;
+        script.scriptPermalinkInstallPageXUrl = 'https://' + aReq.get('host') +
+          script.scriptInstallPageXUrl;
         script.scriptRawPageUrl = '/src/' + (isLib ? 'libs' : 'scripts') + '/'
           + scriptStorage.getInstallNameBase(aReq, { encoding: 'uri' }) +
             (isLib ? '.js#' : '.user.js#');

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "bootstrap": "3.3.6",
     "bootstrap-markdown": "2.9.0",
     "chalk": "1.1.1",
+    "clipboard": "1.5.5",
     "compression": "1.6.0",
     "connect-mongo": "1.0.2",
     "cookie-parser": "1.4.0",

--- a/public/less/bootstrap/oujs-variables.less
+++ b/public/less/bootstrap/oujs-variables.less
@@ -196,7 +196,7 @@
 @legend-border-color:            #e5e5e5;
 
 //** Background color for textual input addons
-@input-group-addon-bg:           @gray-lighter;
+@input-group-addon-bg:           #ddd;
 //** Border color for textual input addons
 @input-group-addon-border-color: @input-border;
 

--- a/routesStatic.js
+++ b/routesStatic.js
@@ -58,6 +58,10 @@ module.exports = function (aApp) {
     'css/bootstrap-markdown.min.css': { maxage: day * 1 }
   });
 
+  serveModule('/redist/npm/', 'clipboard/', {
+    'dist/clipboard.js': { maxage: day * 7 }
+  });
+
   serveModule('/redist/npm/', 'font-awesome/', {
     'css/font-awesome.min.css': { maxage: day * 1 },
     'fonts/fontawesome-webfont.eot': { maxage: day * 7 },

--- a/views/includes/scripts/clipboard.html
+++ b/views/includes/scripts/clipboard.html
@@ -1,0 +1,21 @@
+<script type="text/javascript" src="/redist/npm/clipboard/dist/clipboard.js"></script>
+<script type="text/javascript">
+  (function () {
+    var clipboard = new Clipboard('#require-raw, #require-min');
+    var rMin = /\.min\.js$/;
+
+    clipboard.on('success', function(aE) {
+      if (rMin.test(aE.text)) {
+        // TODO: Flash tooltip saying copied and then restore it
+      } else {
+        // TODO: Flash tooltip saying copied and then restore it
+      }
+    });
+
+    clipboard.on('error', function(aE) {
+      $('#require-min').prop('disabled', true);
+      $('#require-raw').prop('disabled', true);
+    });
+
+  })();
+</script>

--- a/views/pages/scriptPage.html
+++ b/views/pages/scriptPage.html
@@ -16,8 +16,12 @@
             {{#script.isLib}}
             <div class="form-group">
               <div class="input-group col-xs-12">
-                <div class="input-group-addon">// @require </div>
-                <input type="text" class="form-control" value="{{{script.scriptPermalinkInstallPageUrl}}}">
+                <div class="input-group input-group-addon">// @require </div>
+                <input type="text" class="form-control" id="require" value="{{{script.scriptPermalinkInstallPageUrl}}}" readonly="readonly">
+                <span class="input-group-btn">
+                  <button class="btn btn-warning" id="require-min" data-clipboard-text="// @require {{{script.scriptPermalinkInstallPageXUrl}}}.min.js" title="EXPERIMENTAL: Copy key and minified URL to clipboard"><i class="glyphicon glyphicon-copy"></i></button>
+                  <button class="btn btn-info" id="require-raw" data-clipboard-text="// @require {{{script.scriptPermalinkInstallPageUrl}}}" title="Copy key and raw URL to clipboard"><i class="octicon octicon-clippy"></i></button>
+                </span>
               </div>
             </div>
             {{/script.isLib}}
@@ -114,5 +118,8 @@
   {{> includes/scriptModals.html }}
   {{> includes/footer.html }}
   {{> includes/scripts/lazyIconScript.html }}
+  {{#script.isLib}}
+    {{> includes/scripts/clipboard.html }}
+  {{/script.isLib}}
 </body>
 </html>


### PR DESCRIPTION
* New dep for HTML5 copy to clipboard
* Serve this dep statically to the DOM
* Add button for Copy raw *(native)* URL to clipboard button
* **EXPERIMENTAL** Copy minified URL to clipboard button ... same color as label for .user.js denoting experimental for now
* Tint the `input-group` class a little darker for better distinction when inputs are disabled
* BUG FIX: Disable editing in the input box for the library URL
* Add missing "X" mustache objects to accommodate all of this from #858

**NOTES**
* TODO: Finish off the jQuery notifications... having issues with *jQuery* and *bootstrap* not reassigning tooltip text dynamically... will get to this after the holidaze.
* Linux Opera Presto does **not** support HTML5 Copy to Clipboard structures... however one can still copy the text and type `// @require`
* This is needed to potentially avoid possibly hazardous flash scripts that are already in use... also Adobe deprecated Flash.
* Icon sets are limited on choices... also have some other "copy" icons which may give a better distinction but need to ponder some on this... in the meantime use **first** glyphicon from *bootstrap* and *octicons* clipboard icons
* Not sure when an `error` will occur but disable both of these if it happens... will need to have someone report if problematic.

Applies to #432