### PR TITLE
Fix when `saveContent` flags are zero

### DIFF
--- a/libs/flag.js
+++ b/libs/flag.js
@@ -109,7 +109,7 @@ function saveContent(aModel, aContent, aAuthor, aFlags, aCallback) {
   }
 
   aContent.flags.critical += aFlags;
-  aContent.flags.absolute += (aFlags > 0 ? 1 : -1); // NOTE: ES6 `Math.sign(x)`
+  aContent.flags.absolute += (aFlags > 0 ? 1 : (aFlags < 0 ? -1 : 0)); // NOTE: ES6 `Math.sign(x)`
 
   if (aContent.flags.critical >= thresholds[aModel.modelName] * (aAuthor.role < 4 ? 2 : 1)) {
     return getThreshold(aModel, aContent, aAuthor, function (aThreshold) {


### PR DESCRIPTION
* Code point ref https://github.com/OpenUserJs/OpenUserJS.org/blob/7b3c673ddc020d31617942bc8ba47e219c20a553/controllers/script.js#L540

**NOTES**
* This causes `flags.absolute` to be negative which should never happen... didn't realize we were using zero so didn't include it with the ES5 code.

Post fix for #641