### PR TITLE
Integrate file uploads into *bootstrap*

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -1363,8 +1363,9 @@ exports.uploadScript = function (aReq, aRes, aNext) {
     var failUrl = '/user/add/' + (isLib ? 'lib' : 'scripts');
 
     // Reject missing, non-js, and huge files
-    if (!script || script.type !== 'application/javascript' ||
-      script.size > settings.maximum_upload_script_size) {
+    if (!script ||
+      !(script.type === 'application/javascript' || script.type === 'application/x-javascript') ||
+        script.size > settings.maximum_upload_script_size) {
       aRes.redirect(failUrl);
       return;
     }

--- a/public/css/common.css
+++ b/public/css/common.css
@@ -312,3 +312,24 @@ ul.flaggedList {
 .navbar {
   position: static;
 }
+
+.btn-file {
+    position: relative;
+    overflow: hidden;
+}
+.btn-file input[type=file] {
+    position: absolute;
+    top: 0;
+    right: 0;
+    min-width: 100%;
+    min-height: 100%;
+    font-size: 100px;
+    text-align: right;
+    filter: alpha(opacity=0);
+    opacity: 0;
+    outline: none;
+    background: white;
+    cursor: inherit;
+    display: block;
+}
+

--- a/views/includes/scripts/browseFeedback.html
+++ b/views/includes/scripts/browseFeedback.html
@@ -1,0 +1,30 @@
+<script type="text/javascript">
+  (function () {
+
+    $(document).on('change', '.btn-file :file', function () {
+      var input = $(this);
+      var numFiles = input.get(0).files ? input.get(0).files.length : 1;
+      var label = input.val().replace(/\\/g, '/').replace(/.*\//, '');
+
+      input.trigger('fileselect', [numFiles, label]);
+    });
+
+
+    $(document).ready( function () {
+      $('.btn-file :file').on('fileselect', function (aE, aNumFiles, aLabel) {
+
+        var input = $(this).parents('.input-group').find(':text');
+        var log = aNumFiles > 1 ? aNumFiles + ' files selected' : aLabel;
+
+        if (input.length) {
+          input.val(log);
+        } else {
+          if (log) {
+            alert(log);
+          }
+        }
+      });
+    });
+
+  })();
+</script>

--- a/views/pages/newScriptPage.html
+++ b/views/pages/newScriptPage.html
@@ -100,16 +100,27 @@
                   <input type="hidden" name="uploadScript" value="true">
                   {{#newJSLibrary}}
                   <div class="form-group">
-                    <input type="text" class="form-control" name="script_name" placeholder="Script Name" required />
+                    <input type="text" class="form-control" name="script_name" placeholder="Script Name" required="required" />
                   </div>
                   {{/newJSLibrary}}
                   <div class="form-group">
                     <div class="input-group">
-                      <input type="file" class="form-control" name="script" placeholder="Enter email" required />
+                      <span class="input-group-btn">
+                        <span class="btn btn-primary btn-file">
+                          Browse...
+                          <input type="file" name="script" required="required" />
+                        </span>
+                      </span>
+                      <input type="text" readonly="readonly" class="form-control" />
                       <span class="input-group-btn">
                         <button class="btn btn-success" type="submit">Submit</button>
                       </span>
                     </div>
+                    <noscript>
+                      <div role="alert" class="alert alert-warning small">
+                        <i class="fa fa-exclamation-triangle"></i> <strong>JavaScript DISABLED</strong>: No file selection feedback will be given.
+                      </div>
+                    </noscript>
                   </div>
                 </form>
               </p>
@@ -166,5 +177,6 @@
     </div>
   </div>
   {{> includes/footer.html }}
+  {{> includes/scripts/browseFeedback.html }}
 </body>
 </html>


### PR DESCRIPTION
* Ported from http://www.abeautifulsite.net/whipping-file-inputs-into-shape-with-bootstrap-3/ . Thanks to Cory LaViska
* Uses client-side *jQuery* to simulate the text label for feedback
* **Can** support multiple files however only one is currently chosen in our base code
* Replace weird `placeholder` value which is never seen and isn't in context
* Correct some previously defined attribute minimization in the view
* Add a warning note about no feedback if JavaScript is disabled.
* Fix a bug with Opera Presto based browsers *(12.16ish)* still using `x-javascript` MIME type... e.g. allow that MIME type for file uploads

**NOTE** Untested in Safari for Windows and latest Safari for Mac... should work according to all available documentation. Will test in last Safari for Windows after deployment.