### PR TITLE
Don't mangle identifiers

### DIFF
--- a/controllers/scriptStorage.js
+++ b/controllers/scriptStorage.js
@@ -221,6 +221,9 @@ exports.sendScript = function (aReq, aRes, aNext) {
     // Disable *express-minify* for response that don't contain `.min.` extension
     if (!/\.min(\.user)?\.js$/.test(aReq._parsedUrl.pathname)) {
       aRes._skip = true;
+    } else {
+      // Otherwise set some defaults per script request in *express-minify* via *UglifyJS2*
+      aRes._uglifyMangle = false;
     }
 
     aStream.setEncoding('utf8');


### PR DESCRIPTION
* Disable this option per user script serving since it's close to obfuscation. As per sizzle and confirmed with me
* Do not apply this to *node* packages as they are already redist in their native form via the static routes

Applies to #432