### PR TITLE
Move script minification to UglifyJS2 harmony branch fork

### DIFF
--- a/app.js
+++ b/app.js
@@ -224,10 +224,10 @@ var minifyErrorHandler = function (aErr, aStage, aAssetType, aMinifyOptions, aBo
   // TODO: Lookup script meta with aBody for script identification?
 
   console.warn([ // NOTE: Pushing this to stderr instead of default stdout
-    'message: ' + aErr.message,
-    'line: ' + aErr.line,
-    'col: ' + aErr.col,
-    'pos: ' + aErr.pos
+    'MINIFICATION WARNING (release):',
+    '  filename: ' + aErr.filename,
+    '  message: ' + aErr.message,
+    '  line: ' + aErr.line + ' col: ' + aErr.col + ' pos: ' + aErr.pos
 
   ].join('\n'));
 
@@ -248,10 +248,9 @@ if (minify && !isDbg) {
 app.use(function(aReq, aRes, aNext) {
   var pathname = aReq._parsedUrl.pathname;
 
+  // If a userscript or libary...
   if (/(\.user|\.meta)?\.js$/.test(pathname) && /^\/(install|src)\//.test(pathname)) {
-    aRes._uglifyOutput = {
-      comments: true
-    };
+    aRes._skip = true; // ... skip using release minification
   }
   aNext();
 });

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "select2": "3.5.2-browserify",
     "select2-bootstrap-css": "1.4.6",
     "serve-favicon": "2.3.0",
+    "uglify-js-harmony": "git://github.com/OpenUserJs/UglifyJS2#harmony-named",
     "underscore": "1.8.3"
   },
   "optionalDependencies": {


### PR DESCRIPTION
* Works in *npm*@2.x ... will test 3.x soon
* Load custom named harmony UglifyJS2 branch from OUJS for Userscripts and Libaries only... package .js still uses release... confirmed by monkey hacking into their init routines with some console messages and visual output with monkey hacked *clipboard*.js
* Load the stream into a String for processing ... not the most efficient but works
* Cleaned up stdout and stderr logging a bit ... added request logging for script minification on success

**NOTES**
* Not sure if a stream can be passed directly to `minify` function but didn't see much related to this in the docs... followup at mishoo/UglifyJS2#930
* Chunks are currently of type `String` and not `Buffer` so not using `Buffer.concat` and using standard `join` concatenation
* This is a compromise of middleware and direct API usage... it's the only way that I can see to do this.

Applies to #432 and mishoo/UglifyJS2#448

Cc: @fabiosantoscode