### PR TITLE
Some dep updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "passport-windowslive": "1.0.2",
     "passport-yahoo": "0.3.0",
     "pegjs": "0.9.0",
-    "request": "2.67.0",
+    "request": "2.69.0",
     "sanitize-html": "1.11.3",
     "select2": "3.5.2-browserify",
     "select2-bootstrap-css": "1.4.6",


### PR DESCRIPTION
* Technically just one... *request* cleared up their semver sync issue... tags appear to be "working on that version" versus release status again
* *passport-google-oauth* is now a "meta package" for *passport-google-oauth1* and *passport-google-oauth20* *(sp? jaredhanson/passport-google-oauth2#1)* ... this will take a little more in depth looking to see if it's easily migrated and hopefully without any errs Cc: @sizzlemctwizzle