### PR TITLE
Some visual notices for script minification issues

### DIFF
--- a/app.js
+++ b/app.js
@@ -248,7 +248,7 @@ if (minify && !isDbg) {
 app.use(function(aReq, aRes, aNext) {
   var pathname = aReq._parsedUrl.pathname;
 
-  // If a userscript or libary...
+  // If a userscript or library...
   if (/(\.user|\.meta)?\.js$/.test(pathname) && /^\/(meta|install|src)\//.test(pathname)) {
     aRes._skip = true; // ... skip using release minification
   }

--- a/controllers/scriptStorage.js
+++ b/controllers/scriptStorage.js
@@ -225,7 +225,7 @@ exports.sendScript = function (aReq, aRes, aNext) {
     if (!/\.min(\.user)?\.js$/.test(aReq._parsedUrl.pathname)) {
       aStream.pipe(aRes);
     } else {
-      // Otherwise set some defaults per script request in *express-minify* via *UglifyJS2*
+      // Otherwise set some defaults per script request via *UglifyJS2*
       // and try minifying output
 
       aStream.on('data', function (aData) {
@@ -486,7 +486,7 @@ exports.storeScript = function (aUser, aMeta, aBuf, aCallback, aUpdate) {
   var match = null;
   var rLibrary = new RegExp(
     '^(?:(?:(?:https?:)?\/\/' +
-      (isPro ? 'openuserjs\.org' : 'localhost:8080') +
+      (isPro ? 'openuserjs\.org' : 'localhost:' + (process.env.PORT || 8080)) +
         ')?\/(?:libs\/src|src\/libs)\/)?(.*?)([^\/]*\.js)$', '');
   var libraries = [];
 

--- a/libs/modelParser.js
+++ b/libs/modelParser.js
@@ -117,6 +117,9 @@ var parseScript = function (aScriptData) {
   var icon = null;
   var supportURL = null;
 
+  var downloadURL = null;
+  var rAlternateDownload = null;
+
   // Temporaries
   var htmlStub = null;
 
@@ -161,6 +164,34 @@ var parseScript = function (aScriptData) {
         hasNoFollow: !/^(?:https?:\/\/)?openuserjs\.org/i.test(supportURL)
       }];
     }
+  }
+
+  // Download Url
+  downloadURL = findMeta(script.meta, 'UserScript.downloadURL.0.value');
+  if (downloadURL) {
+    rAlternateDownload = new RegExp(
+      '^https?://(?:openuserjs\.org|localhost:' + (process.env.PORT || 8080) +
+        ')/(?:install|src/scripts)/' +
+          script.installName.replace(/\.user\.js$/, '.min.user.js'));
+
+    try {
+      downloadURL = decodeURIComponent(downloadURL);
+
+    } catch (aE) {
+      script.hasInvalidDownloadURL = true;
+      script.showMinficationNotices = true;
+    }
+
+    if (!rAlternateDownload.test(downloadURL)) {
+      script.hasAlternateDownloadURL = true;
+      script.showMinficationNotices = true;
+    }
+  }
+
+  // OpenUserJS metadata block checks
+  if (findMeta(script.meta, 'OpenUserJS.unstableMinify.0.value')) {
+    script.hasUnstableMinify = true;
+    script.showMinficationNotices = true;
   }
 
   //

--- a/public/pegjs/blockOpenUserJS.pegjs
+++ b/public/pegjs/blockOpenUserJS.pegjs
@@ -6,6 +6,7 @@ Test the generated parser with some input for PEG.js site at http://pegjs.org/on
 // ==OpenUserJS==
 // @author          Marti
 // @collaborator    sizzle
+// @unstableMinify  Some reason
 // ==/OpenUserJS==
 
 */
@@ -37,7 +38,8 @@ non_newline = $[^\n]+
 item1 =
   key:
     (
-      'author'
+      'author' /
+      'unstableMinify'
     )
   whitespace
   value: non_newline

--- a/views/includes/scriptPageHeader.html
+++ b/views/includes/scriptPageHeader.html
@@ -12,8 +12,27 @@
       <ul class="dropdown-menu">
         <li>
           <div class="btn-group btn-group-justified">
-            <a href="{{{script.scriptInstallPageXUrl}}}.min.user.js" class="btn btn-warning" title="EXPERIMENTAL"><i class="fa fa-fw fa-download"></i> Install with minification</a>
+            <a href="{{{script.scriptInstallPageXUrl}}}.min.user.js" class="btn btn-{{#script.showMinficationNotices}}warning{{/script.showMinficationNotices}}{{^script.showMinficationNotices}}primary{{/script.showMinficationNotices}}" title="EXPERIMENTAL INSTALLATION FORKING"><i class="fa fa-fw fa-download"></i> Install with minification</a>
           </div>
+          {{#script.showMinficationNotices}}
+          <div class="alert alert-warning" role="alert">
+            {{#script.hasInvalidDownloadURL}}
+              <p>
+                <i class="fa fa-fw fa-exclamation"></i> Invalid download target
+              <p>
+            {{/script.hasInvalidDownloadURL}}
+            {{#script.hasUnstableMinify}}
+              <p>
+                <i class="fa fa-fw fa-exclamation-triangle"></i> The script author suggests that minification of this script may be unstable.
+              <p>
+            {{/script.hasUnstableMinify}}
+            {{#script.hasAlternateDownloadURL}}
+              <p>
+                <i class="fa fa-fw fa-exclamation-triangle"></i> Alternate download target.
+              </p>
+            {{/script.hasAlternateDownloadURL}}
+          </div>
+          {{/script.showMinficationNotices}}
         </li>
         <li role="separator" class="divider"></li>
         <li><a href="/about/Userscript-Beginners-HOWTO"><em class="fa fa-fw fa-file-text-o"></em> Userscript Beginners HOWTO</a></li>


### PR DESCRIPTION
* Fix a regular expression to use environment port if available ... this is a dev bug
* Some prior typos and comments clarified
* New OpenUserJS metadata block key of `unstableMinify`... following Scriptish example of camel casing *(interCaps)*. This requires a string after it which is the reason why... invalid reasons may reduce ones karma :)
* Using boolean switch so that the view contains the strings and not the controller/libs side of our code... useful for #18 and how views should eventually be rendered
* Libraries aren't covered yet because of #723
* `decodeURIComponent` is required as per #819 ... do a trap for now just in case it fails... which may produce a false positive but these are just notices at this time

Applies to #432