### PR TITLE
Some identifier symmetry and STYLEGUIDE.md conformance

### DIFF
--- a/controllers/_template.js
+++ b/controllers/_template.js
@@ -136,11 +136,11 @@ exports.example2 = function (aReq, aRes, aNext) {
 
   // Scripts
   tasks.push(function (aCallback) {
-    scriptListQuery.exec(function (aErr, aScriptDataList) {
+    scriptListQuery.exec(function (aErr, aScriptList) {
       if (aErr) {
         aCallback();
       } else {
-        options.scriptList = _.map(aScriptDataList, modelParser.parseScript);
+        options.scriptList = _.map(aScriptList, modelParser.parseScript);
         aCallback();
       }
     });

--- a/controllers/discussion.js
+++ b/controllers/discussion.js
@@ -275,7 +275,7 @@ exports.show = function (aReq, aRes, aNext) {
     return;
   }
 
-  findDiscussion(category.slug, topic, function (aDiscussionData) {
+  findDiscussion(category.slug, topic, function (aDiscussion) {
     function preRender() {
       // commentList
       options.commentList = _.map(options.commentList, modelParser.parseComment);
@@ -312,7 +312,7 @@ exports.show = function (aReq, aRes, aNext) {
     var pagination = null;
     var tasks = [];
 
-    if (!aDiscussionData) {
+    if (!aDiscussion) {
       aNext();
       return;
     }
@@ -326,7 +326,7 @@ exports.show = function (aReq, aRes, aNext) {
     category = options.category = modelParser.parseCategory(category);
 
     // Discussion
-    discussion = options.discussion = modelParser.parseDiscussion(aDiscussionData);
+    discussion = options.discussion = modelParser.parseDiscussion(aDiscussion);
 
     // Page metadata
     pageMetadata(options, [discussion.topic, 'Discussions'], discussion.topic);

--- a/controllers/moderation.js
+++ b/controllers/moderation.js
@@ -52,13 +52,13 @@ exports.removedItemPage = function (aReq, aRes, aNext) {
 
   Remove.find({
     _id: removedItemId
-  }, function (aErr, aRemovedItemData) {
-    if (aErr || !aRemovedItemData) {
+  }, function (aErr, aRemovedItem) {
+    if (aErr || !aRemovedItem) {
       aNext();
       return;
     }
 
-    aRes.json(aRemovedItemData);
+    aRes.json(aRemovedItem);
   });
 };
 

--- a/controllers/script.js
+++ b/controllers/script.js
@@ -327,7 +327,7 @@ exports.view = function (aReq, aRes, aNext) {
   Script.findOne({
     installName: scriptStorage.caseSensitive(installNameBase +
       (isLib ? '.js' : '.user.js'))
-    }, function (aErr, aScriptData) {
+    }, function (aErr, aScript) {
       function preRender() {
         if (script.groups) {
           pageMetadata(options, ['About', script.name, (script.isLib ? 'Libraries' : 'Userscripts')],
@@ -363,7 +363,7 @@ exports.view = function (aReq, aRes, aNext) {
       var tasks = [];
 
       //---
-      if (aErr || !aScriptData) {
+      if (aErr || !aScript) {
         aNext();
         return;
       }
@@ -374,7 +374,7 @@ exports.view = function (aReq, aRes, aNext) {
       options.isAdmin = authedUser && authedUser.isAdmin;
 
       // Script
-      options.script = script = modelParser.parseScript(aScriptData);
+      options.script = script = modelParser.parseScript(aScript);
       options.isOwner = authedUser && authedUser._id == script._authorId;
       modelParser.renderScript(script);
       script.installNameSlug = installNameBase;
@@ -413,7 +413,7 @@ exports.edit = function (aReq, aRes, aNext) {
   Script.findOne({
     installName: scriptStorage.caseSensitive(installNameBase +
       (isLib ? '.js' : '.user.js'))
-    }, function (aErr, aScriptData) {
+    }, function (aErr, aScript) {
       function preRender() {
         var groupNameList = (options.script.groups || []).map(function (aGroup) {
           return aGroup.name;
@@ -438,7 +438,7 @@ exports.edit = function (aReq, aRes, aNext) {
       var tasks = [];
 
       // ---
-      if (aErr || !aScriptData) {
+      if (aErr || !aScript) {
         aNext();
         return;
       }
@@ -449,7 +449,7 @@ exports.edit = function (aReq, aRes, aNext) {
       options.isAdmin = authedUser && authedUser.isAdmin;
 
       // Page metadata
-      options.script = script = modelParser.parseScript(aScriptData);
+      options.script = script = modelParser.parseScript(aScript);
       options.isOwner = authedUser && authedUser._id == script._authorId;
       pageMetadata(options, ['Edit', script.name, (script.isLib ? 'Libraries' : 'Userscripts')],
         script.name);
@@ -466,15 +466,15 @@ exports.edit = function (aReq, aRes, aNext) {
 
       if (aReq.body.remove) {
         // POST
-        scriptStorage.deleteScript(aScriptData.installName, function () {
+        scriptStorage.deleteScript(aScript.installName, function () {
           aRes.redirect(authedUser.userScriptListPageUrl);
         });
       } else if (typeof aReq.body.about !== 'undefined') {
         // POST
-        aScriptData.about = aReq.body.about;
+        aScript.about = aReq.body.about;
         scriptGroups = (aReq.body.groups || '');
         scriptGroups = scriptGroups.split(/,/);
-        addScriptToGroups(aScriptData, scriptGroups, function () {
+        addScriptToGroups(aScript, scriptGroups, function () {
           aRes.redirect(script.scriptPageUrl);
         });
       } else {

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -288,7 +288,7 @@ exports.view = function (aReq, aRes, aNext) {
 
   User.findOne({
     name: caseInsensitive(username)
-  }, function (aErr, aUserData) {
+  }, function (aErr, aUser) {
     function preRender() {
     }
 
@@ -320,7 +320,7 @@ exports.view = function (aReq, aRes, aNext) {
     var scriptListQuery = null;
     var tasks = [];
 
-    if (aErr || !aUserData) {
+    if (aErr || !aUser) {
       aNext();
       return;
     }
@@ -331,7 +331,7 @@ exports.view = function (aReq, aRes, aNext) {
     options.isAdmin = authedUser && authedUser.isAdmin;
 
     // User
-    options.user = user = modelParser.parseUser(aUserData);
+    options.user = user = modelParser.parseUser(aUser);
     user.aboutRendered = renderMd(user.about);
     options.isYou = authedUser && user && authedUser._id == user._id;
 
@@ -373,7 +373,7 @@ exports.userCommentListPage = function (aReq, aRes, aNext) {
 
   User.findOne({
     name: caseInsensitive(username)
-  }, function (aErr, aUserData) {
+  }, function (aErr, aUser) {
     function preRender() {
       // commentList
       options.commentList = _.map(options.commentList, modelParser.parseComment);
@@ -433,7 +433,7 @@ exports.userCommentListPage = function (aReq, aRes, aNext) {
     var pagination = null;
     var tasks = [];
 
-    if (aErr || !aUserData) {
+    if (aErr || !aUser) {
       aNext();
       return;
     }
@@ -444,7 +444,7 @@ exports.userCommentListPage = function (aReq, aRes, aNext) {
     options.isAdmin = authedUser && authedUser.isAdmin;
 
     // User
-    user = options.user = modelParser.parseUser(aUserData);
+    user = options.user = modelParser.parseUser(aUser);
     options.isYou = authedUser && user && authedUser._id == user._id;
 
     // Page metadata
@@ -495,7 +495,7 @@ exports.userScriptListPage = function (aReq, aRes, aNext) {
 
   User.findOne({
     name: caseInsensitive(username)
-  }, function (aErr, aUserData) {
+  }, function (aErr, aUser) {
     function preRender() {
       // scriptList
       options.scriptList = _.map(options.scriptList, modelParser.parseScript);
@@ -552,7 +552,7 @@ exports.userScriptListPage = function (aReq, aRes, aNext) {
     var pagination = null;
     var tasks = [];
 
-    if (aErr || !aUserData) {
+    if (aErr || !aUser) {
       aNext();
       return;
     }
@@ -563,7 +563,7 @@ exports.userScriptListPage = function (aReq, aRes, aNext) {
     options.isAdmin = authedUser && authedUser.isAdmin;
 
     // User
-    options.user = user = modelParser.parseUser(aUserData);
+    options.user = user = modelParser.parseUser(aUser);
     options.isYou = authedUser && user && authedUser._id == user._id;
 
     switch (aReq.query.library) {
@@ -643,7 +643,7 @@ exports.userEditProfilePage = function (aReq, aRes, aNext) {
 
   User.findOne({
     _id: authedUser._id
-  }, function (aErr, aUserData) {
+  }, function (aErr, aUser) {
     function preRender() {
     }
 
@@ -662,7 +662,7 @@ exports.userEditProfilePage = function (aReq, aRes, aNext) {
     var scriptListQuery = null;
     var tasks = [];
 
-    if (aErr || !aUserData) {
+    if (aErr || !aUser) {
       aNext();
       return;
     }
@@ -673,7 +673,7 @@ exports.userEditProfilePage = function (aReq, aRes, aNext) {
     options.isAdmin = authedUser && authedUser.isAdmin;
 
     // User
-    options.user = user = modelParser.parseUser(aUserData);
+    options.user = user = modelParser.parseUser(aUser);
     options.isYou = authedUser && user && authedUser._id == user._id;
 
     // Page metadata
@@ -715,7 +715,7 @@ exports.userEditPreferencesPage = function (aReq, aRes, aNext) {
 
   User.findOne({
     _id: authedUser._id
-  }, function (aErr, aUserData) {
+  }, function (aErr, aUser) {
     function preRender() {
     }
 
@@ -734,7 +734,7 @@ exports.userEditPreferencesPage = function (aReq, aRes, aNext) {
     var scriptListQuery = null;
     var tasks = [];
 
-    if (aErr || !aUserData) {
+    if (aErr || !aUser) {
       aNext();
       return;
     }
@@ -745,7 +745,7 @@ exports.userEditPreferencesPage = function (aReq, aRes, aNext) {
     options.isAdmin = authedUser && authedUser.isAdmin;
 
     // User
-    options.user = user = modelParser.parseUser(aUserData);
+    options.user = user = modelParser.parseUser(aUser);
     options.isYou = authedUser && user && authedUser._id == user._id;
 
     // Page metadata
@@ -1625,19 +1625,19 @@ exports.editScript = function (aReq, aRes, aNext) {
     Script.findOne({
       installName: scriptStorage.caseSensitive(installNameBase +
         (isLib ? '.js' : '.user.js'))
-      }, function (aErr, aScriptData) {
+      }, function (aErr, aScript) {
         //
         var script = null;
         var scriptOpenIssueCountQuery = null;
 
         //---
-        if (aErr || !aScriptData) {
+        if (aErr || !aScript) {
           aNext();
           return;
         }
 
         // Script
-        options.script = script = modelParser.parseScript(aScriptData);
+        options.script = script = modelParser.parseScript(aScript);
         options.isOwner = authedUser && authedUser._id == script._authorId;
         modelParser.renderScript(script);
         script.installNameSlug = installNameBase;


### PR DESCRIPTION
* `a`Modelname indicates "live" Object document vs `a`ModelnameData indicates that `toObject()` is applied for plain JavaScript Object and is EXPECTED... the "old style" was due to lack of Hungarian Apps notation See #264. There is inconsistency noted in the individual parsers here but leaving until further testing can be done
* Line length max 100 excluding TODO/NOTE/BUG comments as those should eventually go away
* Added some issue pounds to what needs to be done in these files
* More STYLEGUIDE.md conformance with newlines
* Top header style conformance previously done in controllers
* `var` hoisting as per STYLEGUIDE.md for ES5 coding

**NOTES**
* All of this should be a parallel change e.g. no logic changes
* Some *mu2* *(mustache)* `option`s appear unused... followup

Applies to #819 and #262... treads on https://github.com/OpenUserJs/OpenUserJS.org/issues/262#issuecomment-5759212