### PR TITLE
Fix some bugs with encoding

### DIFF
--- a/controllers/admin.js
+++ b/controllers/admin.js
@@ -497,6 +497,6 @@ exports.authAsUser = function (aReq, aRes, aNext) {
 
     aReq.session.user = user;
 
-    aRes.redirect(encodeURI(user.userPageUrl)); // NOTE: Watchpoint
+    aRes.redirect(user.userPageUrl); // NOTE: Watchpoint
   });
 };

--- a/controllers/flag.js
+++ b/controllers/flag.js
@@ -23,6 +23,7 @@ var scriptStorage = require('./scriptStorage');
 var flagLib = require('../libs/flag');
 
 var statusCodePage = require('../libs/templateHelpers').statusCodePage;
+var encode = require('../libs/helpers').encode;
 
 //--- Configuration inclusions
 
@@ -103,7 +104,7 @@ exports.flag = function (aReq, aRes, aNext) {
 
             fn(Script, aScript, authedUser, reason, function (aFlagged) {
               aRes.redirect((isLib ? '/libs/' : '/scripts/') + scriptStorage.getInstallNameBase(
-                aReq, { encoding: 'uri' }));
+                  aReq, { encoding: 'url' })); // NOTE: Watchpoint
             });
 
         });
@@ -121,7 +122,7 @@ exports.flag = function (aReq, aRes, aNext) {
             }
 
             fn(User, aUser, authedUser, reason, function (aFlagged) {
-              aRes.redirect('/users/' + encodeURIComponent(username));
+              aRes.redirect('/users/' + encode(username)); // NOTE: Watchpoint
             });
 
           });

--- a/controllers/issue.js
+++ b/controllers/issue.js
@@ -380,12 +380,12 @@ exports.open = function (aReq, aRes, aNext) {
         discussionLib.postTopic(authedUser, category.slug, topic, content, true,
           function (aDiscussion) {
             if (!aDiscussion) {
-              aRes.redirect('/' + encodeURI(category) + '/open');
+              aRes.redirect('/' + category.slugUrl + '/open'); // NOTE: Watchpoint
               return;
             }
 
-            aRes.redirect(encodeURI(aDiscussion.path +
-              (aDiscussion.duplicateId ? '_' + aDiscussion.duplicateId : '')));
+            aRes.redirect(aDiscussion.path +
+              (aDiscussion.duplicateId ? '_' + aDiscussion.duplicateId : '')); // NOTE: Watchpoint
           }
         );
       } else {
@@ -439,8 +439,8 @@ exports.comment = function (aReq, aRes, aNext) {
 
         discussionLib.postComment(authedUser, aIssue, content, false,
           function (aErr, aDiscussion) {
-            aRes.redirect(encodeURI(aDiscussion.path
-              + (aDiscussion.duplicateId ? '_' + aDiscussion.duplicateId : '')));
+            aRes.redirect(aDiscussion.path
+              + (aDiscussion.duplicateId ? '_' + aDiscussion.duplicateId : '')); // NOTE: Watchpoint
           });
       });
     });
@@ -487,8 +487,8 @@ exports.changeStatus = function (aReq, aRes, aNext) {
 
         if (changed) {
           aIssue.save(function (aErr, aDiscussion) {
-            aRes.redirect(encodeURI(aDiscussion.path
-              + (aDiscussion.duplicateId ? '_' + aDiscussion.duplicateId : '')));
+            aRes.redirect(aDiscussion.path
+              + (aDiscussion.duplicateId ? '_' + aDiscussion.duplicateId : '')); // NOTE: Watchpoint
           });
         } else {
           aNext();

--- a/controllers/remove.js
+++ b/controllers/remove.js
@@ -20,6 +20,8 @@ var scriptStorage = require('./scriptStorage');
 //--- Library inclusions
 var removeLib = require('../libs/remove');
 
+var encode = require('../libs/helpers').encode;
+
 var destroySessions = require('../libs/modifySessions').destroy;
 var statusCodePage = require('../libs/templateHelpers').statusCodePage;
 
@@ -92,7 +94,7 @@ exports.rm = function (aReq, aRes, aNext) {
                 aNext();
                 return;
               }
-              aRes.redirect('/users/' + encodeURIComponent(username) + '/scripts');
+              aRes.redirect('/users/' + encode(username) + '/scripts'); // NOTE: Watchpoint
             });
           });
         break;

--- a/controllers/scriptStorage.js
+++ b/controllers/scriptStorage.js
@@ -26,6 +26,7 @@ var RepoManager = require('../libs/repoManager');
 
 var cleanFilename = require('../libs/helpers').cleanFilename;
 var findDeadorAlive = require('../libs/remove').findDeadorAlive;
+var encode = require('../libs/helpers').encode;
 
 //--- Configuration inclusions
 var userRoles = require('../models/userRoles.json');
@@ -84,14 +85,13 @@ function getInstallNameBase(aReq, aOptions) {
   }
 
   switch (aOptions.encoding) {
-    case 'uri':
-      base = encodeURIComponent(username) + '/' + encodeURIComponent(scriptname);
+    case 'url':
+      base = encode(username) + '/' + encode(scriptname);
       break;
 
     default:
       base = username + '/' + scriptname;
   }
-
 
   return base;
 }

--- a/libs/helpers.js
+++ b/libs/helpers.js
@@ -96,6 +96,13 @@ exports.cleanFilename = function (aFilename, aDefaultName) {
   return cleanName || aDefaultName;
 };
 
+// Default encoding like GitHubs
+// Future code point for the smart encoder
+// pending *express* redirect issue resolution
+exports.encode = function (aStr) {
+  return encodeURIComponent(aStr);
+}
+
 exports.limitRange = function (aMin, aX, aMax, aDefault) {
   var x = Math.max(Math.min(aX, aMax), aMin);
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "OpenUserJS.org",
   "description": "An open source user scripts repo built using Node.js",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "main": "app",
   "dependencies": {
     "ace-builds": "git://github.com/ajaxorg/ace-builds#e94cb3c",

--- a/views/pages/scriptPage.html
+++ b/views/pages/scriptPage.html
@@ -58,7 +58,7 @@
                 <ul>
                 {{#script.fork}}
                   <li>
-                    <a href="/{{#script.isLib}}libs{{/script.isLib}}{{^script.isLib}}scripts{{/script.isLib}}/{{{url}}">{{url}}</a>
+                    <a href="/{{#script.isLib}}libs{{/script.isLib}}{{^script.isLib}}scripts{{/script.isLib}}/{{{url}}">{{utf}}</a>
                   </li>
                 {{/script.fork}}
                 </ul>


### PR DESCRIPTION
* Remove the patch I put in for this portion
* Create function for encoding like GH's... see helper `encoding`
* Using encodeURIComponent from #795
* Fix bug of Fork History showing "slugged" instead of native/raw
* Fix a missing model parser item for `category` virtual model
* Fix some more bugs in modelParser.js
* Transform a watchpoint with AuthAs ... see third alternative at http://stackoverflow.com/questions/15825333/how-to-reload-current-page-in-express-js with `aRes.redirect(req.get('referer'));` or *express*@4.x shortcut of `aRes.redirect('back');`... but if referer is missing will default to `/` Ref: http://expressjs.com/en/api.html#res.redirect ... this still appears to be a bug in *express* for quite some time so this is a workaround
* Add another series of watchpoints with *express*@4.x `redirect()` doing `escape` on occasion ... special handling of `redirect`.... this particular bug doesn't appear to make much sense
* Project version bump

**NOTES**
* [ ] Followup with DB migration to add `fork.utf` to existing forks otherwise they may show up as `/` *(or a list bullet)* [Array](https://github.com/OpenUserJs/OpenUserJS.org/blob/ec98e843a9e396cb2ff70f836b7103cddcb7fd63/models/script.js#L32) typed values write themselves... interesting.
* [ ] Followup with `discussion.path` fixes. *(ready)*
* [ ] If *express* fixes their redirect issue can simplify `encode` to be a smarter encode where it only encodes when needed... which is where it started but had to back that out in this PR
* Leaving GH import alone as it still works so far
* `./app.js` has one `encodeURI` in it... leaving that be for the time being until it can be retested on production... dev isn't https so no way to test here
* Not all User urls are covered in this PR *(perhaps yet)*

Applies to #819 and #262... treads on https://github.com/OpenUserJs/OpenUserJS.org/issues/262#issuecomment-57592127 among many others.