### PR TITLE
Fix some bugs with encoding

### DIFF
--- a/controllers/admin.js
+++ b/controllers/admin.js
@@ -195,7 +195,7 @@ exports.adminUserUpdate = function (aReq, aRes, aNext) {
 
       // Make sure the change is reflected in the session store
       updateSessions(aReq, aUser, function (aErr, aSess) {
-        aRes.redirect(user.userPageUrl);
+        aRes.redirect(user.userPageUri);
       });
     });
   });
@@ -497,6 +497,6 @@ exports.authAsUser = function (aReq, aRes, aNext) {
 
     aReq.session.user = user;
 
-    aRes.redirect(encodeURI(user.userPageUrl)); // NOTE: Watchpoint
+    aRes.redirect(user.userPageUri);
   });
 };

--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -172,7 +172,7 @@ exports.callback = function (aReq, aRes, aNext) {
   var username = aReq.session.username;
   var newstrategy = aReq.session.newstrategy;
   var strategyInstance = null;
-  var doneUrl = aReq.session.user ? '/user/preferences' : '/';
+  var doneUri = aReq.session.user ? '/user/preferences' : '/';
 
   // The callback was called improperly
   if (!strategy || !username) {
@@ -231,7 +231,7 @@ exports.callback = function (aReq, aRes, aNext) {
         console.error(chalk.red('`User` not found'));
       }
 
-      aRes.redirect(doneUrl + (doneUrl === '/' ? 'register' : '') + '?authfail');
+      aRes.redirect(doneUri + (doneUri === '/' ? 'register' : '') + '?authfail');
       return;
     }
 
@@ -263,16 +263,16 @@ exports.callback = function (aReq, aRes, aNext) {
       addSession(aReq, aUser, function () {
         if (newstrategy && newstrategy !== strategy) {
           // Allow a user to link to another account
-          aRes.redirect('/auth/' + newstrategy);
+          aRes.redirect('/auth/' + newstrategy); // NOTE: Watchpoint... careful with encoding
           return;
         } else {
           // Delete the username that was temporarily stored
           delete aReq.session.username;
           delete aReq.session.newstrategy;
-          doneUrl = aReq.session.redirectTo;
+          doneUri = aReq.session.redirectTo;
           delete aReq.session.redirectTo;
 
-          aRes.redirect(doneUrl);
+          aRes.redirect(doneUri);
           return;
         }
       });

--- a/controllers/discussion.js
+++ b/controllers/discussion.js
@@ -525,8 +525,10 @@ exports.createTopic = function (aReq, aRes, aNext) {
       return;
     }
 
-    aRes.redirect(encodeURI(aDiscussion.path
-      + (aDiscussion.duplicateId ? '_' + aDiscussion.duplicateId : '')));
+    aRes.redirect(aDiscussion.path.split('/').map(function (aStr) {
+      return encodeURIComponent(aStr);
+    }).join('/')
+      + (aDiscussion.duplicateId ? '_' + aDiscussion.duplicateId : ''));
   });
 };
 
@@ -560,8 +562,10 @@ exports.createComment = function (aReq, aRes, aNext) {
     }
 
     postComment(authedUser, aDiscussion, content, false, function (aErr, aDiscussion) {
-      aRes.redirect(encodeURI(aDiscussion.path
-        + (aDiscussion.duplicateId ? '_' + aDiscussion.duplicateId : '')));
+      aRes.redirect(aDiscussion.path.split('/').map(function (aStr) {
+        return encodeURIComponent(aStr);
+      }).join('/') +
+        (aDiscussion.duplicateId ? '_' + aDiscussion.duplicateId : ''));
     });
   });
 };

--- a/controllers/index.js
+++ b/controllers/index.js
@@ -297,16 +297,16 @@ exports.register = function (aReq, aRes) {
 
 exports.logout = function (aReq, aRes) {
   var authedUser = aReq.session.user;
-  var redirectUrl = getRedirect(aReq);
+  var redirectUri = getRedirect(aReq); // NOTE: Watchpoint
 
   if (!authedUser) {
-    aRes.redirect(redirectUrl);
+    aRes.redirect(redirectUri);
     return;
   }
 
   User.findOne({ _id: authedUser._id }, function (aErr, aUser) {
     removeSession(aReq, aUser, function () {
-      aRes.redirect(redirectUrl);
+      aRes.redirect(redirectUri);
     });
   });
 };

--- a/controllers/issue.js
+++ b/controllers/issue.js
@@ -380,12 +380,14 @@ exports.open = function (aReq, aRes, aNext) {
         discussionLib.postTopic(authedUser, category.slug, topic, content, true,
           function (aDiscussion) {
             if (!aDiscussion) {
-              aRes.redirect('/' + encodeURI(category) + '/open');
+              aRes.redirect('/' + category.slugUri + '/open');
               return;
             }
 
-            aRes.redirect(encodeURI(aDiscussion.path +
-              (aDiscussion.duplicateId ? '_' + aDiscussion.duplicateId : '')));
+            aRes.redirect(aDiscussion.path.split('/').map(function (aStr) {
+              return encodeURIComponent(aStr);
+            }).join('/') +
+              (aDiscussion.duplicateId ? '_' + aDiscussion.duplicateId : ''));
           }
         );
       } else {
@@ -439,8 +441,10 @@ exports.comment = function (aReq, aRes, aNext) {
 
         discussionLib.postComment(authedUser, aIssue, content, false,
           function (aErr, aDiscussion) {
-            aRes.redirect(encodeURI(aDiscussion.path
-              + (aDiscussion.duplicateId ? '_' + aDiscussion.duplicateId : '')));
+            aRes.redirect(aDiscussion.path.split('/').map(function (aStr) {
+              return encodeURIComponent(aStr);
+            }).join('/') +
+              (aDiscussion.duplicateId ? '_' + aDiscussion.duplicateId : ''));
           });
       });
     });
@@ -487,8 +491,10 @@ exports.changeStatus = function (aReq, aRes, aNext) {
 
         if (changed) {
           aIssue.save(function (aErr, aDiscussion) {
-            aRes.redirect(encodeURI(aDiscussion.path
-              + (aDiscussion.duplicateId ? '_' + aDiscussion.duplicateId : '')));
+            aRes.redirect(aDiscussion.path.split('/').map(function (aStr) {
+              return encodeURIComponent(aStr);
+            }).join('/') +
+              (aDiscussion.duplicateId ? '_' + aDiscussion.duplicateId : ''));
           });
         } else {
           aNext();

--- a/controllers/script.js
+++ b/controllers/script.js
@@ -467,7 +467,7 @@ exports.edit = function (aReq, aRes, aNext) {
       if (aReq.body.remove) {
         // POST
         scriptStorage.deleteScript(aScript.installName, function () {
-          aRes.redirect(authedUser.userScriptListPageUrl);
+          aRes.redirect(authedUser.userScriptListPageUri);
         });
       } else if (typeof aReq.body.about !== 'undefined') {
         // POST
@@ -475,7 +475,7 @@ exports.edit = function (aReq, aRes, aNext) {
         scriptGroups = (aReq.body.groups || '');
         scriptGroups = scriptGroups.split(/,/);
         addScriptToGroups(aScript, scriptGroups, function () {
-          aRes.redirect(script.scriptPageUrl);
+          aRes.redirect(script.scriptPageUri);
         });
       } else {
         // GET
@@ -495,7 +495,7 @@ exports.edit = function (aReq, aRes, aNext) {
 // Script voting
 exports.vote = function (aReq, aRes, aNext) {
   //
-  var url = aReq._parsedUrl.pathname.split('/');
+  var uri = aReq._parsedUrl.pathname.split('/');
   var vote = aReq.params.vote;
   var unvote = false;
 
@@ -503,12 +503,12 @@ exports.vote = function (aReq, aRes, aNext) {
   var installNameBase = scriptStorage.getInstallNameBase(aReq);
 
   // ---
-  if (url.length > 5) {
-    url.pop();
+  if (uri.length > 5) {
+    uri.pop();
   }
-  url.shift();
-  url.shift();
-  url = '/' + url.join('/');
+  uri.shift();
+  uri.shift();
+  uri = '/' + uri.join('/');
 
   if (vote === 'up') {
     vote = true;
@@ -517,7 +517,7 @@ exports.vote = function (aReq, aRes, aNext) {
   } else if (vote === 'unvote') {
     unvote = true;
   } else {
-    aRes.redirect(url);
+    aRes.redirect(uri);
     return;
   }
 
@@ -530,7 +530,7 @@ exports.vote = function (aReq, aRes, aNext) {
 
       // ---
       if (aErr || !aScript) {
-        aRes.redirect(url);
+        aRes.redirect(uri);
         return;
       }
 
@@ -543,7 +543,7 @@ exports.vote = function (aReq, aRes, aNext) {
           function saveScript() {
             if (!flags) {
               aScript.save(function (aErr, aScript) {
-                aRes.redirect(url);
+                aRes.redirect(uri);
               });
               return;
             }
@@ -551,7 +551,7 @@ exports.vote = function (aReq, aRes, aNext) {
             flagLib.getAuthor(aScript, function (aAuthor) {
               flagLib.saveContent(Script, aScript, aAuthor, flags,
                 function (aFlagged) {
-                  aRes.redirect(url);
+                  aRes.redirect(uri);
                 });
             });
           }
@@ -565,7 +565,7 @@ exports.vote = function (aReq, aRes, aNext) {
           }
 
           if (authedUser._id == aScript._authorId || (!aVoteModel && unvote)) {
-            aRes.redirect(url);
+            aRes.redirect(uri);
             return;
           } else if (!aVoteModel) {
             aVoteModel = new Vote({

--- a/controllers/scriptStorage.js
+++ b/controllers/scriptStorage.js
@@ -26,6 +26,7 @@ var RepoManager = require('../libs/repoManager');
 
 var cleanFilename = require('../libs/helpers').cleanFilename;
 var findDeadorAlive = require('../libs/remove').findDeadorAlive;
+var encode = require('../libs/helpers').encode;
 
 //--- Configuration inclusions
 var userRoles = require('../models/userRoles.json');
@@ -87,6 +88,9 @@ function getInstallNameBase(aReq, aOptions) {
     case 'uri':
       base = encodeURIComponent(username) + '/' + encodeURIComponent(scriptname);
       break;
+
+    case 'url':
+      base = encode(username) + '/' + encode(scriptname);
 
     default:
       base = username + '/' + scriptname;
@@ -733,7 +737,11 @@ exports.webhook = function (aReq, aRes) {
     payload.commits.forEach(function (aCommit) {
       aCommit.modified.forEach(function (aFilename) {
         if (aFilename.substr(-8) === '.user.js') {
-          repo[aFilename] = '/' + encodeURI(aFilename);
+          console.log([
+            'Webhook filename:',
+            '  ' + aFilename
+          ].join('\n')); // TODO: After some data collected, reaffirm and remove this
+          repo[aFilename] = '/' + encodeURI(aFilename); // NOTE: Watchpoint
         }
       });
     });

--- a/libs/helpers.js
+++ b/libs/helpers.js
@@ -96,6 +96,19 @@ exports.cleanFilename = function (aFilename, aDefaultName) {
   return cleanName || aDefaultName;
 };
 
+// Smarter encoder
+exports.encode = function (aStr) {
+  try {
+    // Check for bad decoding
+    decodeURIComponent(aStr);
+
+    return aStr;
+
+  } catch (aE) {
+    return encodeURIComponent(aStr);
+  }
+}
+
 exports.limitRange = function (aMin, aX, aMax, aDefault) {
   var x = Math.max(Math.min(aX, aMax), aMin);
 

--- a/routes.js
+++ b/routes.js
@@ -57,14 +57,15 @@ module.exports = function (aApp) {
   aApp.route('/user/add').get(function (aReq, aRes) { aRes.redirect('/user/add/scripts'); });
 
   // Script routes
-  aApp.route('/scripts/:username/:namespace?/:scriptname').get(script.view);
-  aApp.route('/scripts/:username/:namespace?/:scriptname/edit').get(authentication.validateUser, script.edit).post(authentication.validateUser, script.edit);
-  aApp.route('/scripts/:username/:namespace?/:scriptname/source').get(user.editScript);
+  aApp.route('/scripts/:username/:scriptname').get(script.view);
+  aApp.route('/scripts/:username/:scriptname/edit').get(authentication.validateUser, script.edit).post(authentication.validateUser, script.edit);
+  aApp.route('/scripts/:username/:scriptname/source').get(user.editScript);
   aApp.route('/scripts/:username').get(function (aReq, aRes) {
-    aRes.redirect('/users/' + aReq.params.username + '/scripts');
+    aRes.redirect('/users/' + aReq.params.username + '/scripts'); // NOTE: Watchpoint
   });
-  aApp.route('/install/:username/:namespace?/:scriptname').get(scriptStorage.sendScript);
-  aApp.route('/meta/:username/:namespace?/:scriptname').get(scriptStorage.sendMeta);
+
+  aApp.route('/install/:username/:scriptname').get(scriptStorage.sendScript);
+  aApp.route('/meta/:username/:scriptname').get(scriptStorage.sendMeta);
 
   // Github hook routes
   aApp.route('/github/hook').post(scriptStorage.webhook);
@@ -80,10 +81,10 @@ module.exports = function (aApp) {
   aApp.route('/src/:type(scripts|libs)/:username/:scriptname').get(scriptStorage.sendScript);
 
   // Issues routes
-  aApp.route('/:type(scripts|libs)/:username/:namespace?/:scriptname/issues/:open(open|closed|all)?').get(issue.list);
-  aApp.route('/:type(scripts|libs)/:username/:namespace?/:scriptname/issue/new').get(authentication.validateUser, issue.open).post(authentication.validateUser, issue.open);
-  aApp.route('/:type(scripts|libs)/:username/:namespace?/:scriptname/issues/:topic').get(issue.view).post(authentication.validateUser, issue.comment);
-  aApp.route('/:type(scripts|libs)/:username/:namespace?/:scriptname/issues/:topic/:action(close|reopen)').get(authentication.validateUser, issue.changeStatus);
+  aApp.route('/:type(scripts|libs)/:username/:scriptname/issues/:open(open|closed|all)?').get(issue.list);
+  aApp.route('/:type(scripts|libs)/:username/:scriptname/issue/new').get(authentication.validateUser, issue.open).post(authentication.validateUser, issue.open);
+  aApp.route('/:type(scripts|libs)/:username/:scriptname/issues/:topic').get(issue.view).post(authentication.validateUser, issue.comment);
+  aApp.route('/:type(scripts|libs)/:username/:scriptname/issues/:topic/:action(close|reopen)').get(authentication.validateUser, issue.changeStatus);
 
   // Admin routes
   aApp.route('/admin').get(admin.adminPage);
@@ -103,7 +104,7 @@ module.exports = function (aApp) {
 
   // Vote routes
   // TODO: Single vote route + POST
-  aApp.route('/vote/scripts/:username/:namespace?/:scriptname/:vote').get(authentication.validateUser, script.vote);
+  aApp.route('/vote/scripts/:username/:scriptname/:vote').get(authentication.validateUser, script.vote);
   aApp.route('/vote/libs/:username/:scriptname/:vote').get(authentication.validateUser, script.lib(script.vote));
 
   // Flag routes

--- a/views/pages/scriptPage.html
+++ b/views/pages/scriptPage.html
@@ -58,7 +58,7 @@
                 <ul>
                 {{#script.fork}}
                   <li>
-                    <a href="/{{#script.isLib}}libs{{/script.isLib}}{{^script.isLib}}scripts{{/script.isLib}}/{{{url}}">{{url}}</a>
+                    <a href="/{{#script.isLib}}libs{{/script.isLib}}{{^script.isLib}}scripts{{/script.isLib}}/{{{url}}">{{utf}}</a>
                   </li>
                 {{/script.fork}}
                 </ul>


### PR DESCRIPTION
* Remove legacy namespace in all routes ... part of #262 and #130... officially EOL as per sizzle and confirmed by me... no redirects.
* Remove the patches I put in for this portion
* Create function for encoding similar to GH's... see helper `encoding`
* Using encodeURIComponent from #795
* Fix bug of Fork History showing "slugged" instead of native/raw
* Fix category reference bug... redirect was set to the Object itself and not one of its properties
* Fix some more missing object identifiers in modelParser.js ... not all are validated yet and some may still be missing for future proofing
* Remove and Add some more watchpoints
* Flip successful "rating updated" for Groups to debug mode and related in `./libs/modelParser.js` ... these are generating too much log traffic #430

**NOTES**
* [ ] Followup with DB migration to add `fork.utf` to existing forks otherwise they may not show up next to the bullet
* Leaving GH import alone as it still works so far ... however a watchpoint added... GH web UI always `encodeURIComponent` just about everything... will need to reaffirm existing `encodeURI` later
* The term uri is inclusive to urls as previously described in #819 ... however in this context url means it could be partially encoded whereas uri means it absolutely is encoded... except for the slashes... normally those are encoded but we don't want them encoded... again following GH example. A url containing `ä` may be just that however a uri has `%E4`. You will notice that I renamed some of our identifiers from `url` to `uri`... this is on purpose to indicate that is what we are expecting.
* *express* `redirect()` uses [`Location`](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.30) and [`Content-Location`](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.14) headers. This requires all urls to be at least URI encoded as per specs... e.g. all the browsers are adding in an `escape` for the section symbol *which may be an issue with them*. So hence why the naming of `url` vs `uri`.
* The base issue of readability of the code is still there... but at least this punches out some of the bugs mentioned.
* Compression/optimization hasn't occurred yet
* No DB migration is necessary now... this includes fixing `Re:` linkage
* The smarter encoder isn't finished yet as I may be rearranging this a bit but...

**This should knock out the BLOCKING label I put on**... at least from my perspective.

Applies to #819 and #262... treads on https://github.com/OpenUserJs/OpenUserJS.org/issues/262#issuecomment-57592127 among many others.