### PR TITLE
More followup for source code has tiny height

### DIFF
--- a/views/includes/scripts/scriptEditor.html
+++ b/views/includes/scripts/scriptEditor.html
@@ -30,6 +30,11 @@
         return window.innerHeight - {{#newScript}}190{{/newScript}}{{^newScript}}302{{/newScript}};
       }
 
+      function onresize() {
+        $("#editor").height(calcHeight);
+        editor.resize(true);
+      }
+
       editor.setTheme("ace/theme/dawn");
       editor.getSession().setMode("ace/mode/javascript");
 
@@ -45,10 +50,6 @@
       // Some older and newer browser JavaScript work-around for #136
       if (!hasOurRelative()) {
         $("#editor").height(calcHeight());
-
-        function onresize() {
-          $("#editor").height(calcHeight);
-        }
 
         if (window.addEventListener) {
           window.addEventListener('resize', onresize, false);


### PR DESCRIPTION
* Ace needs a hard resize event pushed for some newer browsers when maximizing. e.g. show more lines in code
* Push the function up so it doesn't generate a strict warning if we add that

Applies to #136