### PR TITLE
A dependency downgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "marked": "0.3.5",
     "method-override": "2.3.5",
     "moment": "2.11.2",
-    "mongoose": "4.4.5",
+    "mongoose": "4.4.4",
     "morgan": "1.7.0",
     "mu2": "0.5.20",
     "octicons": "3.5.0",


### PR DESCRIPTION
* *mongoose* somehow is affecting https://openuserjs.org/all by not showing all discussions... was working in previous version