### PR TITLE
Move *express-minify* cache from memory to disk

### DIFF
--- a/app.js
+++ b/app.js
@@ -239,6 +239,7 @@ var minifyErrorHandler = function (aErr, aStage, aAssetType, aMinifyOptions, aBo
 
 if (minify && !isDbg) {
   app.use(minify({
+    cache: './dev/cache/express-minify/release',
     onerror: minifyErrorHandler
   }));
 }

--- a/dev/cache/express-minify/release/.gitignore
+++ b/dev/cache/express-minify/release/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
* This way it's cross-platform and very little manual maintenance.
* Occasionally a job duty task may be needed to clean stale entries in this folder.
* Currently saves about 800KiB but that should be cached RAM available to be used elsewhere. This estimate could grow/shrink depending on what is shared and how many concurrent hits are encountered. Does take a few milliseconds longer to retrieve the cached file.
* Reversible and can be automated for cleanup later
* Start at `./dev/cache` folder.

Refs:
* https://git.wiki.kernel.org/index.php/GitFaq#Can_I_add_empty_directories.3F
* https://github.com/SummerWish/express-minify/issues/30#issuecomment-182164531

Applies to #249