### PR TITLE
Post fix for `@supportURL` and `homepageURL`

### DIFF
--- a/controllers/script.js
+++ b/controllers/script.js
@@ -33,6 +33,7 @@ var removeLib = require('../libs/remove');
 var modelQuery = require('../libs/modelQuery');
 var modelParser = require('../libs/modelParser');
 
+var decode = require('../libs/helpers').decode;
 var countTask = require('../libs/tasks').countTask;
 var pageMetadata = require('../libs/templateHelpers').pageMetadata;
 
@@ -119,12 +120,14 @@ var getScriptPageTasks = function (aOptions) {
     homepageURL.forEach(function (aElement, aIndex, aArray) {
       htmlStub = '<a href="' + aElement.value + '"></a>';
       if (htmlStub === sanitizeHtml(htmlStub, htmlWhitelistLink)) {
+
         aOptions.script.homepages.unshift({
           url: aElement.value,
-          text: decodeURI(aElement.value),
+          text: decode(aElement.value),
           hasNoFollow: !/^(?:https?:\/\/)?openuserjs\.org\//i.
             test(aElement.value)
         });
+
       }
     });
   }

--- a/libs/helpers.js
+++ b/libs/helpers.js
@@ -109,6 +109,16 @@ exports.encode = function (aStr) {
   }
 }
 
+exports.decode = function (aStr) {
+  try {
+    // Check for bad decoding
+    return decodeURIComponent(aStr);
+
+  } catch (aE) {
+    return aStr;
+  }
+}
+
 exports.limitRange = function (aMin, aX, aMax, aDefault) {
   var x = Math.max(Math.min(aX, aMax), aMin);
 

--- a/libs/modelParser.js
+++ b/libs/modelParser.js
@@ -24,6 +24,7 @@ var renderMd = require('../libs/markdown').renderMd;
 var getRating = require('../libs/collectiveRating').getRating;
 var cleanFilename = require('../libs/helpers').cleanFilename;
 var encode = require('../libs/helpers').encode;
+var decode = require('../libs/helpers').decode;
 
 //--- Configuration inclusions
 var htmlWhitelistLink = require('./htmlWhitelistLink.json');
@@ -241,13 +242,15 @@ var parseScript = function (aScript) {
   if (supportURL) {
     htmlStub = '<a href="' + supportURL + '"></a>';
     if (htmlStub === sanitizeHtml(htmlStub, htmlWhitelistLink)) {
+
       script.hasSupport = true;
 
       script.support = [{
         url: supportURL,
-        text: decodeURI(supportURL),
+        text: decode(supportURL),
         hasNoFollow: !/^(?:https?:\/\/)?openuserjs\.org/i.test(supportURL)
       }];
+
     }
   }
 


### PR DESCRIPTION
* Trap if a Userscript doesn't encode one of these urls correctly. Fixes "Page Load Error" with "Failed to Connect"... server trip

Applies to #819, #239, #197, and #189

Ref:
* https://openuserjs.org/discuss/webhook_not_working