### PR TITLE
Add Minified Source dropdown to Raw Source script page

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -1664,6 +1664,9 @@ exports.editScript = function (aReq, aRes, aNext) {
         script.scriptRawPageUrl = '/src/' + (isLib ? 'libs' : 'scripts') + '/'
           + scriptStorage.getInstallNameBase(aReq, { encoding: 'uri' }) +
             (isLib ? '.js#' : '.user.js#');
+        script.scriptRawPageXUrl = '/src/' + (isLib ? 'libs' : 'scripts') + '/'
+          + scriptStorage.getInstallNameBase(aReq, { encoding: 'uri' }) +
+            (isLib ? '.min.js#' : '.min.user.js#');
 
         // Page metadata
         pageMetadata(options);

--- a/views/includes/scriptPageHeader.html
+++ b/views/includes/scriptPageHeader.html
@@ -31,9 +31,32 @@
     {{/script.isLib}}
   {{/isScriptPage}}
   {{#isScriptViewSourcePage}}
-    <a href="{{{script.scriptRawPageUrl}}}" class="btn btn-info pull-right">
-      <i class="fa fa-file-{{#script.isLib}}excel{{/script.isLib}}{{^script.isLib}}code{{/script.isLib}}-o"></i> Raw Source
-    </a>
+    <div class="btn-group pull-right">
+      <a href="{{{script.scriptRawPageUrl}}}" class="btn btn-info">
+        <i class="fa fa-file-{{#script.isLib}}excel{{/script.isLib}}{{^script.isLib}}code{{/script.isLib}}-o"></i> Raw Source
+      </a>
+      <button type="button" class="btn btn-info dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <span class="caret"></span>
+        <span class="sr-only">Toggle Dropdown</span>
+      </button>
+      <ul class="dropdown-menu">
+        <li>
+          <div class="btn-group btn-group-justified">
+            <a href="{{{script.scriptRawPageXUrl}}}" class="btn btn-{{#script.showMinficationNotices}}warning{{/script.showMinficationNotices}}{{^script.showMinficationNotices}}primary{{/script.showMinficationNotices}}" title="EXPERIMENTAL"><i class="fa fa-file-{{#script.isLib}}excel{{/script.isLib}}{{^script.isLib}}code{{/script.isLib}}-o"></i> Minified Source</a>
+          </div>
+          {{#script.showMinficationNotices}}
+          <div class="alert alert-warning" role="alert">
+            {{#script.hasUnstableMinify}}
+              <p>
+                <i class="fa fa-fw fa-exclamation-triangle"></i> The script author suggests that minification of this script may be unstable.
+              <p>
+            {{/script.hasUnstableMinify}}
+          </div>
+          {{/script.showMinficationNotices}}
+        </li>
+      </ul>
+    </div>
+
   {{/isScriptViewSourcePage}}
   {{#script.icon45Url}}
   <span class="page-heading-icon" {{#script.icon45Url}}data-icon-src="{{{script.icon45Url}}}"{{/script.icon45Url}}>


### PR DESCRIPTION
* For easier access
* Reusing X suffix here to denote somethings different than standard... eventually identifier standardization will apply

**NOTES**
*bootstrap* isn't very forgiving on the width. If the text in the button is too wide it could produce horizontal scroll bars on the window. Tested with default notice if available.

Applies to #432