### PR TITLE
Set up a `Warning` header for minification failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Repository | Reference | Recent Version
 [passport-yahoo][passport-yahooGHUrl] | [Documentation][passport-yahooDOCUrl] | [![NPM version][passport-yahooNPMVersionImage]][passport-yahooNPMUrl]
 [pegjs][pegjsGHUrl] | [Documentation][pegjsDOCUrl] | [![NPM version][pegjsNPMVersionImage]][pegjsNPMUrl]
 [request][requestGHUrl] | [Documentation][requestDOCUrl] | [![NPM version][requestNPMVersionImage]][requestNPMUrl]
+[rfc2047][rfc2047GHUrl] | [Documentation][rfc2047DOCUrl] | [![NPM version][rfc2047NPMVersionImage]][rfc2047NPMUrl]
 [sanitize-html][sanitize-htmlGHUrl] | [Documentation][sanitize-htmlDOCUrl] | [![NPM version][sanitize-htmlNPMVersionImage]][sanitize-htmlNPMUrl]
 [select2][select2GHUrl] | [Documentation][select2DOCUrl] | [![NPM version][select2NPMVersionImage]][select2NPMUrl]
 [select2-bootstrap-css][select2-bootstrap-cssGHUrl] | [Documentation][select2-bootstrap-cssDOCUrl] | [![NPM version][select2-bootstrap-cssNPMVersionImage]][select2-bootstrap-cssNPMUrl]
@@ -375,6 +376,11 @@ Outdated dependencies list can also be achieved with `$ npm --depth 0 outdated`
 [requestDOCUrl]: https://github.com/request/request/blob/master/README.md
 [requestNPMUrl]: https://www.npmjs.com/package/request
 [requestNPMVersionImage]: https://img.shields.io/npm/v/request.svg?style=flat
+
+[rfc2047GHUrl]: https://github.com/One-com/rfc2047
+[rfc2047DOCUrl]: https://github.com/One-com/rfc2047/blob/master/README.md
+[rfc2047NPMUrl]: https://www.npmjs.com/package/rfc2047
+[rfc2047NPMVersionImage]: https://img.shields.io/npm/v/rfc2047.svg?style=flat
 
 [sanitize-htmlGHUrl]: https://github.com/punkave/sanitize-html
 [sanitize-htmlDOCUrl]: https://github.com/punkave/sanitize-html/blob/master/README.md

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "passport-yahoo": "0.3.0",
     "pegjs": "0.9.0",
     "request": "2.69.0",
+    "rfc2047": "2.0.0",
     "sanitize-html": "1.11.3",
     "select2": "3.5.2-browserify",
     "select2-bootstrap-css": "1.4.6",


### PR DESCRIPTION
* New dep *rfc2047* to allow external viewing of *UglifyJS2* message warning via header... this one appears to follow the spec as closely as possible unlike some others
* No known guarantee that `message`s from *UglifyJS2* will be ISO-8859-1 so Q encode under RFC2047
* Since it is MIME format typically this should be wrapped at 76 characters... however *express*/*node* throws an exception... current deviation from the spec
* *express* currently only handles one `Warning` header which isn't to spec as well... see http://expressjs.com/en/api.html#res.set
* *node* currently only handles one `Warning` header which isn't spec as well... see https://nodejs.org/api/http.html#http_response_setheader_name_value
* *express* should be sending HTTP/1.1 so no matching date should be required for compliance as per spec

Ref:
* http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.46

Applies to #432