### PR TITLE
Transform two common extended ASCII *(Unicode) chars to back ticks if…

### DIFF
--- a/controllers/scriptStorage.js
+++ b/controllers/scriptStorage.js
@@ -265,8 +265,8 @@ exports.sendScript = function (aReq, aRes, aNext) {
           // Set up a `Warning` header with Q encoding under RFC2047
           msg = [
             '199 ' + aReq.headers.host + ' MINIFICATION WARNING (harmony):',
-            '  ' + rfc2047.encode(aE.message),
-            '  line: ' + aE.line + ' col: ' + aE.col + ' pos: ' + aE.pos
+            '  ' + rfc2047.encode(aE.message.replace(/\xAB/g, '`').replace(/\xBB/g, '`')),
+            '  line: ' + aE.line + ' col: ' + aE.col + ' pos: ' + aE.pos,
 
           ].join('\u0020'); // TODO: Watchpoint... *express*/*node* exception thrown with CRLF SPACE spec
 


### PR DESCRIPTION
… present

* Appears that the `«` and the `»` aren't in a *UglifyJS2* code search... so do this on our end so it's more readable

Applies to #432 and post fix for #923 ... also suggested at https://github.com/mishoo/UglifyJS2/issues/1001#issuecomment-194553846