### PR TITLE
Readd other notices back in

### DIFF
--- a/libs/modelParser.js
+++ b/libs/modelParser.js
@@ -184,6 +184,11 @@ var parseScript = function (aScript) {
   var icon = null;
   var supportURL = null;
 
+  var downloadURL = null;
+  var downloadUtf = null;
+  var rAnySourceUrl = new RegExp('^https?://(?:openuserjs\.org|localhost:' +
+    (process.env.PORT || 8080) + ')/(?:install|scr/scripts)\/(.+?)/(.+?)((?:\.min)?\.user\.js)$');
+
   // Temporaries
   var htmlStub = null;
 
@@ -199,6 +204,7 @@ var parseScript = function (aScript) {
 
   var folders = null;
 
+  var matches = null;
 
   if (!aScript) {
     return;
@@ -360,6 +366,39 @@ var parseScript = function (aScript) {
 
   if (script._since && script.updated && script._since.toString() !== script.updated.toString()) {
     script.isUpdated = true;
+  }
+
+  // Download Url
+  downloadURL = findMeta(script.meta, 'UserScript.downloadURL.0.value');
+  if (downloadURL) {
+    try {
+      downloadUtf = decodeURIComponent(downloadURL);
+
+    } catch (aE) {
+      script.hasInvalidDownloadURL = true;
+      script.showMinficationNotices = true;
+
+    } finally {
+      if (!script.hasInvalidDownloadURL)  {
+        matches = downloadUtf.match(rAnySourceUrl);
+
+        if (matches) {
+          if (matches[1].toLowerCase() === script.authorSlug.toLowerCase() &&
+            matches[2] === script.nameSlug) {
+
+            if (matches[3] === '.user.js') {
+              script.hasAlternateDownloadURL = true;
+            }
+          } else {
+            script.hasAlternateDownloadURL = true;
+            script.showMinficationNotices = true;
+          }
+        } else {
+          script.hasAlternateDownloadURL = true;
+          script.showMinficationNotices = true;
+        }
+      }
+    }
   }
 
   return script;

--- a/views/includes/scriptPageHeader.html
+++ b/views/includes/scriptPageHeader.html
@@ -12,15 +12,25 @@
       <ul class="dropdown-menu">
         <li>
           <div class="btn-group btn-group-justified">
-            <a href="{{{script.scriptInstallPageXUrl}}}.min.user.js" class="btn btn-{{#script.showMinficationNotices}}warning{{/script.showMinficationNotices}}{{^script.showMinficationNotices}}primary{{/script.showMinficationNotices}}" title="EXPERIMENTAL INSTALLATION FORKING"><i class="fa fa-fw fa-download"></i> Install with minification</a>
+            <a href="{{{script.scriptInstallPageXUrl}}}.min.user.js" class="btn btn-{{#script.showMinficationNotices}}warning{{/script.showMinficationNotices}}{{^script.showMinficationNotices}}primary{{/script.showMinficationNotices}}" title="EXPERIMENTAL INSTALLATION FORKING"><i class="fa fa-fw fa-download"></i> Install {{#script.hasAlternateDownloadURL}}once {{/script.hasAlternateDownloadURL}} with minification</a>
           </div>
           {{#script.showMinficationNotices}}
           <div class="alert alert-warning" role="alert">
+            {{#script.hasInvalidDownloadURL}}
+              <p>
+                <i class="fa fa-fw fa-exclamation"></i> Invalid download target
+              </p>
+            {{/script.hasInvalidDownloadURL}}
             {{#script.hasUnstableMinify}}
               <p>
                 <i class="fa fa-fw fa-exclamation-triangle"></i> The script author suggests that minification of this script may be unstable.
               <p>
             {{/script.hasUnstableMinify}}
+            {{#script.hasAlternateDownloadURL}}
+              <p>
+                <i class="fa fa-fw fa-exclamation-triangle"></i> Alternate download target.
+              </p>
+            {{/script.hasAlternateDownloadURL}}
           </div>
           {{/script.showMinficationNotices}}
         </li>


### PR DESCRIPTION
* Total of four type values tested... twiddle to get used to it.
* "once" means it will only do it once for minification... updates may clobber minified installations... this is intentional to get testing done for the harmony branch.

**NOTES**
* *node* has some issues with encoding using *url* right now otherwise I might have gone that route... don't want to guess if they'll be using `escape`, `encodeURI`, and/or `encodeURIComponent`... or worse some other percent encoding.
* ES6 might make this a little simpler/different to do with Unicode regular expressions... but we're ES5 still

Applies to #432