### PR TITLE
Admin and back-end fixes

### DIFF
--- a/app.js
+++ b/app.js
@@ -248,7 +248,11 @@ app.use(function(aReq, aRes, aNext) {
   var pathname = aReq._parsedUrl.pathname;
 
   // If a userscript or library...
-  if (/(\.user)?\.js|\.meta.js(on)?$/.test(pathname) && /^\/(meta|install|src)\//.test(pathname)) {
+  if (
+    (/(\.user)?\.js|\.meta.js(on)?$/.test(pathname) && /^\/(meta|install|src)\//.test(pathname)) ||
+      /^\/admin\/(npm|json)/.test(pathname) ||
+        /^\/mod\/removed\//.test(pathname)
+  ) {
     aRes._skip = true; // ... skip using release minification
   }
   aNext();

--- a/controllers/group.js
+++ b/controllers/group.js
@@ -48,7 +48,7 @@ exports.search = function (aReq, aRes) {
   var terms = term.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, '\\$1').split(/\s+/);
   var results = null;
 
-  aRes.set('Content-Type', 'application/json');
+  aRes.set('Content-Type', 'application/json; charset=UTF-8');
   if (terms.length === 0) {
     return aRes.end(JSON.stringify([]));
   }

--- a/controllers/moderation.js
+++ b/controllers/moderation.js
@@ -50,7 +50,7 @@ exports.removedItemPage = function (aReq, aRes, aNext) {
     return;
   }
 
-  Remove.find({
+  Remove.findOne({
     _id: removedItemId
   }, function (aErr, aRemovedItem) {
     if (aErr || !aRemovedItem) {
@@ -58,7 +58,13 @@ exports.removedItemPage = function (aReq, aRes, aNext) {
       return;
     }
 
-    aRes.json(aRemovedItem);
+    aRes.set('Content-Type', 'application/json; charset=UTF-8');
+    aRes.write(JSON.stringify(
+      aRemovedItem.toObject ? aRemovedItem.toObject({ virtuals: true }) : aRemovedItem,
+      null,
+      isPro ? '' : ' ')
+    );
+    aRes.end();
   });
 };
 

--- a/controllers/scriptStorage.js
+++ b/controllers/scriptStorage.js
@@ -651,8 +651,10 @@ exports.storeScript = function (aUser, aMeta, aBuf, aCallback, aUpdate) {
             // Don't save a script if storing failed
             if (aErr) {
               console.error(aUser.name, '-', installName);
-              console.error(JSON.stringify(aErr));
-              console.error(JSON.stringify(aScript.toObject()));
+              console.error(JSON.stringify(aErr, null, ' '));
+              console.error(JSON.stringify(
+                aScript.toObject ? aScript.toObject({ virtuals: true }) : aScript, null, ' ')
+              );
               aCallback(null);
               return;
             }

--- a/routes.js
+++ b/routes.js
@@ -90,7 +90,6 @@ module.exports = function (aApp) {
   aApp.route('/admin').get(admin.adminPage);
   aApp.route('/admin/authas').get(admin.authAsUser);
   aApp.route('/admin/json').get(admin.adminJsonView);
-  aApp.route('/admin/user/:id').get(admin.adminUserView);
   aApp.route('/admin/api').get(admin.adminApiKeysPage);
   aApp.route('/admin/npm/package').get(admin.adminNpmPackageView);
   aApp.route('/admin/npm/list').get(admin.adminNpmListView);


### PR DESCRIPTION
* Move other JSON minification to `JSON.stringify` instead of *express-minify*... applies to #432 and followup for #899
* Remove some legacy dead code w/ route... can cause server trip
* Add some graceful failures for JSON pages... applies to #37
* Stop using `res.json` as it's not very configurable... do it manually with `Content-Type` header and such
* Add `virtuals` to JSON output if available
* Fix `find` to `findOne` in moderation removed item routine... removes outer `Array` notation and makes it look more like the model... one would hope there would be a unique id in this case
* Add a missing `charset`

Applies to #249 and some of #262