### PR TITLE
Refix negative absolute flags

### DIFF
--- a/libs/flag.js
+++ b/libs/flag.js
@@ -109,7 +109,8 @@ function saveContent(aModel, aContent, aAuthor, aFlags, aCallback) {
   }
 
   aContent.flags.critical += aFlags;
-  aContent.flags.absolute += (aFlags > 0 ? 1 : (aFlags < 0 ? -1 : 0)); // NOTE: ES6 `Math.sign(x)`
+  aContent.flags.absolute +=
+    (aFlags > 0 ? 1 : (aFlags < 0 && aContent.flags.absolute !== 0 ? -1 : 0));
 
   if (aContent.flags.critical >= thresholds[aModel.modelName] * (aAuthor.role < 4 ? 2 : 1)) {
     return getThreshold(aModel, aContent, aAuthor, function (aThreshold) {


### PR DESCRIPTION
* This causes `flags.absolute` to be negative which should never happen

**NOTE**
* ES6 routine could still be used however logic would have to be post change... so removed that comment note

Post fix for #641