### PR TITLE
Use one `maxLag` value

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "select2": "3.5.2-browserify",
     "select2-bootstrap-css": "1.4.6",
     "serve-favicon": "2.3.0",
-    "toobusy-js": "0.4.3",
+    "toobusy-js-harmony": "git://github.com/OpenUserJs/node-toobusy#harmony",
     "uglify-js-harmony": "git://github.com/OpenUserJs/UglifyJS2#harmony-named+cdba43c",
     "underscore": "1.8.3"
   },


### PR DESCRIPTION
* This package isn't fast enough to keep up with multiple resets so going back to a single `maxLag`
* Using our repo fork of *toobusy-js* now for ES6 improvements
* If we're low on memory and script sources... abandon request

Applies to #944