### PR TITLE
Add `@updateURL` to script homepage

### DIFF
--- a/controllers/script.js
+++ b/controllers/script.js
@@ -376,6 +376,11 @@ exports.view = function (aReq, aRes, aNext) {
       options.isMod = authedUser && authedUser.isMod;
       options.isAdmin = authedUser && authedUser.isAdmin;
 
+      // Lockdown
+      options.lockdown = {};
+      options.lockdown.scriptStorageRO = process.env.READ_ONLY_SCRIPT_STORAGE === 'true';
+      options.lockdown.updateURLCheck = process.env.FORCE_BUSY_UPDATEURL_CHECK === 'true';
+
       // Script
       options.script = script = modelParser.parseScript(aScript);
       options.isOwner = authedUser && authedUser._id == script._authorId;
@@ -385,6 +390,8 @@ exports.view = function (aReq, aRes, aNext) {
         script.scriptInstallPageUrl;
       script.scriptPermalinkInstallPageXUrl = 'https://' + aReq.get('host') +
         script.scriptInstallPageXUrl;
+      script.scriptPermalinkMetaPageUrl = 'https://' + aReq.get('host') +
+        script.scriptMetaPageUrl;
 
       // Page metadata
       pageMetadata(options, ['About', script.name, (script.isLib ? 'Libraries' : 'Userscripts')],

--- a/libs/modelParser.js
+++ b/libs/modelParser.js
@@ -139,6 +139,15 @@ var getScriptInstallPageUrl = function (aScriptData) {
           (isLib ? '.js' : '.user.js')
 };
 
+var getScriptMetaPageUrl = function (aScriptData) {
+  var isLib = aScriptData.isLib || false;
+
+  return (isLib ? null : '/meta/') +
+    aScriptData.authorSlugUrl +
+      '/' +
+        aScriptData.nameSlugUrl +
+          '.meta.js'
+};
 
 
 // Uris
@@ -173,6 +182,15 @@ var getScriptInstallPageUri = function (aScriptData) {
           (isLib ? '.js' : '.user.js')
 };
 
+var getScriptMetaPageUri = function (aScriptData) {
+  var isLib = aScriptData.isLib || false;
+
+  return (isLib ? null : '/meta/') +
+    aScriptData.authorSlugUri +
+      '/' +
+        aScriptData.nameSlugUri +
+          '.meta.js'
+};
 
 
 //
@@ -312,6 +330,7 @@ var parseScript = function (aScript) {
   script.scriptPageUrl = getScriptPageUrl(script);
   script.scriptInstallPageUrl = getScriptInstallPageUrl(script);
   script.scriptInstallPageXUrl = script.scriptInstallPageUrl.replace(/(\.user)?\.js/, '');
+  script.scriptMetaPageUrl = getScriptMetaPageUrl(script);
   script.scriptViewSourcePageUrl = getScriptViewSourcePageUrl(script);
 
   // Urls: Issues
@@ -338,6 +357,7 @@ var parseScript = function (aScript) {
   script.scriptPageUri = getScriptPageUri(script);
   script.scriptInstallPageUri = getScriptInstallPageUri(script);
   script.scriptInstallPageXUri = script.scriptInstallPageUri.replace(/(\.user)?\.js/, '');
+  script.scriptMetaPageUri = getScriptMetaPageUri(script);
   script.scriptViewSourcePageUri = getScriptViewSourcePageUri(script);
 
   // Uris: Issues

--- a/views/includes/scriptAuthorToolsPanel.html
+++ b/views/includes/scriptAuthorToolsPanel.html
@@ -9,6 +9,14 @@
       <li><a rel="nofollow" href="{{{script.scriptEditSourcePageUrl}}}"><i class="fa fa-file-text"></i> Edit Script</a></li>
     </ul>
     {{^script.isLib}}
+    <div class="form-group">
+      <div class="input-group col-xs-12">
+        <span class="input-group-btn">
+          <button class="btn btn-{{#lockdown.updateURLCheck}}info{{/lockdown.updateURLCheck}}{{^lockdown.updateURLCheck}}default{{/lockdown.updateURLCheck}}" id="updateurl-raw" data-clipboard-text="// @updateURL {{{script.scriptPermalinkMetaPageUrl}}}" title="Copy key and raw URL to clipboard"><i class="octicon octicon-clippy"></i> // @updateURL</button>
+        </span>
+        <input type="text" class="form-control" id="updateurl" value="{{{script.scriptPermalinkMetaPageUrl}}}" readonly="readonly">
+      </div>
+    </div>
     <hr>
     <h4>Installs per Version <small>effective <time title='Tue Sep 2 2014'>Sep '14</time></small></h4>
     <p><code>{{script.meta.version}}{{^script.meta.version}}Current{{/script.meta.version}}</code> <span class="label label-default">{{script.installsSinceUpdate}} installs</span></p>

--- a/views/includes/scripts/clipboard.html
+++ b/views/includes/scripts/clipboard.html
@@ -1,7 +1,7 @@
 <script type="text/javascript" src="/redist/npm/clipboard/dist/clipboard.js"></script>
 <script type="text/javascript">
   (function () {
-    var clipboard = new Clipboard('#require-raw, #require-min');
+    var clipboard = new Clipboard('#require-raw, #require-min, #updateurl-raw');
     var rMin = /\.min\.js$/;
 
     clipboard.on('success', function(aE) {

--- a/views/pages/scriptPage.html
+++ b/views/pages/scriptPage.html
@@ -117,8 +117,6 @@
   {{> includes/scriptModals.html }}
   {{> includes/footer.html }}
   {{> includes/scripts/lazyIconScript.html }}
-  {{#script.isLib}}
-    {{> includes/scripts/clipboard.html }}
-  {{/script.isLib}}
+  {{> includes/scripts/clipboard.html }}
 </body>
 </html>


### PR DESCRIPTION
* Color changes depending upon lockdown mode ... default class vs info class *(currently white and blue respectively)*
* This is useful so there aren't mistakes post published ... many thanks to @jscher2000 for the idea on one placement... more? :)

**NOTE**
This doesn't cover dynamic searching on Source Code pages as those `@name`s can change.
Also using the `url` routines here... `uri` routines are available but need `options` link added in if needed

Applies to #970