### PR TITLE
Broader `downloadURL` check

### DIFF
--- a/controllers/scriptStorage.js
+++ b/controllers/scriptStorage.js
@@ -795,22 +795,21 @@ exports.storeScript = function (aUser, aMeta, aBuf, aCallback, aUpdate) {
 
     // `downloadURL` validations
     downloadURL = findMeta(aMeta, 'UserScript.downloadURL.0.value');
-    
+
     if (downloadURL) {
       downloadURL = URL.parse(downloadURL);
 
-      // Shouldn't install a userscript with a downloadURL of meta .user.js
+      // Shouldn't install a userscript with a downloadURL of non-Userscript-source
       if (rAnyLocalHost.test(downloadURL.host) &&
-        /^\/meta/.test(downloadURL.pathname) &&
-          /\.user\.js$/.test(downloadURL.pathname))
+        !/^\/(?:install|src\/scripts)\//.test(downloadURL.pathname))
       {
         aCallback(null);
         return;
       }
 
-     // Shouldn't install a userscript with a downloadURL of source .meta.js
+      // Shouldn't install a userscript with a downloadURL of source .meta.js
       if (rAnyLocalHost.test(downloadURL.host) &&
-        /^\/(?:install|src\/scripts)/.test(downloadURL.pathname) &&
+        /^\/(?:install|src\/scripts)\//.test(downloadURL.pathname) &&
           /\.meta\.js$/.test(downloadURL.pathname))
       {
         aCallback(null);


### PR DESCRIPTION
* Fix someone who did an OUJS script homepage for a `downloadURL`... should cover any other non-Userscript-source route. Previous meta check is inclusive since that's not a Userscript source route.

Post fix for #944 and #1004 change