### PR TITLE
Add a sweetening factor to not using the install counter on Userscrip…

### DIFF
--- a/app.js
+++ b/app.js
@@ -136,9 +136,9 @@ process.on('SIGINT', function () {
 var sessionStore = new MongoStore({ mongooseConnection: db });
 
 // See https://hacks.mozilla.org/2013/01/building-a-node-js-server-that-wont-melt-a-node-js-holiday-season-part-5/
-var ensureNumberOrNull = require('./libs/helpers').ensureNumberOrNull;
+var ensureIntegerOrNull = require('./libs/helpers').ensureIntegerOrNull;
 
-var maxLag = ensureNumberOrNull(process.env.BUSY_MAXLAG) || 70;
+var maxLag = ensureIntegerOrNull(process.env.BUSY_MAXLAG) || 70;
 app.use(function (aReq, aRes, aNext) {
   var pathname = aReq._parsedUrl.pathname;
   var hostMaxMem = process.env.HOST_MAXMEM_BYTES || 1073741824; // NOTE: Default 1GiB
@@ -184,7 +184,7 @@ app.use(function (aReq, aRes, aNext) {
       usedMem = parseInt(process.memoryUsage().rss / hostMaxMem * 100);
 
       // Compare current RSS memory used to maximum
-      maxMem = ensureNumberOrNull(process.env.BUSY_MAXMEM);
+      maxMem = ensureIntegerOrNull(process.env.BUSY_MAXMEM);
       if (usedMem > (isSources ? (parseInt(maxMem / 3 * 2) || 50) : (maxMem || 75))) {
         statusCodePage(aReq, aRes, aNext, {
           statusCode: 503,

--- a/libs/helpers.js
+++ b/libs/helpers.js
@@ -147,15 +147,17 @@ exports.updateUrlQueryString = function (aBaseUrl, aDict) {
   return url;
 };
 
-// Helper function to ensure value is type `number` or `null`
+// Helper function to ensure value is type Integer `number` or `null`
 // Please be very careful if this is edited
-exports.ensureNumberOrNull = function (aEnvVar) {
+exports.ensureIntegerOrNull = function (aEnvVar) {
   if (typeof aEnvVar !== 'number') {
     aEnvVar = parseInt(aEnvVar);
 
     if (aEnvVar !== aEnvVar) { // NOTE: ES6 `Number.isNaN`
       aEnvVar = null;
     }
+  } else {
+    aEnvVar = parseInt(aEnvVar);
   }
 
   return aEnvVar;

--- a/views/includes/documents/Frequently-Asked-Questions.md
+++ b/views/includes/documents/Frequently-Asked-Questions.md
@@ -118,6 +118,8 @@ A: Yes, use the raw source route like this in the UserScript metadata block:
 
 ... notice the **src**/**scripts** p.a.t.h/t.o instead of **install**.
 
+As an added advantage and incentive to utilizing this source route *(URL path)* with `@downloadURL` the "Too Many Requests" period is divided by a sweet factor. In other words this route is currently "less" managed than the install route. This UserScript metadata block key is not currently required but highly encouraged especially due to faulty .user.js engine updaters.
+
 [greasemonkeyForFirefox]: Greasemonkey-for-Firefox
 [metaJSExample]: https://openuserjs.org/meta/Marti/oujs_-_Meta_View.meta.js
 [metaJSExample2]: https://openuserjs.org/install/Marti/oujs_-_Meta_View.meta.js


### PR DESCRIPTION
…t updates

* Make an incentive to utilize `downloadURL` with the `src` route that has a factor of the maximum calculated wait time as compared to the `install` route
* Create a new instance of *express-brute* to handle this
* Change additional checks to ensure Integer all the time
* Update FAQ to reflect this
* Addresses and offers an alternative for some of the bad .user.js engine updaters
* Additional separation may be done for libraries... still contemplating

Post addition to #944