### PR TITLE
Repair *passport-steam*

### DIFF
--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -185,7 +185,7 @@ exports.callback = function (aReq, aRes, aNext) {
 
   // Hijack the private verify method so we can mess stuff up freely
   // We use this library for things it was never intended to do
-  if (openIdStrategies[strategy]) {
+  if (openIdStrategies[strategy] && strategy !== 'steam') {
     strategyInstance._verify = function (aId, aDone) {
       verifyPassport(aId, strategy, username, aReq.session.user, aDone);
     };


### PR DESCRIPTION
* Way back in https://github.com/liamcurry/passport-steam/blob/765869b566319bf7e5c44a4d3e1d4b6439731383/README.md the callback signature was modified to include a profile. The "hijacking" didn't account for this.
* Prevents a server trip

Applies to https://github.com/OpenUserJs/OpenUserJS.org/issues/1021#issue-161379631