### PR TITLE
Rerepair *passport-steam* usage

### DIFF
--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -185,10 +185,16 @@ exports.callback = function (aReq, aRes, aNext) {
 
   // Hijack the private verify method so we can mess stuff up freely
   // We use this library for things it was never intended to do
-  if (openIdStrategies[strategy] && strategy !== 'steam') {
-    strategyInstance._verify = function (aId, aDone) {
-      verifyPassport(aId, strategy, username, aReq.session.user, aDone);
-    };
+  if (openIdStrategies[strategy]) {
+    if (strategy === 'steam') {
+      strategyInstance._verify = function (aIgnore, aId, aDone) {
+        verifyPassport(aId, strategy, username, aReq.session.user, aDone);
+      };
+    } else {
+      strategyInstance._verify = function (aId, aDone) {
+        verifyPassport(aId, strategy, username, aReq.session.user, aDone);
+      };
+    }
   } else if (strategy === 'google') { // OpenID to OAuth2 migration
     strategyInstance._verify =
       function(aAccessToken, aRefreshToken, aParams, aProfile, aDone) {


### PR DESCRIPTION
* This really is a a bizarre fix since there is no mention of a prior parameter. I suspect this is a bug in *passport-steam* but we'll work around it for now.
* Prior patch was incorrect

Post #1043 patch