### PR TITLE
Change *ansi-colors* to work with `inverse` correctly

### DIFF
--- a/dev/init.js
+++ b/dev/init.js
@@ -175,7 +175,7 @@ var tasks = [
 async.waterfall(tasks, function (aErr, aResults) {
   if (aErr) {
     console.error(
-      colors.red.inverse('Project dependency error!\n\n'),
+      colors.inverse(colors.red('Project dependency error!\n\n')),
       'Code ' + aErr.code + '\n',
       aErr.message
     );


### PR DESCRIPTION
* First error, of this kind, detected via init.js
* Needed for this init.js message on pro of:

``` sh-session
Project dependency error!

 Code 1
 Command failed: bundler outdated
```

This isn't true but seems to get past this... probably an issue with gem/bundler

Post #993