### PR TITLE
Convert a jQuery script to Web API

### DIFF
--- a/views/includes/scripts/tableTrLinkScript.html
+++ b/views/includes/scripts/tableTrLinkScript.html
@@ -1,31 +1,48 @@
 <script type="text/javascript">
   (function () {
+    function onClick(aEv) {
+      var container = aEv.target;
+      var anchor = null;
+      var url = null;
 
-    $(document).ready(function () {
-      // https://stackoverflow.com/questions/4904938/link-entire-table-row
-
-      $('.tr-link').click(function (aE) {
-        var anchor = null;
-        var url = null;
-
-        if ($(aE.target).is('a,input,a *')) { // anything else you don't want to trigger the click
+      // Traverse up the DOM to find the container tr tag
+      while (!container.classList.contains('tr-link')) {
+        if (!(container = container.parentNode)) {
           return;
         }
+      }
 
-        anchor = $(this).find('a.tr-link-a').first();
-        if (!anchor) {
-          return;
-        }
+      // Find the anchor tag for redirection
+      anchor = container.querySelector('a.tr-link-a');
+      if (!anchor) {
+        return;
+      }
 
-        url = anchor.attr('href');
-        if (!url) {
-          return;
-        }
+      // Check to see if the href tag exists
+      url = anchor.getAttribute('href');
+      if (!url) {
+        return;
+      }
 
-        window.location = url;
-        aE.stopPropagation();
-      })
-    });
+      // Stop propagation as soon as possible
+      aEv.stopPropagation();
+
+      // Redirect to the anchor href
+      window.location = url;
+    }
+
+    function onDOMContentLoaded(aEv) {
+      var i = undefined;
+      var el = undefined;
+      var els = document.querySelectorAll('tr.tr-link');
+
+      // Place handler on everything within the tr.tr-link
+      for (i = 0, el; el = els[i++];) {
+        el.addEventListener('click', onClick);
+      }
+    }
+
+    document.addEventListener('DOMContentLoaded', onDOMContentLoaded);
 
   })();
 </script>


### PR DESCRIPTION
* Eliminating early exit test as bootstrap/DOM may return `b` tag, a.k.a child tag, instead of `a` tag... unreachable code usually
* Refining target tags detected
* Works in Opera Presto *(Oldest supported browser. Certain older versions of IE are unsupported already with jQuery)*
* Comment up the code a bit

Applies to #904