### PR TITLE
Enable meta cache from Server to Client

### DIFF
--- a/controllers/scriptStorage.js
+++ b/controllers/scriptStorage.js
@@ -627,16 +627,16 @@ exports.sendMeta = function (aReq, aRes, aNext) {
   var installNameBase = getInstallNameBase(aReq, { hasExtension: true });
   var meta = null;
 
-  var eTag = null;
-  var maxAge = 1 * 60 * 60 * 24; // nth day(s) in seconds
-  var lastModified = null;
-
   Script.findOne({ installName: caseSensitive(installNameBase + '.user.js') },
     function (aErr, aScript) {
       var script = null;
       var scriptOpenIssueCountQuery = null;
       var whitespace = '\u0020\u0020\u0020\u0020';
       var tasks = [];
+
+      var eTag = null;
+      var maxAge = 1 * 60 * 60 * 24; // nth day(s) in seconds
+      var lastModified = null;
 
       if (!aScript) {
         aNext();


### PR DESCRIPTION
* Caching works well but GM kills it with [`channel.LOAD_BYPASS_CACHE`](https://github.com/greasemonkey/greasemonkey/blob/696848acc40c6395904a53acdc15a653d5be502c/modules/remoteScript.js#L606)
* Scoot identifier declaration down a little

**NOTE** Keep this at one day, possibly for long term.

Applies to #432 and #249. Possible addition to #944 down the line. Regression **not** present, nor needed, from detection and revert in #894 . Script meta should always be the same whether minified fork or original
