### PR TITLE
Use base62 instead of base36

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Repository | Reference | Recent Version
 [ansi-colors][ansi-colorsGHUrl] | [Documentation][ansi-colorsDOCUrl] | [![NPM version][ansi-colorsNPMVersionImage]][ansi-colorsNPMUrl]
 [async][asyncGHUrl] | [Documentation][asyncDOCUrl] | [![NPM version][asyncNPMVersionImage]][asyncNPMUrl]
 [aws-sdk][aws-sdkGHUrl] | [Documentation][aws-sdkDOCUrl] | [![NPM version][aws-sdkNPMVersionImage]][aws-sdkNPMUrl]
+[base62][base62GHUrl] | [Documentation][base62DOCUrl] | [![NPM version][base62NPMVersionImage]][base62NPMUrl]
 [body-parser][body-parserGHUrl] | [Documentation][body-parserDOCUrl] | [![NPM version][body-parserNPMVersionImage]][body-parserNPMUrl]
 [bootstrap][bootstrapGHUrl] | [Documentation][bootstrapDOCUrl] | [![NPM version][bootstrapNPMVersionImage]][bootstrapNPMUrl]
 [bootstrap-markdown][bootstrap-markdownGHUrl] | [Documentation][bootstrap-markdownDOCUrl] | [![NPM version][bootstrap-markdownNPMVersionImage]][bootstrap-markdownNPMUrl]
@@ -145,6 +146,11 @@ Outdated dependencies list can also be achieved with `$ npm --depth 0 outdated`
 [aws-sdkDOCUrl]: https://github.com/aws/aws-sdk-js/blob/master/README.md
 [aws-sdkNPMUrl]: https://www.npmjs.com/package/aws-sdk
 [aws-sdkNPMVersionImage]: https://img.shields.io/npm/v/aws-sdk.svg?style=flat
+
+[base62GHUrl]: https://github.com/andrew/base62.js
+[base62DOCUrl]: https://github.com/andrew/base62.js/blob/master/Readme.md
+[base62NPMUrl]: https://www.npmjs.com/package/base62
+[base62NPMVersionImage]: https://img.shields.io/npm/v/base62.svg?style=flat
 
 [body-parserGHUrl]: https://github.com/expressjs/body-parser
 [body-parserDOCUrl]: https://github.com/expressjs/body-parser/blob/master/README.md

--- a/controllers/scriptStorage.js
+++ b/controllers/scriptStorage.js
@@ -21,6 +21,7 @@ var mediaType = require('media-type');
 var mediaDB = require('mime-db');
 var async = require('async');
 var moment = require('moment');
+var Base62 = require('base62')
 
 //--- Model inclusions
 var Script = require('../models/script').Script;
@@ -478,8 +479,8 @@ exports.sendScript = function (aReq, aRes, aNext) {
           : mtimeUglifyJS2 > aScript.updated ? mtimeUglifyJS2 : aScript.updated)
       ).utc().format('ddd, DD MMM YYYY HH:mm:ss') + ' GMT';
 
-    // Create a base 36 representation of the hex sha512sum
-    eTag = '"'  + parseInt('0x' + aScript.hash, 16).toString(36) + '"';
+    // Create a based representation of the hex sha512sum
+    eTag = '"'  + Base62.encode(parseInt('0x' + aScript.hash, 16)) + '"';
 
     // NOTE: HTTP/1.1 Caching
     aRes.set('Cache-Control', 'public, max-age=' + maxAge +
@@ -549,9 +550,9 @@ exports.sendScript = function (aReq, aRes, aNext) {
             }
           }).code;
 
-          // Create a base 36 representation of the hex sha512sum
-          eTag = '"' + parseInt('0x' + crypto.createHash('sha512').update(source).digest('hex'), 16)
-            .toString(36) + '"';
+          // Create a based representation of the hex sha512sum
+          eTag = '"'  + Base62.encode(
+            parseInt('0x' + crypto.createHash('sha512').update(source).digest('hex'), 16)) + '"';
 
         } catch (aE) { // On any failure default to unminified
           console.warn([
@@ -645,8 +646,8 @@ exports.sendMeta = function (aReq, aRes, aNext) {
 
       lastModified = aScript.updated;
 
-      // Create a base 36 representation of the hex sha512sum
-      eTag = '"'  + parseInt('0x' + aScript.hash, 16).toString(36) + '"';
+      // Create a based representation of the hex sha512sum
+      eTag = '"'  + Base62.encode(parseInt('0x' + aScript.hash, 16)) + '"';
 
       script = modelParser.parseScript(aScript);
       meta = script.meta; // NOTE: Watchpoint

--- a/controllers/scriptStorage.js
+++ b/controllers/scriptStorage.js
@@ -21,7 +21,7 @@ var mediaType = require('media-type');
 var mediaDB = require('mime-db');
 var async = require('async');
 var moment = require('moment');
-var Base62 = require('base62')
+var Base62 = require('base62');
 
 //--- Model inclusions
 var Script = require('../models/script').Script;

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "ansi-colors": "0.2.0",
     "async": "1.5.2",
     "aws-sdk": "2.23.0",
+    "base62": "1.1.2",
     "body-parser": "1.17.1",
     "bootstrap": "3.3.7",
     "bootstrap-markdown": "2.10.0",


### PR DESCRIPTION
* Save a few bytes in the headers... not huge but some
* Leaving .meta.json full SHA512 for human visual inspection comparison in Admin + UI and with `sha512sum`

Applies to #432 and #249.  Possible addition to #944 down the line.