### PR TITLE
Ensure session username is same casing

### DIFF
--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -139,10 +139,16 @@ exports.auth = function (aReq, aRes, aNext) {
 
   User.findOne({ name: { $regex: new RegExp('^' + username + '$', 'i') } },
     function (aErr, aUser) {
+      // WARNING: No error handling at this stage
       var strategies = null;
       var strat = null;
 
       if (aUser) {
+        // Ensure that casing is identical so we still have it, correctly, when they
+        // get back from authentication
+        if (aUser.name !== username) {
+          aReq.session.username = aUser.name;
+        }
         strategies = aUser.strategies;
         strat = strategies.pop();
 


### PR DESCRIPTION
* This goes back to when I first came into the project and noticed that `marti` and `Marti` were inconsistent in script access
* Added in a WARNING note for no error handling again

Applies to #83 and #180 / #130 / https://github.com/OpenUserJs/OpenUserJS.org/issues/130#issuecomment-45703001