### PR TITLE
Add an err parm in callback for *async* migration

### DIFF
--- a/libs/modifySessions.js
+++ b/libs/modifySessions.js
@@ -43,8 +43,11 @@ exports.add = function (aReq, aUser, aCallback) {
   // Remove invalid session ids from user model
   if (aUser.sessionIds && aUser.sessionIds.length > 0) {
     async.filter(aUser.sessionIds, function (aId, aCb) {
-      store.get(aId, function (aErr, aSess) { aCb(!aErr && aSess); });
-    }, function (aSessionIds) {
+      store.get(aId, function (aErr, aSess) {
+        aCb(null, !aErr && aSess);
+      });
+
+    }, function (aErr, aSessionIds) {
       // No duplicates
       if (aSessionIds.indexOf(aReq.sessionID) === -1) {
         aSessionIds.push(aReq.sessionID);
@@ -84,7 +87,9 @@ exports.update = function (aReq, aUser, aCallback) {
   async.each(aUser.sessionIds, function (aId, aCb) {
     store.get(aId, function (aErr, aSess) {
       // Invalid session, will be removed on login
-      if (aErr || !aSess) { return aCb(null); }
+      if (aErr || !aSess) {
+        return aCb(null);
+      }
 
       aSess.user = userObj;
       store.set(aId, aSess, aCb);

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "ace-builds": "git://github.com/ajaxorg/ace-builds#9a9e786",
     "ansi-colors": "0.2.0",
-    "async": "1.5.2",
+    "async": "2.3.0",
     "aws-sdk": "2.43.0",
     "base62": "1.1.2",
     "body-parser": "1.17.1",


### PR DESCRIPTION
* Similar code point symmetry pattern found with [option 1](https://github.com/OpenUserJs/OpenUserJS.org/issues/1037#issuecomment-297116548) at [.../blob/`fbc2465`/libs/modifySessions.js#L84-L94](https://github.com/OpenUserJs/OpenUserJS.org/blob/fbc24652ed1e1dfb880c871baf8cce80fdc8e07e/libs/modifySessions.js#L84-L94).
* Some adjustment on newlines
* Migration bump of *async*

**NOTES**
* **Not** a backward compatible fix with older *async*

Applies to #1037

---

**PASS** dev GH login
**PASS** dev goo login