### PR TITLE
Lessen the CPU load when eTag is same

### DIFF
--- a/controllers/scriptStorage.js
+++ b/controllers/scriptStorage.js
@@ -708,6 +708,12 @@ exports.sendScript = function (aReq, aRes, aNext) {
 
         // If already client-side... partial HTTP/1.1 Caching
         if (aReq.get('if-none-match') === eTag) {
+
+          // Conditionally send lastModified
+          if (aReq.get('if-modified-since') !== lastModified) {
+            aRes.set('Last-Modified', lastModified);
+          }
+
           aRes.status(304).send(); // Not Modified
           return;
         }


### PR DESCRIPTION
* Assuming *UglifyJS2* does return the same hash at this point for minification... reset, if needed, client side `lastModified` for next round

Applies to #432