### PR TITLE
Add some forms and their names into the UI

### DIFF
--- a/public/css/common.css
+++ b/public/css/common.css
@@ -369,3 +369,7 @@ ul.flaggedList {
 .fade-icon {
   transition: opacity 0.33s ease-in-out;
 }
+
+.form-inline {
+  display: inline;
+}

--- a/views/includes/comment.html
+++ b/views/includes/comment.html
@@ -31,27 +31,39 @@
             <nav class="post-controls text-right">
               <div class="pull-right">
                 {{#authedUser}}
-                  <div class="btn-group" role="administrate">
-                    {{#canRemove}}
-                      <button type="button" class="btn btn-sm btn-danger btn-comment-remove disabled" title="Remove this reply.">
+                  {{#canRemove}}
+                    <form class="form-inline" action="{{{comment.commentRemovePageUrl}}}" method="post" enctype="multipart/form-data">
+                      <input type="hidden" name="remove" value="true">
+                      <button type="button" class="btn btn-sm btn-danger btn-comment-remove" title="Remove this reply.">
                         <i class="fa fa-ban"></i><span class="hidden-xs"> Remove</span>
                       </button>
-                    {{/canRemove}}
-                    {{#canFlag}}
-                      <button type="button" class="btn btn-sm btn-warning btn-comment-flag disabled" title="Flag this reply.">
-                        <i class="fa fa-flag-o"></i><span class="hidden-xs"> Flag</span>
-                      </button>
-                    {{/canFlag}}
-                  </div>
+                    </form>
+                  {{/canRemove}}
+                  {{#canFlag}}
+                    {{#flagged}}
+                      <form class="form-inline" action="{{{comment.commentFlagPageUrl}}}" method="post" enctype="multipart/form-data">
+                        <input type="hidden" name="flag" value="false">
+                        <button class="btn btn-sm btn-warning btn-comment-flag" type="submit" title="Unflag this reply.">
+                          <i class="fa fa-flag"></i><span class="hidden-xs"> Unflag</span>
+                        </button>
+                      </form>
+                    {{/flagged}}
+                    {{^flagged}}
+                      <form class="form-inline" action="{{{comment.commentFlagPageUrl}}}" method="post" enctype="multipart/form-data">
+                        <input type="hidden" name="flag" value="true">
+                        <button class="btn btn-sm btn-warning btn-comment-flag" type="submit" title="Flag this reply.">
+                          <i class="fa fa-flag-o"></i><span class="hidden-xs"> Flag</span>
+                        </button>
+                      </form>
+                    {{/flagged}}
+                  {{/canFlag}}
                   {{#canEdit}}
-                    <div class="btn-group" role="owner">
-                      <button type="button" class="btn btn-sm btn-danger btn-comment-delete disabled" title="Delete this reply.">
-                        <i class="fa fa-remove"></i><span class="hidden-xs"> Delete</span>
-                      </button>
-                      <button type="button" class="btn btn-sm btn-default btn-comment-edit disabled" title="Begin editing this reply.">
-                        <i class="fa fa-edit"></i><span class="hidden-xs"> Edit</span>
-                      </button>
-                    </div>
+                    <button type="button" class="btn btn-sm btn-danger btn-comment-delete" title="Delete this reply.">
+                      <i class="fa fa-remove"></i><span class="hidden-xs"> Delete</span>
+                    </button>
+                    <button type="button" class="btn btn-sm btn-default btn-comment-edit" title="Begin editing this reply.">
+                      <i class="fa fa-edit"></i><span class="hidden-xs"> Edit</span>
+                    </button>
                   {{/canEdit}}
                   <button class="btn btn-sm btn-info btn-comment-reply" title="Begin composing a reply to this post.">
                     <i class="fa fa-reply"></i><span class="hidden-xs"> Reply</span>


### PR DESCRIPTION
* Presuming similar POST op for flag/unflag and remove ops
* Since *bootstrap* seems to have some issues with button groupings and forms not playing well together... split out the buttons. Started with this before I compressed the UI post controls.
* Add a common class to coerce these inline
* Since can't predict what the editLib is going to be... left those as plain buttons for now... e.g. don't know if there will be a POST op yet and how it's named.
* After the backend is more complete can add the modals in.

Applies to #601 and post #1102