### PR TITLE
Dealias all found *async* methods

### DIFF
--- a/controllers/flag.js
+++ b/controllers/flag.js
@@ -139,7 +139,7 @@ exports.getFlaggedListForContent = function (aModelName, aOptions, aCallback) {
   var content = aModelName.toLowerCase();
   var contentList = aOptions[content + 'List'] || [aOptions[content]];
 
-  async.forEachOf(contentList, function (aContent, aContentKey, aEachOuterCallback) {
+  async.eachOf(contentList, function (aContent, aContentKey, aEachOuterCallback) {
 
     // NOTE: Directly use indexed parent identifier allowing set of the dynamic, virtual, field
     //       So basically do not use `aContent` anywhere in this function
@@ -167,7 +167,7 @@ exports.getFlaggedListForContent = function (aModelName, aOptions, aCallback) {
 
       aOptions.hasFlagged = true;
 
-      async.forEachOfSeries(aFlagList, function (aFlag, aFlagKey, aEachInnerCallback) {
+      async.eachOfSeries(aFlagList, function (aFlag, aFlagKey, aEachInnerCallback) {
         User.findOne({ _id: aFlag._userId }, function (aErr, aUser) {
           if (aErr || !aUser) {
             // Notify in stdout

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -536,7 +536,7 @@ exports.userScriptListPage = function (aReq, aRes, aNext) {
           var scriptKeyMax = scriptList.length - 1;
 
           if (scriptKeyMax >= 0 && options.isYou) {
-            async.forEachOfSeries(options.scriptList, function (aScript, aScriptKey, aEachCallback) {
+            async.eachOfSeries(options.scriptList, function (aScript, aScriptKey, aEachCallback) {
               var script = modelParser.parseScript(aScript);
 
               // Find if script has any open issues


### PR DESCRIPTION
* Their method renaming over the years with an alias that might disappear... so use native and indexed.

Applies to #72