### PR TITLE
Rework error routine on network failure

### DIFF
--- a/controllers/scriptStorage.js
+++ b/controllers/scriptStorage.js
@@ -352,10 +352,12 @@ exports.getSource = function (aReq, aCallback) {
                   'in the', bucketName, 'bucket'
           );
         }
+      });
 
+      if (!s3Object) {
         aCallback(null);
         return;
-      });
+      }
 
       // Get the script
       aCallback(aScript, s3Object);


### PR DESCRIPTION
* Assume that `s3Object` doesn't exist and do null callback ... hopefully this prevents server trip... time will tell

Ref:
* http://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/requests-using-stream-objects.html *(standard doc example uses piping which we don't)*

Applies to #1110