### PR TITLE
A dep downgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "ace-builds": "git://github.com/ajaxorg/ace-builds#9a9e786",
     "ansi-colors": "0.2.0",
     "async": "2.4.0",
-    "aws-sdk": "2.50.0",
+    "aws-sdk": "2.49.0",
     "base62": "1.1.2",
     "body-parser": "1.17.1",
     "bootstrap": "3.3.7",


### PR DESCRIPTION
* The latest *aws-sdk* version is great for testing but I think it's throwing an error and tripping the server
* Will resume this after nap regardless of tripping state after this

Applies to #1110