### PR TITLE
Work-around for *UglifyJS* failures with v2.x to v3.x migration and documentation absence

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "select2-bootstrap-css": "1.4.6",
     "serve-favicon": "2.4.2",
     "toobusy-js-harmony": "git://github.com/OpenUserJs/node-toobusy#harmony",
-    "uglify-es": "git://github.com/mishoo/UglifyJS2#harmony",
+    "uglify-es": "3.0.4",
     "underscore": "1.8.3"
   },
   "optionalDependencies": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "select2-bootstrap-css": "1.4.6",
     "serve-favicon": "2.4.2",
     "toobusy-js-harmony": "git://github.com/OpenUserJs/node-toobusy#harmony",
-    "uglify-js-harmony": "git://github.com/OpenUserJs/UglifyJS2#harmony+renamed",
+    "uglify-es": "git://github.com/mishoo/UglifyJS2#harmony",
     "underscore": "1.8.3"
   },
   "optionalDependencies": {


### PR DESCRIPTION
* Apparently that package no longer returns the unminified/untouched code on erroring in v3.x so handle/propagate the errors ourselves.

**NOTE**
* [Current README.md](https://github.com/mishoo/UglifyJS2/blob/daf44f2b21a5628f73c4cd94503a26cfeb5e80a1/README.md) makes no mention and CHANGELOG is absent from the project. See mishoo/UglifyJS2#1875 / mishoo/UglifyJS2#1881

Refs:
* mishoo/UglifyJS2#1907
* mishoo/UglifyJS2#1906
* mishoo/UglifyJS2#1904
* Probably more since migration guide wasn't included for breaking changes in major semver change


Post #1114 /#1115 /#1116 and issued at mishoo/UglifyJS2#1927