### PR TITLE
Use *aws-sdk* aErr callback instead of stream error listener

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -1600,18 +1600,19 @@ function getExistingScript(aReq, aOptions, aAuthedUser, aCallback) {
         collaborators = []; // NOTE: Watchpoint
       }
 
-      aStream.on('error', function (aE) {
+      aStream.on('error', function (aErr) {
+        // This covers errors during connection in source view
+        console.error(
+          'S3 GET (chunking indirect) ',
+            aErr.code,
+              'for', installNameBase + (isLib ? '.js' : '.user.js'),
+                'in the', bucketName, 'bucket\n' +
+                  JSON.stringify(aErr, null, ' ') + '\n' +
+                    aErr.stack
+        );
+
         if (continuation) {
           continuation = false;
-
-          // This covers errors during connection in source view
-          console.error(
-            'S3 GET (chunking indirect) ',
-              aE.code,
-                'for', installNameBase + (isLib ? '.js' : '.user.js'),
-                  'in the', bucketName, 'bucket\n' +
-                    JSON.stringify(aE, null, ' ')
-          );
 
           aCallback(null);
           // fallthrough


### PR DESCRIPTION
* Removed continuation from this portion of code as it's no longer needed
* Passthrough the Buffer to a stream object with native *stream*
* Revert disk latency test
* Output the `stack`, if present, on errors so doesn't need to be launched manually on server and can be used with process manager

Applies to #1110