### PR TITLE
A dep update

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "ace-builds": "git://github.com/ajaxorg/ace-builds#9a9e786",
     "ansi-colors": "0.2.0",
     "async": "2.4.0",
-    "aws-sdk": "2.49.0",
+    "aws-sdk": "2.52.0",
     "base62": "1.1.2",
     "body-parser": "1.17.1",
     "bootstrap": "3.3.7",


### PR DESCRIPTION
* Please note *aws-sdk*@2.50.0 and *aws-sdk*@2.51.0 are a bit shakier than *aws-sdk*@2.49.0
* Error traps should accommodate for the previously mentioned shakiness. This is not currently the HOST.
* If a S3 connection error is detected it should return a 404. Due to the construction of our multiple callbacks/fallthroughs a 502 BAD GATEWAY can't currently be sent... however a 404 says "...but may be available in the future"
* If a stream passthrough error is detected it should return a 404. Due to the construction of our multiple callbacks/fallthroughs a 502 BAD GATEWAY can't currently be sent... however a 404 says "...but may be available in the future"


Applies to #1110