### PR TITLE
A dep downgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "select2-bootstrap-css": "1.4.6",
     "serve-favicon": "2.4.3",
     "toobusy-js-harmony": "git://github.com/OpenUserJs/node-toobusy#harmony",
-    "uglify-es": "3.0.20",
+    "uglify-es": "3.0.15",
     "underscore": "1.8.3"
   },
   "optionalDependencies": {


### PR DESCRIPTION
* Since *uglify-js* maintainers are introducing more and more errors including security issues downgrade to last known IIFE compatible release.

This may end minification if a stable alternative can't be found

Applies to #432 , #1148 and mishoo/UglifyJS2#2166