### PR TITLE
Use native `Promise` construction from ES6+ implementation in *nodejs* for *mongoose* dep

### DIFF
--- a/app.js
+++ b/app.js
@@ -36,6 +36,8 @@ var lessMiddleware = require('less-middleware');
 var session = require('express-session');
 var MongoStore = require('connect-mongo')(session);
 var mongoose = require('mongoose');
+mongoose.Promise = global.Promise;
+
 var passport = require('passport');
 var colors = require('ansi-colors');
 

--- a/models/comment.js
+++ b/models/comment.js
@@ -7,6 +7,8 @@ var isDbg = require('../libs/debug').isDbg;
 
 //
 var mongoose = require('mongoose');
+mongoose.Promise = global.Promise;
+
 var Schema = mongoose.Schema;
 
 var commentSchema = new Schema({

--- a/models/discussion.js
+++ b/models/discussion.js
@@ -7,6 +7,8 @@ var isDbg = require('../libs/debug').isDbg;
 
 //
 var mongoose = require('mongoose');
+mongoose.Promise = global.Promise;
+
 var Schema = mongoose.Schema;
 
 var discussionSchema = new Schema({

--- a/models/flag.js
+++ b/models/flag.js
@@ -7,6 +7,8 @@ var isDbg = require('../libs/debug').isDbg;
 
 //
 var mongoose = require('mongoose');
+mongoose.Promise = global.Promise;
+
 var Schema = mongoose.Schema;
 
 var flagSchema = new Schema({

--- a/models/group.js
+++ b/models/group.js
@@ -7,6 +7,8 @@ var isDbg = require('../libs/debug').isDbg;
 
 //
 var mongoose = require('mongoose');
+mongoose.Promise = global.Promise;
+
 var Schema = mongoose.Schema;
 var ObjectId = Schema.Types.ObjectId;
 

--- a/models/remove.js
+++ b/models/remove.js
@@ -7,6 +7,8 @@ var isDbg = require('../libs/debug').isDbg;
 
 //
 var mongoose = require('mongoose');
+mongoose.Promise = global.Promise;
+
 var Schema = mongoose.Schema;
 
 var removeSchema = new Schema({

--- a/models/script.js
+++ b/models/script.js
@@ -7,6 +7,8 @@ var isDbg = require('../libs/debug').isDbg;
 
 //
 var mongoose = require('mongoose');
+mongoose.Promise = global.Promise;
+
 var Schema = mongoose.Schema;
 
 var scriptSchema = new Schema({

--- a/models/strategy.js
+++ b/models/strategy.js
@@ -7,6 +7,8 @@ var isDbg = require('../libs/debug').isDbg;
 
 //
 var mongoose = require('mongoose');
+mongoose.Promise = global.Promise;
+
 var Schema = mongoose.Schema;
 
 var strategySchema = new Schema({

--- a/models/user.js
+++ b/models/user.js
@@ -7,6 +7,8 @@ var isDbg = require('../libs/debug').isDbg;
 
 //
 var mongoose = require('mongoose');
+mongoose.Promise = global.Promise;
+
 var Schema = mongoose.Schema;
 
 var userSchema = new Schema({

--- a/models/vote.js
+++ b/models/vote.js
@@ -7,6 +7,8 @@ var isDbg = require('../libs/debug').isDbg;
 
 //
 var mongoose = require('mongoose');
+mongoose.Promise = global.Promise;
+
 var Schema = mongoose.Schema;
 
 var voteSchema = new Schema({


### PR DESCRIPTION
* Squashes a deprecation warning that has been around a long time. Unable to get `mpromise`, the *mongoose* default, to work... server never initializes... so defaulting to native implementation.
* Delete op retested

Refs:
* http://ecma-international.org/ecma-262/6.0/#sec-promise-constructor
* http://ecma-international.org/ecma-262/7.0/#sec-promise-constructor
* http://ecma-international.org/ecma-262/8.0/#sec-promise-constructor