### PR TITLE
A dep update

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "express": "4.15.5",
     "express-brute": "1.0.1",
     "express-brute-mongo": "1.0.0",
-    "express-minify": "0.2.0",
+    "express-minify": "1.0.0",
     "express-session": "1.15.5",
     "font-awesome": "4.7.0",
     "formidable": "1.1.1",
@@ -63,6 +63,7 @@
     "select2-bootstrap-css": "1.4.6",
     "serve-favicon": "2.4.4",
     "toobusy-js-harmony": "git://github.com/OpenUserJs/node-toobusy#harmony",
+    "uglify-js": "3.1.2",
     "uglify-es": "3.1.2",
     "underscore": "1.8.3"
   },


### PR DESCRIPTION
*express-minify* only

* Actual breaking changes from pre-release to release status of 1.0.0
* Removed test if *express-minify* doesn't initialize... no instances found since Zren mentioned this and it was put in by me to accommodate... now debug mode will minify
* Code migration to newer object structures for error object
* Include *uglify-js* in top level app to keep deps from being buried in `express-minify` folder
* Increase dump size for release *uglify-js* with *express-minify* ... currently not enough to determine in logs which dep is doing this.

NOTE(S):
* During testing ensure *express-minify* cache and browser cache are cleared otherwise may result in `responseText` being absent from xhr in OUJS - Meta View and core install button will return incorrect data source usually showing `@include *`
* Tested bad .user.js with trailing bad code to force an *uglify-es* error to test *express-minify* error handling.
* Holding off on express-minify#18 test/migration for stability run-time tests on release status of *express-minify*
* Retested CSS minification with `/css/common.css`... does minify