### PR TITLE
Mostly repair autolinking once again

### DIFF
--- a/libs/markdown.js
+++ b/libs/markdown.js
@@ -60,9 +60,25 @@ function sanitize(aHtml) {
 // Sanitize the output from the block level renderers
 blockRenderers.forEach(function (aType) {
   renderer[aType] = function () {
-    return sanitize(marked.Renderer.prototype[aType].apply(renderer, arguments)
-      .replace(/(^|\s|(?:[^c][^o][^d][^e])>)@([^\s\\\/:*?\'\"<>|#;@=&]+)/gm,
-      '$1<a href="/users/$2">@$2</a>'));
+    // Sanitize first to close any tags
+    var sanitized = sanitize(marked.Renderer.prototype[aType].apply(renderer, arguments));
+
+    // Autolink most usernames
+    return sanitized.replace(/(^|\s|>)@([^\s\\\/:*?\'\"<>|#;@=&,]+)/gm,
+      function (aMatch, aP1, aP2, aOffset, aString) {
+
+        // Look behind anywhere in chunk
+        if (aString.indexOf('<code>') !== -1 && aString.indexOf('<code>') <= aOffset) {
+          return  aP1 + '@' + aP2; // NOTE: Return as early as possible
+        }
+
+        // Look behind anywhere in chunk
+        if (aString.indexOf('<pre>') !== -1 && aString.indexOf('<pre>') <= aOffset) {
+          return  aP1 + '@' + aP2; // NOTE: Return as early as possible
+        }
+
+        return aP1 + '<a href="/users/' + aP2 + '">@' + aP2 + '</a>';
+      });
   };
 });
 


### PR DESCRIPTION
* Use a pseudo negative floating look behind since re in V8 still doesn't support this yet

NOTE(S):
* Sanitizing first to get rid of any unclosed tags e.g. this is a post op
* At some point the prior fix stopped working from #840
* There are still some users missed since other rendering is done first before any post op is applied... those should be filtered at some point.

Applies to #735