### PR TITLE
Use *jsdom* for a virtual DOM inside *node*

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Repository | Reference | Recent Version
 [github][githubGHUrl] | [Documentation][githubDOCUrl] | [![NPM version][githubNPMVersionImage]][githubNPMUrl]
 [highlight.js][highlight.jsGHUrl] | [Documentation][highlight.jsDOCUrl][ᴸᴬᴺᴳ][highlight.jsLANGUrl] | [![NPM version][highlight.jsNPMVersionImage]][highlight.jsNPMUrl]
 [jquery][jQueryGHUrl] | [Documentation][jQueryDOCUrl] | [![NPM version][jQueryNPMVersionImage]][jQueryNPMUrl]
+[jsdom][jsdomGHUrl] | [Documentation][jsdomDOCUrl] | [![NPM version][jsdomNPMVersionImage]][jsdomNPMUrl]
 [jwt-simple][jwt-simpleGHUrl] | [Documentation][jwt-simpleDOCUrl] | [![NPM version][jwt-simpleNPMVersionImage]][jwt-simpleNPMUrl]
 [kerberos][kerberosGHUrl] | [Documentation][kerberosDOCUrl] | [![NPM version][kerberosNPMVersionImage]][kerberosNPMUrl]
 [less-middleware][less-middlewareGHUrl] [&#x00b9;][lessGHUrl] | [Documentation][less-middlewareDOCUrl] [&#x00b9;][lessDOCUrl] | [![NPM version][less-middlewareNPMVersionImage]][less-middlewareNPMUrl]
@@ -255,6 +256,11 @@ Outdated dependencies list can also be achieved with `$ npm --depth 0 outdated`
 [jQueryGHUrl]: https://github.com/jquery/jquery
 [jQueryUrl]: http://jquery.com/
 [jQueryDOCUrl]: http://api.jquery.com/
+
+[jsdomNPMUrl]: https://www.npmjs.com/package/jsdom
+[jsdomNPMVersionImage]: https://img.shields.io/npm/v/jsdom.svg?style=flat
+[jsdomGHUrl]: https://github.com/tmpvar/jsdom
+[jsdomDOCUrl]: https://github.com/tmpvar/jsdom/blob/master/README.md
 
 [jwt-simpleNPMUrl]: https://www.npmjs.com/package/jwt-simple
 [jwt-simpleNPMVersionImage]: https://img.shields.io/npm/v/jwt-simple.svg?style=flat

--- a/libs/markdown.js
+++ b/libs/markdown.js
@@ -9,6 +9,10 @@ var isDbg = require('../libs/debug').isDbg;
 var marked = require('marked');
 var hljs = require('highlight.js');
 var sanitizeHtml = require('sanitize-html');
+
+var jsdom = require("jsdom");
+var { JSDOM } = jsdom;
+
 var htmlWhitelistPost = require('./htmlWhitelistPost.json');
 var renderer = new marked.Renderer();
 var blockRenderers = [
@@ -64,21 +68,61 @@ blockRenderers.forEach(function (aType) {
     var sanitized = sanitize(marked.Renderer.prototype[aType].apply(renderer, arguments));
 
     // Autolink most usernames
-    return sanitized.replace(/(^|\s|>)@([^\s\\\/:*?\'\"<>|#;@=&,]+)/gm,
-      function (aMatch, aP1, aP2, aOffset, aString) {
 
-        // Look behind anywhere in chunk
-        if (aString.indexOf('<code>') !== -1 && aString.indexOf('<code>') <= aOffset) {
-          return  aP1 + '@' + aP2; // NOTE: Return as early as possible
+    var dom = new JSDOM('<div id="sandbox"></div>');
+    var win = dom.window;
+    var doc = win.document;
+
+    var hookNode = doc.querySelector('#sandbox');
+
+    var xpr = null;
+    var i = null;
+
+    var textNode = null;
+    var textChunk = null;
+
+    var htmlContainer = null;
+    var thisNode = null;
+
+    hookNode.innerHTML = sanitized;
+
+    xpr = doc.evaluate(
+      './/text()',
+      hookNode,
+      null,
+      win.XPathResult.ORDERED_NODE_SNAPSHOT_TYPE,
+      null
+    );
+
+    if (xpr) {
+      for (i = 0; textNode = xpr.snapshotItem(i++);) {
+        switch(textNode.parentNode.tagName) {
+          case 'PRE':
+          case 'CODE':
+          case 'A':
+            break;
+          default:
+            // replace all instance of @whatever with autolinked
+            textChunk = textNode.textContent.replace(/(^|\s)@([^\s\\\/:*?\'\"<>|#;@=&,]+)/gm,
+              '$1<a href="/users/$2">@$2</a>');
+
+            // Import to virtual DOM element
+            htmlContainer = doc.createElement('span');
+            htmlContainer.classList.add('autolink');
+            htmlContainer.innerHTML = textChunk;
+
+            // Clone everything to remove span element
+            for (thisNode = htmlContainer.firstChild; thisNode; thisNode = thisNode.nextSibling) {
+              textNode.parentNode.insertBefore(thisNode.cloneNode(true), textNode);
+            }
+            textNode.parentNode.removeChild(textNode);
         }
+      }
 
-        // Look behind anywhere in chunk
-        if (aString.indexOf('<pre>') !== -1 && aString.indexOf('<pre>') <= aOffset) {
-          return  aP1 + '@' + aP2; // NOTE: Return as early as possible
-        }
+      sanitized = hookNode.innerHTML
+    }
 
-        return aP1 + '<a href="/users/' + aP2 + '">@' + aP2 + '</a>';
-      });
+    return sanitized;
   };
 });
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "git-rev": "0.2.1",
     "github": "0.2.4",
     "highlight.js": "9.12.0",
+    "jsdom": "11.3.0",
     "jquery": "3.2.1",
     "jwt-simple": "0.5.1",
     "less-middleware": "2.2.1",


### PR DESCRIPTION
* Use a script **disabled** virtual DOM for *node* to autolink in order to find parent if code/pre/a tags e.g. don't link on those but otherwise do
* This still doesn't cover every username but it's more than #1161

NOTE(S):
* Tried using their fragment creation methods however `createElement` was absent during tests

Applies to #735