### PR TITLE
Start tracking and showing browser used to post comments

### DIFF
--- a/controllers/issue.js
+++ b/controllers/issue.js
@@ -345,6 +345,7 @@ exports.open = function (aReq, aRes, aNext) {
       var category = null;
       var topic = aReq.body['discussion-topic'];
       var content = aReq.body['comment-content'];
+      var userAgent = aReq.headers['user-agent'];
       var tasks = [];
 
       // Session
@@ -377,7 +378,7 @@ exports.open = function (aReq, aRes, aNext) {
         }
 
         // Issue Submission
-        discussionLib.postTopic(authedUser, category.slug, topic, content, true,
+        discussionLib.postTopic(authedUser, category.slug, topic, content, true, userAgent,
           function (aDiscussion) {
             if (!aDiscussion) {
               aRes.redirect('/' + category.slugUri + '/open');
@@ -407,6 +408,7 @@ exports.comment = function (aReq, aRes, aNext) {
   //
   var installNameBase = scriptStorage.getInstallNameBase(aReq);
   var type = aReq.params.type;
+  var userAgent = aReq.headers['user-agent'];
 
   Script.findOne({
     installName: scriptStorage.caseSensitive(installNameBase +
@@ -439,7 +441,7 @@ exports.comment = function (aReq, aRes, aNext) {
           return;
         }
 
-        discussionLib.postComment(authedUser, aIssue, content, false,
+        discussionLib.postComment(authedUser, aIssue, content, false, userAgent,
           function (aErr, aDiscussion) {
             aRes.redirect(aDiscussion.path.split('/').map(function (aStr) {
               return encodeURIComponent(aStr);

--- a/models/comment.js
+++ b/models/comment.js
@@ -18,6 +18,7 @@ var commentSchema = new Schema({
   created: Date,
   rating: Number,
   updated: Date,
+  userAgent: String,
 
   // Moderation
   creator: Boolean,

--- a/public/css/common.css
+++ b/public/css/common.css
@@ -373,3 +373,9 @@ ul.flaggedList {
 .form-inline {
   display: inline;
 }
+
+.user-agent {
+  cursor: default;
+  width: 16px;
+  height: 16px;
+}

--- a/views/includes/comment.html
+++ b/views/includes/comment.html
@@ -15,8 +15,9 @@
           </div>
           <div class="post-info pull-right">
             {{#isUpdated}}
-              <time datetime="{{updatedISOFormat}}" title="{{updated}}">edited &bull; </time>
+              <time datetime="{{updatedISOFormat}}" title="{{updated}}">edited</time>
             {{/isUpdated}}
+            <i class="fa fa-globe user-agent" title="{{#userAgent}}{{userAgent}}{{/userAgent}}{{^userAgent}}n/a{{/userAgent}}"></i>
             <a href="#comment-{{id}}" class="post-date">
               <time datetime="{{createdISOFormat}}" title="{{created}}">{{createdHumanized}}</time>
             </a>


### PR DESCRIPTION
* Converted the bullet to an icon from *font-awesome*
* We can make the `background-image` set to an image at some point with `color: transparent;`. Fits within current constraints. e.g. pretty when we add fair use icons *(tried one of mine hard-coded already)*
* The other site shows the full agent and I guess it's not as much of a privacy risk... weighing in more on beneficial to not having to ask "What browser are you using" for support. It is somewhat cosmetic but somewhat useful save for those spoofing which is why it's discrete
* UA shows up on tooltip only, if available, to keep it more discrete. Current shows `n/a` if not collected, and always showing *(prefer this personally esp. when `edited` gets completed)* since this commit starts collection.

Applies to #764 and modification of #601