### PR TITLE
Fix for type `other` on UA

### DIFF
--- a/libs/modelParser.js
+++ b/libs/modelParser.js
@@ -674,8 +674,9 @@ var parseComment = function (aComment) {
   comment.ua.raw = comment.userAgent;
   ua = useragent.parse(comment.userAgent).family.toLowerCase().replace(/\s+/g, '-');
   if (ua !== 'other') {
-    comment.ua.class = 'fa-lg ua-' + useragent.parse(comment.userAgent).family.toLowerCase()
-      .replace(/\s+/g, '-')
+    comment.ua.class = 'fa-lg ua-' + ua;
+  } else if (comment.userAgent) {
+    comment.ua.class = 'fa-lg ua-' + ua;
   }
 
   // Dates


### PR DESCRIPTION
* This is needed for the icon vs. larger if unknown. Test case missed.
* Optimized a bit on redundancy *(sure this could be further minimized but still in testing period)*

Post fix for #764