### PR TITLE
Disable some more of Register during Login

### DIFF
--- a/views/pages/loginPage.html
+++ b/views/pages/loginPage.html
@@ -32,11 +32,11 @@
         </h3>
         <div class="input-group">
           <span class="input-group-addon"><i class="fa fa-user fa-fw"></i></span>
-          <input class="form-control" type="text" name="username" value="{{wantname}}" placeholder="Username"{{^wantname}} disabled="disabled"{{/wantname}}>
+          <input class="form-control" type="text" name="username" value="{{wantname}}"{{#wantname}} placeholder="Username"{{/wantname}}{{^wantname}} disabled="disabled"{{/wantname}}>
           <span class="input-group-btn">
             <select name="auth" class="btn btn-addon-default" style="border-radius: 0px;">
               {{#strategies}}
-              <option value="{{strat}}" {{#selected}}selected="selected"{{/selected}}{{^wantname}} disabled="disabled"{{/wantname}}>{{display}}</option>
+              <option value="{{strat}}" {{#wantname}}{{#selected}}selected="selected"{{/selected}}{{/wantname}}{{^wantname}} disabled="disabled"{{/wantname}}>{{display}}</option>
               {{/strategies}}
             </select>
           </span>
@@ -45,7 +45,7 @@
           </span>
         </div>
         <div class="alert alert-warning small" role="alert">
-          <i class="fa fa-exclamation-triangle"></i> <strong>CAUTION</strong>: The unique Username that you choose to attach here will be displayed to everyone as shown above. It is strongly recommended to <strong>not</strong> use an email address.<br><br>Additional changes to the Username above may include additional sanitizing for web friendly urls and Userscript engine compatibility. If you wish to see the sanitization changes please reload this page and start over.
+          <i class="fa fa-exclamation-triangle"></i> <strong>CAUTION</strong>: The unique Username that you choose to attach here will be displayed to everyone as shown above. It is strongly recommended to <strong>not</strong> use an email address.<br><br>Additional changes to the registering Username above may include additional sanitizing for web friendly URLs and Userscript engine compatibility. If you wish to see the sanitization changes please <a href="javascript:void(0);" onclick="history.go(0)">reload this page</a> and start over.
         </div>
       </form>
     </div>


### PR DESCRIPTION
* Don't select default auth.
* Hide some more of the items that are disabled
* Put a local page reload in the alert in case the nav bar is collapsed. `history.go(0)` only attempts reloads the page and no other resources.

Applies to #1174