### PR TITLE
Destroy session completely

### DIFF
--- a/libs/modifySessions.js
+++ b/libs/modifySessions.js
@@ -62,12 +62,16 @@ exports.add = function (aReq, aUser, aCallback) {
   }
 };
 
-// Remove a session id from the user model
+// Remove a session id from the user model **and** the session store
 exports.remove = function (aReq, aUser, aCallback) {
   var pos = aUser && aUser.sessionIds ?
     aUser.sessionIds.indexOf(aReq.sessionID) : -1;
 
-  delete aReq.session.user;
+  if (aReq.session.destroy) {
+    aReq.session.destroy();
+  } else { // TODO: Remove conditional and this fallback when satisifed
+    delete aReq.session.user;
+  }
 
   if (pos > -1) {
     aUser.sessionIds.splice(pos, 1);


### PR DESCRIPTION
* When logging out destroy the current session not only in the User model but also the session store
* Currently `maxAge` is set to expire at browser session end... client side cookie goes away at browser private data clear but sessionId in the store sticks around for quite some time. Logging out means destroy it and login again later.
* Leaving the old `delete` in for extra cautiousness... not really needed imho as it throws an error outside of it after `destroy()`

Related to #604