### PR TITLE
Set `maxAge` idle session to four (4) hours

### DIFF
--- a/app.js
+++ b/app.js
@@ -289,7 +289,9 @@ app.use(session({
   resave: false,
   saveUninitialized: false,
   unset: 'destroy',
-  cookie: { maxAge: null },
+  cookie: {
+    maxAge: 4 * 60 * 60 * 1000 // 4 hours in ms
+  },
   secret: sessionSecret,
   store: sessionStore
 }));


### PR DESCRIPTION
* This can be tweaked to slightly larger but the default of two weeks server side is too much. Sync both client access and server expiration to this value.
* Going to bump all stored sessions in a few moments

Related to #604