### PR TITLE
Don't stall npm init on exit code

### DIFF
--- a/dev/init.js
+++ b/dev/init.js
@@ -157,10 +157,10 @@ var tasks = [
     });
   },
   function (aStdouts, aCallback) {
-    var cmd = 'npm --depth 0 outdated';
+    var cmd = 'npm outdated';
 
     exec(cmd, function (aErr, aStdout, aStderr) {
-      if (aErr) {
+      if (aErr && aErr.code !== 1) {
         aCallback(aErr);
         return;
       }


### PR DESCRIPTION
* code = 1 on `npm outdated` however runs fine... possibly indicating deps are out date.
* `oudated` presumes a depth of zero so remove that