### PR TITLE
Implement basic OSI `@license` check and reject

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Repository | Reference | Recent Version
 [select2][select2GHUrl] | [Documentation][select2DOCUrl] | [![NPM version][select2NPMVersionImage]][select2NPMUrl]
 [select2-bootstrap-css][select2-bootstrap-cssGHUrl] | [Documentation][select2-bootstrap-cssDOCUrl] | [![NPM version][select2-bootstrap-cssNPMVersionImage]][select2-bootstrap-cssNPMUrl]
 [serve-favicon][serve-faviconGHUrl] | [Documentation][serve-faviconDOCUrl] | [![NPM version][serve-faviconNPMVersionImage]][serve-faviconNPMUrl]
+[spdx-is-osi][spdx-is-osiGHUrl] | [Documentation][spdx-is-osiDOCUrl] | [![NPM version][spdx-is-osiNPMVersionImage]][spdx-is-osiNPMUrl]
 [toobusy-js][toobusy-jsGHUrl] <br />&#x22D4; [`harmony`][toobusy-jsGHUrlHarmonyUrl] | [Documentation][toobusy-jsDOCUrl] | [![NPM version][toobusy-jsNPMVersionImage]][toobusy-jsNPMUrl]
 [uglifyJS][uglifyJS2GHUrl] <br />&#x21B3; [`harmony`][uglifyJS2GHHarmonyUrl] | [Documentation][uglifyJS2DOCUrl] [&#x00b9;][uglifyJS2DOC1Url] | [![NPM version][uglifyJS2NPMVersionImage]][uglifyJS2NPMUrl] <br />&#x21B3; [![NPM Harmony version][uglifyJS2NPMHarmonyVersionImage]][uglifyJS2NPMHarmonyUrl]
 [underscore][underscoreGHUrl] | [Documentation][underscoreDOCUrl] | [![NPM version][underscoreNPMVersionImage]][underscoreNPMUrl]
@@ -445,6 +446,11 @@ Outdated dependencies list can also be achieved with `$ npm --depth 0 outdated`
 [serve-faviconDOCUrl]: https://github.com/expressjs/serve-favicon/blob/master/README.md
 [serve-faviconNPMUrl]: https://www.npmjs.com/package/serve-favicon
 [serve-faviconNPMVersionImage]: https://img.shields.io/npm/v/serve-favicon.svg?style=flat
+
+[spdx-is-osiGHUrl]: https://github.com/jslicense/spdx-is-osi.js
+[spdx-is-osiDOCUrl]: https://github.com/jslicense/spdx-is-osi.js/blob/master/README.md
+[spdx-is-osiNPMUrl]: https://www.npmjs.com/package/spdx-is-osi
+[spdx-is-osiNPMVersionImage]: https://img.shields.io/npm/v/spdx-is-osi.svg?style=flat
 
 [toobusy-jsGHUrl]: https://github.com/STRML/node-toobusy
 [toobusy-jsGHUrlHarmonyUrl]: https://github.com/OpenUserJs/node-toobusy/tree/harmony

--- a/libs/htmlWhitelistWeb.json
+++ b/libs/htmlWhitelistWeb.json
@@ -1,0 +1,16 @@
+{
+  "allowedTags": [
+    "a"
+  ],
+  "allowedAttributes": {
+    "a": [
+      "href"
+    ]
+  },
+  "selfClosing": [
+  ],
+  "allowedSchemes": [
+    "http",
+    "https"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "select2": "3.5.2-browserify",
     "select2-bootstrap-css": "1.4.6",
     "serve-favicon": "2.4.5",
+    "spdx-is-osi": "0.1.2",
     "toobusy-js-harmony": "git://github.com/OpenUserJs/node-toobusy#harmony",
     "uglify-js": "3.1.6",
     "uglify-es": "3.1.6",

--- a/public/pegjs/blockOpenUserJS.pegjs
+++ b/public/pegjs/blockOpenUserJS.pegjs
@@ -7,9 +7,33 @@ Test the generated parser with some input for peg.js site at https://pegjs.org/o
 // @author          Marti
 // @collaborator    sizzle
 // @unstableMinify  Some reason
+// @name            RFC 2606§3 - Hello, World!
+// @name:es         ¡Hola mundo!
+// @name:fr         Salut tout le monde!
+// @description     Test values with known UserScript metadata keys.
+// @description:es  Prueba de valores con UserScript metadatos llaves conocidas.
+// @description:fr  Valeurs d'essai avec des clés de métadonnées UserScript connues.
+// @version       1.2.3
+// @license       GPL version 3 or any later version; http://www.gnu.org/copyleft/gpl.html
+// @licence       (CC); https://creativecommons.org/licenses/by-nc-sa/3.0/
+// @copyright     2013+, OpenUserJS Group (https://github.com/orgs/OpenUserJs/people)
 // ==/OpenUserJS==
 
 */
+
+{
+  var upmix = function (aKeyword) {
+    // Keywords need to mirrored in the below rules for detection and transformation
+    switch (aKeyword) {
+      case 'licence':
+        aKeyword = 'license';
+        break;
+    }
+
+    return aKeyword;
+  }
+}
+
 
 block =
   '// ==OpenUserJS==\n'
@@ -24,7 +48,8 @@ line =
   data:
     (
       item1 /
-      items1
+      items1 /
+      item1Localized
     )
   '\n'?
   {
@@ -36,10 +61,11 @@ non_whitespace = $[^ \t\n]+
 non_newline = $[^\n]+
 
 item1 =
-  key:
+  keyword:
     (
       'author' /
-      'unstableMinify'
+      'unstableMinify' /
+      'version'
     )
   whitespace
   value: non_newline
@@ -47,21 +73,54 @@ item1 =
     return {
       unique: true,
 
-      key: key,
+      key: upmix(keyword),
       value: value.replace(/\s+$/, '')
     };
   }
 
-items1 =
-  key:
+item1Localized =
+  keyword:
     (
-      'collaborator'
+      'name' /
+      'description'
+    )
+  locale: (':' localeValue:$[a-zA-Z-]+ {
+    return localeValue;
+  })?
+  whitespace
+  value: non_newline
+  {
+    var keywordUpmixed = upmix(keyword);
+
+    var obj = {
+      unique: true,
+
+      key: keywordUpmixed,
+      value: value.replace(/\s+$/, '')
+    }
+
+    if (locale) {
+      obj.key += ':' + locale;
+      obj.keyword = keywordUpmixed;
+      obj.locale = locale;
+    }
+
+    return obj;
+  }
+
+items1 =
+  keyword:
+    (
+      'collaborator' /
+      'license' /
+      'licence' /
+      'copyright'
     )
   whitespace
   value: non_newline
   {
     return {
-      key: key,
+      key: upmix(keyword),
       value: value.replace(/\s+$/, '')
     };
   }

--- a/views/pages/newScriptPage.html
+++ b/views/pages/newScriptPage.html
@@ -30,7 +30,7 @@
             <div class="panel panel-default">
               <div class="panel-heading">
                 <h5 class="panel-title">
-                  <a data-toggle="collapse" data-parent="#accordion-userscript-block" href="#collapse-name"><code>@name My Script</code></a>
+                  <a class="small"  data-toggle="collapse" data-parent="#accordion-userscript-block" href="#collapse-name"><code>@name My Script</code></a>
                 </h5>
               </div>
               <div id="collapse-name" class="panel-collapse collapse in">
@@ -40,7 +40,7 @@
             <div class="panel panel-default">
               <div class="panel-heading">
                 <h5 class="panel-title">
-                  <a data-toggle="collapse" data-parent="#accordion-userscript-block" href="#collapse-description"><code>@description This script even does the laundry!</code></a>
+                  <a class="small" data-toggle="collapse" data-parent="#accordion-userscript-block" href="#collapse-description"><code>@description This script even does the laundry!</code></a>
                 </h5>
               </div>
               <div id="collapse-description" class="panel-collapse collapse">
@@ -50,7 +50,7 @@
             <div class="panel panel-default">
               <div class="panel-heading">
                 <h5 class="panel-title">
-                  <a data-toggle="collapse" data-parent="#accordion-userscript-block" href="#collapse-copyright"><code>@copyright Year, Author (Author Website)</code></a>
+                  <a class="small" data-toggle="collapse" data-parent="#accordion-userscript-block" href="#collapse-copyright"><code>@copyright Year, Author (Author Website)</code></a>
                 </h5>
               </div>
               <div id="collapse-copyright" class="panel-collapse collapse">
@@ -60,17 +60,17 @@
             <div class="panel panel-default">
               <div class="panel-heading">
                 <h5 class="panel-title">
-                  <a data-toggle="collapse" data-parent="#accordion-userscript-block" href="#collapse-license"><code>@license License Type; License Homepage</code></a>
+                  <a class="small" data-toggle="collapse" data-parent="#accordion-userscript-block" href="#collapse-license"><code>@license License Type; License Homepage</code></a>
                 </h5>
               </div>
-              <div id="collapse-license" class="panel-collapse collapse">
-                <div class="panel-body">Specially formatted on the script page. All values shown in reverse order. If absent <a href="https://spdx.org/licenses/MIT.html"><code>MIT</code></a> <a href="https://opensource.org/licenses/MIT">License <em>(Expat)</em></a> is implied. See <a href="/about/Terms-of-Service#licensing">licensing terms</a> for specifics.</div>
+              <div id="collapse-license" class="panel-collapse collapse in">
+                <div class="panel-body"><p>Specially formatted on the script page. All values shown in reverse order. If absent <a href="https://spdx.org/licenses/MIT.html"><code>MIT</code></a> <a href="https://opensource.org/licenses/MIT">License <em>(Expat)</em></a> is implied. See <a href="/about/Terms-of-Service#licensing">licensing terms</a> for specifics.</p><p><strong><code>License Type</code> component is required</strong> using at least one <a href="https://opensource.org/licenses/category">OSI approved</a> <a href="https://spdx.org/licenses/">SPDX short identifier</a> and must the primary, last, <code>@license</code> key. Single short ids are accepted only per license key. e.g. No conjunctions like <code>AND</code> or <code>OR</code>. These are handled by multiple <code>@license</code> keys.</p><p><strong><code>; License Homepage</code> component is currently optional</strong></p><p>Single Licensed Example <em>(No specific document license web reference)</em>:<pre class="small"><code>// ==UserScript==</code><br /><code>// ...</code><br /><code>// @license MIT</code><br /><code>// ...</code><br /><code>// ==/UserScript==</code></pre></p><p>Dual Licensed Example <em>(Specific document license web references)</em>:<pre class="small"><code>// ==UserScript==</code><br /><code>// ...</code><br /><code>// @license CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode</code><br /><code>// @license GPL-3.0+; http://www.gnu.org/licenses/gpl-3.0.txt</code><br /><code>// ...</code><br /><code>// ==/UserScript==</code></pre></p></div>
               </div>
             </div>
             <div class="panel panel-default">
               <div class="panel-heading">
                 <h5 class="panel-title">
-                  <a data-toggle="collapse" data-parent="#accordion-userscript-block" href="#collapse-icon"><code>@icon url</code></a>
+                  <a class="small" data-toggle="collapse" data-parent="#accordion-userscript-block" href="#collapse-icon"><code>@icon url</code></a>
                 </h5>
               </div>
               <div id="collapse-icon" class="panel-collapse collapse">
@@ -80,7 +80,7 @@
             <div class="panel panel-default">
               <div class="panel-heading">
                 <h5 class="panel-title">
-                  <a data-toggle="collapse" data-parent="#accordion-userscript-block" href="#collapse-homepageurl"><code>@homepageURL url</code></a>
+                  <a class="small" data-toggle="collapse" data-parent="#accordion-userscript-block" href="#collapse-homepageurl"><code>@homepageURL url</code></a>
                 </h5>
               </div>
               <div id="collapse-homepageurl" class="panel-collapse collapse">
@@ -90,7 +90,7 @@
             <div class="panel panel-default">
               <div class="panel-heading">
                 <h5 class="panel-title">
-                  <a data-toggle="collapse" data-parent="#accordion-userscript-block" href="#collapse-supporturl"><code>@supportURL url</code></a>
+                  <a class="small" data-toggle="collapse" data-parent="#accordion-userscript-block" href="#collapse-supporturl"><code>@supportURL url</code></a>
                 </h5>
               </div>
               <div id="collapse-supporturl" class="panel-collapse collapse">
@@ -100,7 +100,7 @@
             <div class="panel panel-default">
               <div class="panel-heading">
                 <h5 class="panel-title">
-                  <a data-toggle="collapse" data-parent="#accordion-userscript-block" href="#collapse-version"><code>@version 1.0.0</code></a>
+                  <a class="small" data-toggle="collapse" data-parent="#accordion-userscript-block" href="#collapse-version"><code>@version 1.0.0</code></a>
                 </h5>
               </div>
               <div id="collapse-version" class="panel-collapse collapse">
@@ -110,7 +110,7 @@
             <div class="panel panel-default">
               <div class="panel-heading">
                 <h5 class="panel-title">
-                  <a data-toggle="collapse" data-parent="#accordion-userscript-block" href="#collapse-updateurl"><code>@updateURL https://openuserjs.org/meta/{{#authedUser}}{{authedUser.name}}{{/authedUser}}{{^authedUser}}username{{/authedUser}}/My_Script.meta.js</code></a>
+                  <a class="small" data-toggle="collapse" data-parent="#accordion-userscript-block" href="#collapse-updateurl"><code>@updateURL https://openuserjs.org/meta/{{#authedUser}}{{authedUser.name}}{{/authedUser}}{{^authedUser}}username{{/authedUser}}/My_Script.meta.js</code></a>
                 </h5>
               </div>
               <div id="collapse-updateurl" class="panel-collapse collapse in">
@@ -123,17 +123,17 @@
             <div class="panel panel-default">
               <div class="panel-heading">
                 <h5 class="panel-title">
-                  <a data-toggle="collapse" data-parent="#accordion-openuserjs-block" href="#collapse-oujs-author"><code>@author {{#authedUser}}{{authedUser.name}}{{/authedUser}}{{^authedUser}}username{{/authedUser}}</code></a>
+                  <a class="small" data-toggle="collapse" data-parent="#accordion-openuserjs-block" href="#collapse-oujs-author"><code>@author {{#authedUser}}{{authedUser.name}}{{/authedUser}}{{^authedUser}}username{{/authedUser}}</code></a>
                 </h5>
               </div>
               <div id="collapse-oujs-author" class="panel-collapse collapse in">
-                <div class="panel-body">The author of the script. Required to enable <a href="#collaboration">Collaboration</a>. Last value shown.</div>
+                <div class="panel-body">The author of the script. <strong>Required to enable <a href="#collaboration">Collaboration</a></strong>. Last value shown.</div>
               </div>
             </div>
             <div class="panel panel-default">
               <div class="panel-heading">
                 <h5 class="panel-title">
-                  <a data-toggle="collapse" data-parent="#accordion-openuserjs-block" href="#collapse-oujs-collaboration"><code>@collaborator username</code></a>
+                  <a class="small" data-toggle="collapse" data-parent="#accordion-openuserjs-block" href="#collapse-oujs-collaboration"><code>@collaborator username</code></a>
                 </h5>
               </div>
               <div id="collapse-oujs-collaboration" class="panel-collapse collapse">
@@ -239,7 +239,7 @@
           <h3>Collaboration</h3>
           <div class="panel panel-default">
             <div class="panel-body">
-              <p>To allow other users to upload modified versions of your script to your account from this site create an OpenUserJS metadata block and add the necessary keys... one for you yourself and for every existing user you wish to give write access as demonstrated here:<pre><code>// ==OpenUserJS==</code><br /><code>// @author {{#authedUser}}{{authedUser.name}}{{/authedUser}}{{^authedUser}}username{{/authedUser}}</code><br /><code>// @collaborator username</code><br /><code>// ==/OpenUserJS==</code></pre> Only the real author of the script may modify these metadata keys.</p>
+              <p>To allow other users to upload modified versions of your script to your account from this site create an OpenUserJS metadata block and add the necessary keys... one for you yourself and for every existing user you wish to give write access as demonstrated here:<pre class="small"><code>// ==OpenUserJS==</code><br /><code>// @author {{#authedUser}}{{authedUser.name}}{{/authedUser}}{{^authedUser}}username{{/authedUser}}</code><br /><code>// @collaborator username</code><br /><code>// ==/OpenUserJS==</code></pre> Only the real author of the script may modify these metadata keys.</p>
               <p>Collaborators on this site may not use GitHub integration to update the script. Add them as collaborators to the GitHub repository instead.</p>
               <p>If the webhook is enabled on the GitHub repository it will clobber any changes here on this site.</p>
             </div>


### PR DESCRIPTION
* Start collecting for OpenUserJS block keys for eventual library usage
* Authors **must use** SPDX codes in `@license` e.g. `GPL-3.0+` or `MIT`, etc. and optional document target following `; `
* Not currently enforcing mandatory OSI due to current arbitration... but this will probably change after a period
* Turn on `in` focus on accordions to emphasize this change for a while and fill out some examples.
* Reduce font size a bit on sample keys

Applies to #438