### PR TITLE
Break on all

### DIFF
--- a/public/css/common.css
+++ b/public/css/common.css
@@ -246,6 +246,10 @@ h6:hover a.anchor {
   visibility: visible;
 }
 
+.script-meta {
+  word-break: break-all;
+}
+
 .user-content > :first-child,
 .panel-body > :first-child {
   margin-top: 0;


### PR DESCRIPTION
* Userscript meta busts layout on Android Chrome by overflow and on SM desktop it adds a scrollbar... break on all characters.