### PR TITLE
More sanity checks with rejections on non-urls

### DIFF
--- a/controllers/scriptStorage.js
+++ b/controllers/scriptStorage.js
@@ -47,6 +47,7 @@ var RepoManager = require('../libs/repoManager');
 var cleanFilename = require('../libs/helpers').cleanFilename;
 var findDeadorAlive = require('../libs/remove').findDeadorAlive;
 var encode = require('../libs/helpers').encode;
+var isFQUrl = require('../libs/helpers').isFQUrl;
 var countTask = require('../libs/tasks').countTask;
 var modelParser = require('../libs/modelParser');
 
@@ -1171,6 +1172,9 @@ exports.storeScript = function (aUser, aMeta, aBuf, aCallback, aUpdate) {
   var installName = aUser.name + '/';
   var collaboration = false;
   var requires = null;
+  var supportUrl = null;
+  var homepageUrls = null;
+  var homepageUrl = null;
   var match = null;
   var rLibrary = new RegExp(
     '^(?:(?:(?:https?:)?\/\/' +
@@ -1285,7 +1289,9 @@ exports.storeScript = function (aUser, aMeta, aBuf, aCallback, aUpdate) {
 
       if (thisKeyComponents.length === 2) {
         htmlStub = '<a href="' + thisKeyComponents[1] + '"></a>';
-        if (htmlStub !== sanitizeHtml(htmlStub, htmlWhitelistWeb)) {
+        if (htmlStub !== sanitizeHtml(htmlStub, htmlWhitelistWeb)
+          || !isFQUrl(thisKeyComponents[1])) {
+
           // Not a web url... reject
           aCallback(null);
           return;
@@ -1314,6 +1320,32 @@ exports.storeScript = function (aUser, aMeta, aBuf, aCallback, aUpdate) {
     // Keysets do not match exactly... reject
     aCallback(null);
     return;
+  }
+
+
+  // `@supportURL` validations
+  supportUrl = findMeta(aMeta, 'UserScript.supportURL.0.value');
+  htmlStub = '<a href="' + supportUrl + '"></a>';
+  if (htmlStub !== sanitizeHtml(htmlStub, htmlWhitelistWeb)
+    || !isFQUrl(supportUrl)) {
+
+    // Not a web url... reject
+    aCallback(null);
+    return;
+  }
+
+
+  // `@homepageURL` validations
+  homepageUrls = findMeta(aMeta, 'UserScript.homepageURL.value');
+  for (i = 0; homepageUrl = homepageUrls[i++];) {
+    htmlStub = '<a href="' + homepageUrl + '"></a>';
+    if (htmlStub !== sanitizeHtml(htmlStub, htmlWhitelistWeb)
+      || !isFQUrl(homepageUrl)) {
+
+      // Not a web url... reject
+      aCallback(null);
+      return;
+    }
   }
 
 

--- a/libs/helpers.js
+++ b/libs/helpers.js
@@ -148,6 +148,43 @@ exports.updateUrlQueryString = function (aBaseUrl, aDict) {
   return url;
 };
 
+exports.isFQUrl = function (aString) {
+  var URL = url.parse(aString);
+
+  var protocol = URL.protocol;
+  var username = URL.username; // NOTE: BUG: in current *node*
+  var password = URL.password; // NOTE: BUG: in current *node*
+  var hostname = URL.hostname;
+  var port = URL.port;
+  var pathname = URL.pathname;
+  var search = URL.search;
+  var hash = URL.hash;
+
+  var source = encodeURIComponent(aString);
+  var target = null;
+
+  if (protocol && /https?/.test(protocol)) {
+    if (hostname) {
+      target = encodeURIComponent(protocol)
+        + encodeURIComponent('//')
+          + encodeURIComponent(username ? username : '')
+            + encodeURIComponent(password ? ':' + password : '')
+
+              + (username || password ? encodeURIComponent('@') : '')
+
+                + encodeURIComponent(hostname)
+                  + encodeURIComponent(port ? ':' + port : '')
+                    + encodeURIComponent(pathname)
+                      + encodeURIComponent(search ? search : '')
+                        + encodeURIComponent(hash ? hash : '');
+
+      return target === source;
+    }
+  }
+
+  return false;
+}
+
 // Helper function to ensure value is type Integer `number` or `null`
 // Please be very careful if this is edited
 exports.ensureIntegerOrNull = function (aEnvVar) {


### PR DESCRIPTION
* This isn't perfect but neither is every other package I've tried
* These urls should always be fully qualified as well since GM polls them and a relative/absolute non-FQ doesn't do any good