### PR TITLE
Subclass the `Error` object

### DIFF
--- a/libs/debug.js
+++ b/libs/debug.js
@@ -7,3 +7,15 @@ var isDbg = typeof v8debug === 'object';
 exports.isPro = isPro;
 exports.isDev = isDev;
 exports.isDbg = isDbg;
+
+// ES6+ in use to eliminate extra property
+class statusError extends Error {
+  constructor (aStatus, aCode) {
+    super(JSON.stringify(aStatus, null, ' '));
+    this.name = this.constructor.name;
+    Error.captureStackTrace(this, this.constructor);
+    this.status = aStatus;
+    this.code = aCode;
+  }
+}
+exports.statusError = statusError;


### PR DESCRIPTION
* Some reworking of graceful failures to indicate what they are
* This probably should have been done around the time `statusCodePage` was implemented with ES5 compatible inheritance. May move this routine to debug.js
* One comment BUG fixed
* These trapped errors are `throw`able if we choose

NOTES:
* Almost named the inherited `Error` Object as `userError` since that's what most of these end up being. ;)
* **NOT** tested yet with the webhook... have to merge first. GitHub doesn't seem to show the statusMessage so might be out of luck here. 400 is User Error 500 is Server Error *(usually... have a few Watchpoints to figure out if they are the correct code)*
* This is pass number 1 ... optimizing/tweaking will come later after this testing and additional respite... including some possible status code changes

Applies to #37