### PR TITLE
Ensure `isLib` param is never `undefined`

### DIFF
--- a/controllers/script.js
+++ b/controllers/script.js
@@ -48,6 +48,7 @@ var removeReasons = require('../views/includes/scriptModals.json').removeReasons
 exports.new = function (aController) {
   return (function (aReq, aRes, aNext) {
     aReq.params.isNew = true;
+    aReq.params.isLib = false; // NOTE: Set default .user.js and overridden below
     aController(aReq, aRes, aNext);
   });
 };

--- a/views/includes/scripts/scriptEditor.html
+++ b/views/includes/scripts/scriptEditor.html
@@ -13,7 +13,7 @@
       var hasChanged = false;
       var placeholder = null;
       var username = '{{authedUser.name}}' || 'username';
-      var isLib = !!'{{isLib}}';
+      var isLib = {{isLib}};
       var now = new Date();
       var year = now.getFullYear();
 


### PR DESCRIPTION
* Fixes a hidden boog underneath an existing .user.js with the incorrect placeholder

Applies to #1232