### PR TITLE
Bump icon dimension limits one more time

### DIFF
--- a/controllers/scriptStorage.js
+++ b/controllers/scriptStorage.js
@@ -1384,14 +1384,33 @@ exports.storeScript = function (aUser, aMeta, aBuf, aUpdate, aCallback) {
     function (aInnerCallback) {
       // `@icon` validations
       var icon = null;
-      var maxX = 128; // px
-      var maxY = 128; // px
       var buffer = null;
       var fn = null;
       var dimensions = null;
       var matches = null;
       var data = null;
       var rDataURIbase64 = /^data:image\/.+;base64,(.*)$/;
+
+      function acceptedImage(aDimensions) {
+        var maxX = 256; //px
+        var maxY = 256; //px
+
+        switch (aDimensions.type) {
+          case 'gif':
+            // fallthrough
+          case 'jpeg':
+            // fallthrough
+          case 'png':
+            // fallthrough
+          case 'svg':
+            // fallthrough
+          case 'ico':
+            if (dimensions.width <= maxX && dimensions.height <= maxY) {
+              return true;
+            }
+        }
+        return false;
+      }
 
       icon = findMeta(aMeta, 'UserScript.icon.0.value');
       if (icon) {
@@ -1421,9 +1440,9 @@ exports.storeScript = function (aUser, aMeta, aBuf, aUpdate, aCallback) {
               return;
             }
 
-            if (dimensions.width > maxX || dimensions.height > maxY) {
+            if (!acceptedImage(dimensions)) {
               aInnerCallback(new statusError({
-                message: '`@icon` dimensions are too large.',
+                message: '`@icon` unsupported file type or dimensions are too large.',
                 code: 400
               }), null);
             } else {
@@ -1453,9 +1472,9 @@ exports.storeScript = function (aUser, aMeta, aBuf, aUpdate, aCallback) {
                 return;
               }
 
-              if (dimensions.width > maxX || dimensions.height > maxY) {
+              if (!acceptedImage(dimensions)) {
                 aInnerCallback(new statusError({
-                  message: '`@icon` dimensions are too large.',
+                  message: '`@icon` unsupported file type or dimensions are too large.',
                   code: 400
                 }), null);
               } else {


### PR DESCRIPTION
* Consolidate test into an inline function for reuse
* Check detected types and reject the rest... may add to later

NOTES:
* This is as much as I prefer to go *(may change)*... otherwise the user experience on OUJS will be diminished by excessive bandwidth from client to whatever target.
* Ideally these shouldn't be more than 48px by 48px if an author is being nice to their users as well as visitors but do understand some hosting sites kick it up a bit without scaling.

Post #1303