### PR TITLE
Accomodate dev fix

### DIFF
--- a/libs/modelParser.js
+++ b/libs/modelParser.js
@@ -384,7 +384,7 @@ var parseScript = function (aScript) {
   parseDateProperty(script, '_since'); // Virtual
 
   // Hash
-  script.hashShort = script.hash.substr(0, 7);
+  script.hashShort = script.hash ? script.hash.substr(0, 7) : 'undefined';
 
   if (script._since && script.updated && script._since.toString() !== script.updated.toString()) {
     script.isUpdated = true;


### PR DESCRIPTION
* Too lazy to set `Script.hash` to a value for listed scripts that I haven't created on dev. ;) Pro doesn't have this issue since it was manually set for every script source when this `hash` feature was first introduced. S3 had source fakeS3 doesn't for non-owned.

Post #1312