### PR TITLE
Patch webhook

### DIFF
--- a/controllers/scriptStorage.js
+++ b/controllers/scriptStorage.js
@@ -1950,7 +1950,9 @@ exports.webhook = function (aReq, aRes) {
     // Gather the modified user scripts
     payload.commits.forEach(function (aCommit) {
       aCommit.modified.forEach(function (aFilename) {
-        if (aFilename.substr(-8) === '.user.js' || aFilename.substr(-3) === '.js') {
+        if (aFilename.substr(-8) === '.user.js'
+          || (aFilename.substr(-3) === '.js' && aFilename.substr(-8) !== '.meta.js')) {
+
           repo[aFilename] = '/' + encodeURI(aFilename); // NOTE: Watchpoint
         }
       });


### PR DESCRIPTION
* Patch the webhook so it ignores .meta.js files since those can be sent out when an author utilizes their own .meta.js
* Again this can probably be minimized to just the initial `*.js` check however get to guess and test blind here.

Post #1260