### PR TITLE
Improve the prior patch on import sections

### DIFF
--- a/controllers/scriptStorage.js
+++ b/controllers/scriptStorage.js
@@ -1950,9 +1950,7 @@ exports.webhook = function (aReq, aRes) {
     // Gather the modified user scripts
     payload.commits.forEach(function (aCommit) {
       aCommit.modified.forEach(function (aFilename) {
-        if (aFilename.substr(-8) === '.user.js'
-          || (aFilename.substr(-3) === '.js' && aFilename.substr(-8) !== '.meta.js')) {
-
+        if (aFilename.substr(-3) === '.js' && aFilename.substr(-8) !== '.meta.js') {
           repo[aFilename] = '/' + encodeURI(aFilename); // NOTE: Watchpoint
         }
       });

--- a/libs/githubClient.js
+++ b/libs/githubClient.js
@@ -81,7 +81,7 @@ var githubUserContentGetBlobAsUtf8 = function (aMsg, aCallback) {
 github.usercontent.getBlobAsUtf8 = githubUserContentGetBlobAsUtf8;
 
 var githubGitDataIsJavascriptBlob = function (aBlob) {
-  return aBlob.path.match(/\.js$/);
+  return (aBlob.path.match(/\.js$/) && !aBlob.path.match(/\.meta\.js$/));
 };
 github.gitdata.isJavascriptBlob = githubGitDataIsJavascriptBlob;
 


### PR DESCRIPTION
* e.g. don't show .meta.js
* Optimizing old patch as well for webhook

Applies to #1317 #1260