### PR TITLE
Restore some of the `@icon` checks until resolved

### DIFF
--- a/controllers/scriptStorage.js
+++ b/controllers/scriptStorage.js
@@ -1381,121 +1381,130 @@ exports.storeScript = function (aUser, aMeta, aBuf, aUpdate, aCallback) {
 
       aInnerCallback(null);
     },
-//
-//  See #1323
-//     function (aInnerCallback) {
-//       // `@icon` validations
-//       var icon = null;
-//       var buffer = null;
-//       var fn = null;
-//       var dimensions = null;
-//       var matches = null;
-//       var data = null;
-//       var rDataURIbase64 = /^data:image\/.+;base64,(.*)$/;
-//
-//       function acceptedImage(aDimensions) {
-//         var maxX = 256; //px
-//         var maxY = 256; //px
-//
-//         switch (aDimensions.type) {
-//           case 'gif':
-//             // fallthrough
-//           case 'jpeg':
-//             // fallthrough
-//           case 'png':
-//             // fallthrough
-//           case 'svg':
-//             // fallthrough
-//           case 'ico':
-//             if (dimensions.width <= maxX && dimensions.height <= maxY) {
-//               return true;
-//             }
-//         }
-//         return false;
-//       }
-//
-//       icon = findMeta(aMeta, 'UserScript.icon.0.value');
-//       if (icon) {
-//         if (!isFQUrl(icon, false, true)) {
-//
-//           // Not a web url... reject
-//           aInnerCallback(new statusError({
-//             message: '`@icon` not a web url or image data URI in the UserScript metadata block.',
-//             code: 400
-//           }), null);
-//           return;
-//         }
-//
-//         // Test dimensions
-//         if (/^data:/.test(icon)) {
-//           matches = icon.match(rDataURIbase64);
-//           if (matches) {
-//             data = matches[1];
-//             buffer = new Buffer(data, 'base64');
-//             try {
-//               dimensions = sizeOf(buffer);
-//             } catch (aE) {
-//               aInnerCallback(new statusError({
-//                 message: '`@icon` ' + aE.message,
-//                 code: aE.code
-//               }));
-//               return;
-//             }
-//
-//             if (!acceptedImage(dimensions)) {
-//               aInnerCallback(new statusError({
-//                 message: '`@icon` unsupported file type or dimensions are too large.',
-//                 code: 400
-//               }), null);
-//             } else {
-//               aInnerCallback(null);
-//             }
-//           } else {
-//             aInnerCallback(new statusError({
-//               message: 'Invalid `@icon`',
-//               code: 400
-//             }), null);
-//           }
-//         } else {
-//           fn = /^http:/.test(icon) ? http : https;
-//           fn.get(URL.parse(icon), function (aRes) {
-//             var chunks = [];
-//             aRes.on('data', function (aChunk) {
-//               var buf = null;
-//               chunks.push(aChunk);
-//               buf = Buffer.concat(chunks);
-//               if (buf.length > 3048) { // NOTE: KiB
-//                 aRes.destroy();
-//               }
-//             }).on('end', function () {
-//               buffer = Buffer.concat(chunks);
-//               try {
-//                 dimensions = sizeOf(buffer);
-//               } catch (aE) {
-//                 aInnerCallback(new statusError({
-//                   message: '`@icon` ' + aE.message,
-//                   code: aE.code
-//                 }));
-//                 return;
-//               }
-//
-//               if (!acceptedImage(dimensions)) {
-//                 aInnerCallback(new statusError({
-//                   message: '`@icon` unsupported file type or dimensions are too large.',
-//                   code: 400
-//                 }), null);
-//               } else {
-//                 aInnerCallback(null);
-//               }
-//             }).on('error', function (aErr) {
-//               aInnerCallback(aErr);
-//             });
-//           });
-//         }
-//       } else {
-//         aInnerCallback(null);
-//       }
-//     },
+
+    function (aInnerCallback) {
+      // `@icon` validations
+      var icon = null;
+      var buffer = null;
+      var fn = null;
+      var dimensions = null;
+      var matches = null;
+      var data = null;
+      var rDataURIbase64 = /^data:image\/.+;base64,(.*)$/;
+
+      function acceptedImage(aDimensions) {
+        var maxX = 256; //px
+        var maxY = 256; //px
+
+        switch (aDimensions.type) {
+          case 'gif':
+            // fallthrough
+          case 'jpeg':
+            // fallthrough
+          case 'png':
+            // fallthrough
+          case 'svg':
+            // fallthrough
+          case 'ico':
+            if (dimensions.width <= maxX && dimensions.height <= maxY) {
+              return true;
+            }
+        }
+        return false;
+      }
+
+      icon = findMeta(aMeta, 'UserScript.icon.0.value');
+      if (icon) {
+        if (!isFQUrl(icon, false, true)) {
+
+          // Not a web url... reject
+          aInnerCallback(new statusError({
+            message: '`@icon` not a web url or image data URI in the UserScript metadata block.',
+            code: 400
+          }), null);
+          return;
+        }
+
+        // Test dimensions
+        if (/^data:/.test(icon)) {
+          matches = icon.match(rDataURIbase64);
+          if (matches) {
+            data = matches[1];
+            buffer = new Buffer(data, 'base64');
+            try {
+              dimensions = sizeOf(buffer);
+            } catch (aE) {
+              aInnerCallback(new statusError({
+                message: '`@icon` ' + aE.message,
+                code: aE.code
+              }));
+              return;
+            }
+
+            if (!acceptedImage(dimensions)) {
+              aInnerCallback(new statusError({
+                message: '`@icon` unsupported file type or dimensions are too large.',
+                code: 400
+              }), null);
+            } else {
+              aInnerCallback(null);
+            }
+          } else {
+            aInnerCallback(new statusError({
+              message: 'Invalid `@icon`',
+              code: 400
+            }), null);
+          }
+        } else {
+          fn = /^http:/.test(icon) ? http : https;
+
+          // Workaround for #1323
+          if (fn === https) {
+            aInnerCallback(null); // NOTE: Suspending further checks
+            return;
+          }
+          // /Workaround for #1323
+
+          fn.get(URL.parse(icon), function (aRes) {
+            var chunks = [];
+            aRes.on('data', function (aChunk) {
+              var buf = null;
+              chunks.push(aChunk);
+              buf = Buffer.concat(chunks);
+              if (buf.length > 3048) {
+                aRes.destroy();
+              }
+            }).on('end', function () {
+              buffer = Buffer.concat(chunks);
+              try {
+                dimensions = sizeOf(buffer);
+              } catch (aE) {
+                aInnerCallback(new statusError({
+                  message: '`@icon` ' + aE.message,
+                  code: aE.code
+                }));
+                return;
+              }
+
+              if (!acceptedImage(dimensions)) {
+                aInnerCallback(new statusError({
+                  message: '`@icon` unsupported file type or dimensions are too large.',
+                  code: 400
+                }), null);
+              } else {
+                aInnerCallback(null);
+              }
+            }).on('error', function (aErr) {
+              aInnerCallback(aErr);
+            });
+          }).on('error', function (aErr) {
+            aInnerCallback(aErr); // WARNING: See #1323
+          });
+        }
+      } else {
+        aInnerCallback(null);
+      }
+    },
     function (aInnerCallback) {
       // `@supportURL` validations
       var supportURL = null;


### PR DESCRIPTION
* Do some of the checks that don't pertain to TLS issue
* Fix with additional `on('error',...` for the request instead of response. My bad although still doesn't appear to work with native `https.get` and `https.request`.

Applies to #1323