### PR TITLE
Restore `@icon` check and modify graceful failure landing page

### DIFF
--- a/controllers/scriptStorage.js
+++ b/controllers/scriptStorage.js
@@ -1465,12 +1465,6 @@ exports.storeScript = function (aUser, aMeta, aBuf, aUpdate, aCallback) {
           }
         } else {
           fn = /^http:/.test(icon) ? http : https;
-
-          // Workaround for #1323
-          aInnerCallback(null); // NOTE: Suspend further checks
-          return;
-          // /Workaround for #1323
-
           fn.get(URL.parse(icon), function (aRes) {
             var chunks = [];
             aRes.on('data', function (aChunk) {
@@ -1509,11 +1503,11 @@ exports.storeScript = function (aUser, aMeta, aBuf, aUpdate, aCallback) {
               } else {
                 aInnerCallback(null);
               }
-            }).on('error', function (aErr) {
+            }).on('error', function (aErr) { // NOTE: response error trap
               aInnerCallback(aErr);
             });
-          }).on('error', function (aErr) {
-            aInnerCallback(aErr); // WARNING: See #1323
+          }).on('error', function (aErr) { // NOTE: request error trap
+            aInnerCallback(aErr);
           });
         }
       } else {

--- a/libs/templateHelpers.js
+++ b/libs/templateHelpers.js
@@ -126,7 +126,11 @@ exports.statusCodePage = function (aReq, aRes, aNext, aOptions) {
   pageMetadata(aOptions, [aOptions.statusCode, aOptions.statusMessage], aOptions.statusMessage);
 
   //---
-  aRes.status(aOptions.statusCode).render('pages/statusCodePage', aOptions);
+  if (typeof aOptions.statusCode !== 'number') {
+    aRes.status(400).render('pages/statusCodePage', aOptions);
+  } else {
+    aRes.status(aOptions.statusCode).render('pages/statusCodePage', aOptions);
+  }
 };
 
 // Add page metadata, containing title, description and keywords.


### PR DESCRIPTION
* `statusCode` is a string in the case of *node* failures... change `statusCodePage` code to accommodate this.
* revert suspension again... hopefully the last time

Applies to #1323 and #37