### PR TITLE
Make userscript search the new default for Chrome's "Tab to search"

### DIFF
--- a/views/includes/head.html
+++ b/views/includes/head.html
@@ -6,9 +6,9 @@
 <link rel="shortcut icon" href="/images/favicon.ico" >
 
 <!-- Open Search -->
+<link href="/xml/opensearch-userscripts.xml" type="application/opensearchdescription+xml" rel="search" title="OpenUserJS Userscripts">
 <link href="/xml/opensearch-groups.xml" type="application/opensearchdescription+xml" rel="search" title="OpenUserJS Groups">
 <link href="/xml/opensearch-libraries.xml" type="application/opensearchdescription+xml" rel="search" title="OpenUserJS Libraries">
-<link href="/xml/opensearch-userscripts.xml" type="application/opensearchdescription+xml" rel="search" title="OpenUserJS Userscripts">
 <link href="/xml/opensearch-users.xml" type="application/opensearchdescription+xml" rel="search" title="OpenUserJS Users">
 
 <!-- CSS -->


### PR DESCRIPTION
When auto-adding a OpenSearch plugin on the first visit of a website, Chrome seems to take the first OpenSearch plugin from the HTML header. This commit changes the order of the OpenSearch plugins in the HTML header, so that userscript search is the first one. Will probably only work for first time visitors of the site.