### PR TITLE
Implement a ReadOnly setting for all strategies

### DIFF
--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -243,7 +243,11 @@ exports.callback = function (aReq, aRes, aNext) {
         console.error(colors.red('`User` not found'));
       }
 
-      aRes.redirect(doneUri + (doneUri === '/' ? 'login' : '') + '?authfail');
+      if (aInfo === 'readonly strategy') {
+        aRes.redirect(doneUri + (doneUri === '/' ? 'login' : '') + '?rostrat');
+      } else {
+        aRes.redirect(doneUri + (doneUri === '/' ? 'login' : '') + '?authfail');
+      }
       return;
     }
 

--- a/controllers/strategies.json
+++ b/controllers/strategies.json
@@ -1,62 +1,77 @@
 {
   "aol": {
     "name": "AOL",
-    "oauth": false
+    "oauth": false,
+    "readonly": false
   },
   "facebook": {
     "name": "Facebook",
-    "oauth": true
+    "oauth": true,
+    "readonly": false
   },
   "flickr": {
     "name": "Flickr",
-    "oauth": true
+    "oauth": true,
+    "readonly": false
   },
   "foursquare": {
     "name": "Foursquare",
-    "oauth": true
+    "oauth": true,
+    "readonly": false
   },
   "github": {
     "name": "GitHub",
-    "oauth": true
+    "oauth": true,
+    "readonly": false
   },
   "google": {
     "name": "Google",
-    "oauth": true
+    "oauth": true,
+    "readonly": false
   },
   "imgur": {
     "name": "Imgur",
-    "oauth": true
+    "oauth": true,
+    "readonly": false
   },
   "instagram": {
     "name": "Instagram",
-    "oauth": true
+    "oauth": true,
+    "readonly": false
   },
   "linkedin": {
     "name": "LinkedIn",
-    "oauth": true
+    "oauth": true,
+    "readonly": false
   },
   "reddit": {
     "name": "Reddit",
-    "oauth": true
+    "oauth": true,
+    "readonly": false
   },
   "steam": {
     "name": "Steam",
-    "oauth": false
+    "oauth": false,
+    "readonly": false
   },
   "tumblr": {
     "name": "Tumblr",
-    "oauth": true
+    "oauth": true,
+    "readonly": false
   },
   "twitter": {
     "name": "Twitter",
-    "oauth": true
+    "oauth": true,
+    "readonly": false
   },
   "yahoo": {
     "name": "Yahoo!",
-    "oauth": false
+    "oauth": false,
+    "readonly": false
   },
   "windowslive": {
     "name": "Windows Live",
-    "oauth": true
+    "oauth": true,
+    "readonly": false
   }
 }


### PR DESCRIPTION
* Needed if something gets deprecated/eol'd or just plain bugged
* Efficiency change... **stop slinging** function references around with return statements *(previously done in other sections)*
* Fix double negative in comment
* Comment it up some

NOTE:
* Prime example of this was when Mozilla Persona was deprecated in https://github.com/OpenUserJS/OpenUserJS.org/issues/358#issuecomment-170986576 . Don't need new accounts created/attached