### PR TITLE
Force Steam auth id to secure always

### DIFF
--- a/libs/passportVerify.js
+++ b/libs/passportVerify.js
@@ -32,6 +32,11 @@ exports.verify = function (aId, aStrategy, aUsername, aLoggedIn, aDone) {
   } else if (aStrategy === 'github') {
     // We only keep plaintext ids for GH since that's all we need
     digest = aId;
+  } else if (aStrategy === 'steam') {
+    // Having these forced secure ids would allow us to do things with the user's
+    // account and that is something we DO NOT want to do
+    shasum.update(String(aId).replace(/^http:/, 'https:'));
+    digest = shasum.digest('hex');
   } else {
     // Having these ids would allow us to do things with the user's
     // account and that is something we DO NOT want to do


### PR DESCRIPTION
* This was "our bug" and probably should have been anticipated back in the begginning of OUJS with Steam
* This takes care of the wishy-washy replies I read on a possible reversion from secure to unsecure in their routines. We never utilize the plain text value stored in `aId` so it's not important to match site secure status

NOTE(S):
* There is a manual recovery path discovered for those who have access to the DB directly but working on offloading it to the users. Need sleep first then more testing.
* Still keeping steam auth read-only until the DB can be examined further and this issue recovery

Applies to #1347