### PR TITLE
Fragment line bookmark for Ace

### DIFF
--- a/views/includes/scripts/scriptEditor.html
+++ b/views/includes/scripts/scriptEditor.html
@@ -122,9 +122,42 @@
 
           $('button#submit_code').removeClass('btn-success').addClass('btn-warning');
           $('.ace_gutter-layer').addClass('btn-warning');
+          onhashchange(null);
         }
 
         aEv.target.blur();
+      }
+
+      function onhashchange(aEv) {
+        var hash = null;
+        var line = null;
+        var lines = editor.getSession().getValue().split('\n').length;
+        var matches = window.location.hash.match(/^\#H([0-9a-fA-F]{128})L(\d+)$/);
+
+        // Scroll into
+        if ( !$('#beautify').hasClass('active')) {
+          if (matches) {
+            hash = matches[1];
+            line = parseInt(matches[2]);
+
+            if ('{{script.hash}}' === hash) {
+              if (line > 0 && line <= lines) {
+                editor.resize(true);
+                editor.gotoLine(line, 0, true);
+                editor.scrollToLine(line - 1, false, true, function () {});
+                return;
+              }
+            }
+          }
+        }
+
+        // No matches... reset to defaults
+        if (!$('#beautify').hasClass('active')) {
+          editor.resize(true);
+          editor.gotoLine(1, 0, true);
+          editor.scrollToLine(0, false, true, function () {});
+        }
+        window.location.hash = '';
       }
 
       //
@@ -221,6 +254,20 @@
         wrap.on('click', onwrap);
         beautify.on('click', onbeautify);
         setTimeout(oninput, 250);
+
+        if (window.location.hash) {
+          onhashchange(null);
+        }
+
+        $(window).on('hashchange', onhashchange);
+
+        editor.on("gutterclick", function (aEv) {
+          var gotoLine = aEv.getDocumentPosition().row + 1;
+          if (gotoLine) {
+            window.location.hash = window.location.hash =
+              'H' + '{{script.hash}}' + 'L' + gotoLine;
+          }
+        });
       }
     });
 


### PR DESCRIPTION
* Give some "bookmark" capability client side to current presentational scripts using the fragment *(similar to GH)*
* Still going to be working on selections... the complexity of Ace requires a lot of testing to ensure that minimal disruption occurs

NOTES:
* *marked* can be used to shorten however I think there is a bug with one of it's parameters. 0.4.0 is pending release and may fix it but there are also some other changes for migration to do before this PR can be fully realized.
* Format is `#HhashLlinenumber`. Currently invalidates link bookmark on script update and is case-sensitive.