### PR TITLE
CSS tweak - Establish minimum img width

### DIFF
--- a/public/css/common.css
+++ b/public/css/common.css
@@ -277,6 +277,7 @@ h6:hover a.anchor {
 .user-content img,
 .document-content img {
   max-width: 100%;
+  min-width: 16px;
 }
 
 .table-responsive {


### PR DESCRIPTION
* Prevents images from sometimes never being rendered in certain md
* Currently smallest site favicon which is 16px in width

Applies to #342