### PR TITLE
Don't create npm lockfile

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
* This is causing dependency failures on successive installs with audits... use a clean install to check for dep issues that may already be fixed

Post #1205