### PR TITLE
GDPR7

### DIFF
--- a/views/includes/documents/Terms-of-Service.md
+++ b/views/includes/documents/Terms-of-Service.md
@@ -38,7 +38,7 @@ Within moderation we understand the occasional necessity to conserve device stor
 
 #### Fair Use Rationale
 * OpenUserJS.org is considered to be a safe harbor.
-* OpenUserJS.org provides voluntary access for Authors, Users, and other related material relating to User scripts and Library Scripts.
+* OpenUserJS.org provides voluntary access for Authors, Users, Visitors, and other related material relating to User scripts and Library scripts.
 * The default, minimum, rationale for any publications, including but not limited to User and Library scripts by any Author, is for educational purposes.
 * Any external site may **not** extend their Terms of Service, Terms of Use, Privacy Policy, DMCA, or any other policy for their site to OpenUserJS.org without prior written and signed consent.
 

--- a/views/includes/headerReminders.html
+++ b/views/includes/headerReminders.html
@@ -7,4 +7,9 @@
   </div>
   -->
 {{/hideThisReminder}}
+{{^authedUser}}
+  <div class="alert alert-warning small fade in" role="alert">
+    <p><i class="fa fa-fw fa-exclamation-triangle"></i> <b>NOTICE:</b> By continued use of this site you understand and agree to the binding <a class= "alert-link" href="/about/Terms-of-Service">Terms of Service</a> and <a class="alert-link" href="/about/Privacy-Policy">Privacy Policy</a>.</p>
+  </div>
+{{/authedUser}}
 </div>


### PR DESCRIPTION
* Nag visitors about TOS and PP with a warning reminder. This has always been the case but needs front-and-center approach for visitors especially in the EU. The alternative is to block all EU addresses which many other sites around the globe are already doing. Guess the GPDR definitely falls under protectionism *(e.g. isolationism. They really didn't think this through over there)*
* Since saving a cookie to prevent this from showing would be counter productive to the GDPR *(and currently our site PP/TOS and other current policies regarding sessions)* this should always show for visitors
* Typo and spelled-out inclusion in TOS

NOTE:
* This is non-dismiss-able by nature... it should not show for authed users when they have already consented since day one.