### PR TITLE
GDPR8

### DIFF
--- a/app.js
+++ b/app.js
@@ -318,7 +318,7 @@ app.use(session({
   saveUninitialized: false,
   unset: 'destroy',
   cookie: {
-    maxAge: 6 * 60 * 60 * 1000 // hours in ms
+    maxAge: 5 * 60 * 1000 // minutes in ms NOTE: Expanded after successful auth
   },
   rolling: true,
   secret: sessionSecret,

--- a/controllers/admin.js
+++ b/controllers/admin.js
@@ -397,6 +397,7 @@ exports.adminSessionActiveView = function (aReq, aRes, aNext) {
         if (data && data.user) {
           options.session.push({
             _id: aElement._id,
+            originalMaxAge: data.cookie.originalMaxAge,
             expires: data.cookie.expires,
             name: data.user.name
           });

--- a/libs/modifySessions.js
+++ b/libs/modifySessions.js
@@ -5,6 +5,9 @@ var isPro = require('../libs/debug').isPro;
 var isDev = require('../libs/debug').isDev;
 var isDbg = require('../libs/debug').isDbg;
 
+//--- Library inclusions
+var moment = require('moment');
+
 //
 // This library allows for the modifications of user sessions
 var async = require('async');
@@ -62,6 +65,22 @@ exports.add = function (aReq, aUser, aCallback) {
   }
 };
 
+// Expand a single session
+exports.expand = function (aReq, aUser, aCallback) {
+  var expiry = null;
+
+  if (!aUser) {
+    aCallback('No User');
+    return;
+  }
+
+  // NOTE: Expanded minus initial. Keep initial in sync with app.js
+  expiry = moment(aReq.session.cookie.expires).add(6, 'h').subtract(5, 'm');
+
+  aReq.session.cookie.expires = expiry.toDate();
+  aReq.session.save(aCallback);
+};
+
 // Extend a single session
 exports.extend = function (aReq, aUser, aCallback) {
   if (!aUser) {
@@ -75,7 +94,7 @@ exports.extend = function (aReq, aUser, aCallback) {
   }
 
   // NOTE: Currently allow on any session with
-  //   no additional User restrictions yet
+  //   no additional User restrictions yet...
 
   aReq.session.cookie.expires = false;
   aReq.session.save(aCallback);


### PR DESCRIPTION
* Use very short session before successful auth. Session "bleeding" briefly mentioned at #1411 . This is "expanded" after successful auth.
* Output `originalMaxAge` for sync check in *express-session* via MongoDB
* Don't easily expose improper/expired callbacks. Part of #37
* Remove some currently unneeded `return` statements already captured by block braces

Related to #604 #1201 #1202 and #1393