### PR TITLE
GDPR7A

### DIFF
--- a/app.js
+++ b/app.js
@@ -163,9 +163,18 @@ var forceBusy = process.env.FORCE_BUSY === 'true';
 
 app.use(function (aReq, aRes, aNext) {
   var pathname = aReq._parsedUrl.pathname;
+  var referer = aReq.headers.referer;
   var usedMem = null;
   var isSources = null;
 
+  // Middleware for GDPR Notice
+  if (!aRes.oujsOptions) {
+    aRes.oujsOptions = {};
+  }
+  aRes.oujsOptions.hideReminderGDPR =
+    /^https?:\/\/(?:localhost:8080|openuserjs\.org)/.test(referer);
+
+  //
   if (
     /^\/favicon\.ico$/.test(pathname) ||
       /^\/redist\//.test(pathname) ||

--- a/libs/muExpress.js
+++ b/libs/muExpress.js
@@ -25,8 +25,12 @@ function renderFile(aRes, aPath, aOptions) {
   //   so please do not remove unless refactoring in a new issue as a whole.
   // Example Code task and sync UI with banner text/link at `./includes/headerReminders`:
   // if (aOptions.authedUser && aOptions.authedUser.strategies.indexOf('google') === -1) {
-  //   aOptions.hideThisReminder = true;
+  //   aOptions.hideReminderThis = true;
   // }
+
+  if (aRes.oujsOptions && aRes.oujsOptions.hideReminderGDPR) {
+    aOptions.hideReminderGDPR = aRes.oujsOptions.hideReminderGDPR;
+  }
 
   aRes.set('Content-Type', 'text/html; charset=UTF-8');
   mu.compileAndRender(aPath, aOptions).pipe(aRes);

--- a/views/includes/headerReminders.html
+++ b/views/includes/headerReminders.html
@@ -1,15 +1,16 @@
 <div class="reminders">
 {{^authedUser}}
-  <div class="alert alert-warning alert-dismissible small fade in" role="alert">
-    <button type="button" class="close" data-dismiss="alert"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
-    <p><i class="fa fa-fw fa-exclamation-triangle"></i> <b>NOTICE:</b> By continued use of this site you understand and agree to the binding <a class= "alert-link" href="/about/Terms-of-Service">Terms of Service</a> and <a class="alert-link" href="/about/Privacy-Policy">Privacy Policy</a>.</p>
-  </div>
+  {{^hideReminderGDPR}}
+    <div class="alert alert-warning alert-dismissible small fade in" role="alert">
+      <button type="button" class="close" data-dismiss="alert"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
+      <p><i class="fa fa-fw fa-exclamation-triangle"></i> <b>NOTICE:</b> By continued use of this site you understand and agree to the binding <a class= "alert-link" href="/about/Terms-of-Service">Terms of Service</a> and <a class="alert-link" href="/about/Privacy-Policy">Privacy Policy</a>.</p>
+    </div>
+  {{/hideReminderGDPR}}
 {{/authedUser}}
-{{^hideThisReminder}}
+{{^hideReminderThis}}
 <!--  <div class="alert alert-info alert-dismissible alert-autodismissible small fade in" role="alert">
     <button type="button" class="close" data-dismiss="alert"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
     <p><i class="fa fa-fw fa-exclamation-triangle"></i> <b>REMINDER:</b> Don't miss out reading the <a class="alert-link" href="/">descriptive</a> announcement.</p>
   </div>-->
-
-{{/hideThisReminder}}
+{{/hideReminderThis}}
 </div>


### PR DESCRIPTION
* Only show once if `referer` is not us... if a visitor blocks these or custom crafts these it's not our responsibility e.g. they are exclusively responsible for seeing it if the header is altered.
* Reoriented identifier naming on existing hidden template

NOTE:
* This is similar in nature to current *express-minify* and their `minifyOptions`. Also it is much better than going around to all the `preRender`s to add this `option`.

Post #1414