### PR TITLE
EOL TLSv1

### DIFF
--- a/app.js
+++ b/app.js
@@ -15,6 +15,7 @@ if (isPro) {
 
 //
 var path = require('path');
+var crypto = require('crypto');
 
 var express = require('express');
 var toobusy = require('toobusy-js-harmony');
@@ -279,7 +280,8 @@ if (app.get('securePort') && secured) {
       '!SRP',
       '!CAMELLIA'
     ].join(':'),
-    honorCipherOrder: true
+    honorCipherOrder: true,
+    secureOptions: crypto.constants.SSL_OP_NO_TLSv1
   };
   secureServer = https.createServer(sslOptions, app);
 


### PR DESCRIPTION
* This is a scheduled PR for no later than June 30th, 2018
* TLSv1 is officially EOL on 2018-06-30 ... this may knock out some browsers from being able to login, or even visiting OUJS, *(this is one of the ways how https holds everyone hostage albeit in the name of security... so catch 22... as compared to http)*
* Does work as it's already been tested on pro
* If *node* has an update before then it may not be needed... however usually it's around the first week of the month e.g. past the deadline

---

Ref(s):
* https://blog.pcisecuritystandards.org/are-you-ready-for-30-june-2018-sayin-goodbye-to-ssl-early-tls *(an authority)*
* https://nodejs.org/api/tls.html#tls_modifying_the_default_tls_cipher_suite *(current cipher order which we match unless there is an issue and need to disable something)*
* https://nodejs.org/api/crypto.html#crypto_crypto_constants_1 *(crypto constants)*
* https://caniuse.com/#search=tls *(some site that shows some minimum versions of browsers that have at least TLSv1.1)*

NOTES:
* Didn't test Opera Presto *(12.16.1860)*... that's in the TODO after merge milestone... however one test site says it only supports TLSv1
* @gera2ld sending you a courtesy ping for [violentmonkey-oex](https://github.com/violentmonkey/violentmonkey-oex) since that's older Opera support from our last documentation e.g. most likely since the tester said it only supports TLSv1 this will knock that particular extension out *(but you probably already know this)*. Thanks for the visit.