### PR TITLE
GDPR12

### DIFF
--- a/app.js
+++ b/app.js
@@ -333,7 +333,8 @@ app.use(session({
   unset: 'destroy',
   cookie: {
     maxAge: 5 * 60 * 1000, // minutes in ms NOTE: Expanded after successful auth
-    secure: (isPro && secured ? true : false)
+    secure: (isPro && secured ? true : false),
+    sameSite: 'lax' // NOTE: OpenID necessity
   },
   rolling: true,
   secret: sessionSecret,


### PR DESCRIPTION
* Adopt explicit "First Party Cookie" attribute support ... all clients may not utilize this but for the ones that do enforce it.

NOTES:
* Tested in `Mozilla/5.0 (X11; Linux x86_64; rv:60.0) Gecko/20100101 Firefox/60.0` `.2` with *passport-github* and *passport-steam* *(upper and lower... lower end currently requires `lax` e.g. OpenID)*

Ref(s)
* https://blog.mozilla.org/security/2018/04/24/same-site-cookies-in-firefox-60/
* https://github.com/expressjs/session/blob/master/README.md#cookiesamesite