### PR TITLE
Bump *node* and *npm* min/max

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,8 +88,8 @@
     "clean": "node dev/clean.js"
   },
   "engines": {
-    "node": ">=8.9.0 <9.0.0",
-    "npm": ">=5.5.1"
+    "node": ">=10.5.0 <11.0.0",
+    "npm": ">=6.1.0"
   },
   "private": true
 }


### PR DESCRIPTION
* This is a few months early before LTS happens for 10.x *(Oct 2018)* however we don't want to get caught with our pants down
* Production is already running this on successful compile... hopefully this remains that way.