### PR TITLE
Enable delete route API

### DIFF
--- a/controllers/admin.js
+++ b/controllers/admin.js
@@ -385,7 +385,6 @@ exports.adminSessionActiveView = function (aReq, aRes, aNext) {
     return;
   }
 
-
   // Page metadata
   pageMetadata(options, ['Sessions', 'Admin']);
 
@@ -433,7 +432,7 @@ exports.adminSessionActiveView = function (aReq, aRes, aNext) {
               _id: aElement._id,
               name: (data.user ? data.user.name : data.username),
               strategy: (data.passport ? data.passport.strategy : null),
-              canDestroyOne: false,
+              canDestroyOne: true, // TODO: Perhaps do some further conditionals
               ua: {
                 raw: (data.passport ? data.passport.userAgent : null),
                 class: 'fa-lg ua-' + useragent

--- a/libs/modifySessions.js
+++ b/libs/modifySessions.js
@@ -161,8 +161,12 @@ exports.destroyOne = function (aReq, aUser, aId, aCallback) {
     return;
   }
 
-  // We want to know who requested what
-  console.log(aReq.session.user.name, 'requested session removal of', aUser.name);
+  // We want to know who deleted someone else
+  if (aReq.session.user.name !== aUser.name) {
+    console.log(
+      '`' + aReq.session.user.name + '`', 'removed a session owned by', '`' + aUser.name + '`'
+    );
+  }
 
   store.destroy(aId, aCallback);
 }

--- a/routes.js
+++ b/routes.js
@@ -53,6 +53,7 @@ module.exports = function (aApp) {
   });
   aApp.route('/api/user/exist/:username').head(user.exist);
   aApp.route('/api/user/session/extend').post(user.extend);
+  aApp.route('/api/user/session/destroyOne').post(user.destroyOne);
 
   // Adding script/library routes
   aApp.route('/user/add/scripts').get(authentication.validateUser, user.newScriptPage);


### PR DESCRIPTION
NOTE:
* Anyone can access this route but strict role and name checking is in place.
* Keeping the Admin view Admin+ only until further stages

Please leave the current orphans there because I'm doing a timed test of the database auto-cleanup. It's a little buggy and/or we don't have a value set somewhere. Need to see when and where this is happening.

Post #1446 ... related to #604