### PR TITLE
Try a TTL for *connect-mongo*

### DIFF
--- a/app.js
+++ b/app.js
@@ -139,7 +139,10 @@ process.on('SIGINT', function () {
   process.exit(0);
 });
 
-var sessionStore = new MongoStore({ mongooseConnection: db });
+var sessionStore = new MongoStore({
+  mongooseConnection: db,
+  ttl: (6 / 2) * 60 * 60 // 14 * 24 * 60 * 60 = 14 days. Default
+});
 
 // See https://hacks.mozilla.org/2013/01/building-a-node-js-server-that-wont-melt-a-node-js-holiday-season-part-5/
 var ensureIntegerOrNull = require('./libs/helpers').ensureIntegerOrNull;


### PR DESCRIPTION
* Currently set at half the standard max session time

NOTE(S):
* This may not be the correct setting but giving it an observation try

Ref:
* https://github.com/jdesboeufs/connect-mongo/blob/master/README.md#session-expiration