### PR TITLE
Try interval session expiration

### DIFF
--- a/app.js
+++ b/app.js
@@ -141,7 +141,8 @@ process.on('SIGINT', function () {
 
 var sessionStore = new MongoStore({
   mongooseConnection: db,
-  ttl: (6 / 2) * 60 * 60 // 14 * 24 * 60 * 60 = 14 days. Default
+  autoRemove: 'interval',
+  autoRemoveInterval: (6 / 2) * 60 // In minutes. Default 10
 });
 
 // See https://hacks.mozilla.org/2013/01/building-a-node-js-server-that-wont-melt-a-node-js-holiday-season-part-5/


### PR DESCRIPTION
* TTL setting seems to have failed... some, but not all, sessions have been around way longer than 3 hours

NOTE:
* This is "compatibility" mode which we shouldn't need since we're not running that old of a DB

Ref:
* https://github.com/jdesboeufs/connect-mongo/blob/master/README.md#set-the-compatibility-mode

Post #1471