### PR TITLE
Revert to TTL

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Repository | Reference | Recent Version
 [method-override][method-overrideGHUrl] | [Documentation][method-overrideDOCUrl] | [![NPM version][method-overrideNPMVersionImage]][method-overrideNPMUrl]
 [mime-db][mime-dbGHUrl] | [Documentation][mime-dbDOCUrl] | [![NPM version][mime-dbNPMVersionImage]][mime-dbNPMUrl]
 [moment][momentGHUrl] | [Documentation][momentDOCUrl] | [![NPM version][momentNPMVersionImage]][momentNPMUrl]
+[moment-duration-format][moment-duration-formatGHUrl] | [Documentation][moment-duration-formatDOCUrl] | [![NPM version][moment-duration-formatNPMVersionImage]][moment-duration-formatNPMUrl]
 [mongodb][mongodbGHUrl] | [Documentation][mongodbDOCUrl] | [![NPM version][mongodbNPMVersionImage]][mongodbNPMUrl]
 [mongoose][mongooseGHUrl] | [Documentation][mongooseDOCUrl] | [![NPM version][mongooseNPMVersionImage]][mongooseNPMUrl]
 [morgan][morganGHUrl] | [Documentation][morganDOCUrl] | [![NPM version][morganNPMVersionImage]][morganNPMUrl]
@@ -316,6 +317,11 @@ Outdated dependencies list can also be achieved with `$ npm --depth 0 outdated`
 [momentDOCUrl]: http://momentjs.com/docs/
 [momentNPMUrl]: https://www.npmjs.com/package/moment
 [momentNPMVersionImage]: https://img.shields.io/npm/v/moment.svg?style=flat
+
+[moment-duration-formatGHUrl]: https://github.com/jsmreese/moment-duration-format
+[moment-duration-formatDOCUrl]: https://github.com/jsmreese/moment-duration-format/blob/master/README.md
+[moment-duration-formatNPMUrl]: https://www.npmjs.com/package/moment-duration-format
+[moment-duration-formatNPMVersionImage]: https://img.shields.io/npm/v/moment-duration-format.svg?style=flat
 
 [mongodbGHUrl]: https://github.com/mongodb/node-mongodb-native
 [mongodbDOCUrl]: https://github.com/mongodb/node-mongodb-native/blob/3.0/README.md

--- a/app.js
+++ b/app.js
@@ -141,8 +141,8 @@ process.on('SIGINT', function () {
 
 var sessionStore = new MongoStore({
   mongooseConnection: db,
-  autoRemove: 'interval',
-  autoRemoveInterval: (6 / 2) * 60 // In minutes. Default 10
+  autoRemove: 'native',
+  ttl: (6 * 3) * 60 * 60 // hours ; 14 * 24 * 60 * 60 = 14 days. Default
 });
 
 // See https://hacks.mozilla.org/2013/01/building-a-node-js-server-that-wont-melt-a-node-js-holiday-season-part-5/

--- a/controllers/admin.js
+++ b/controllers/admin.js
@@ -12,6 +12,8 @@ var exec = require('child_process').exec;
 
 var async = require('async');
 var _ = require('underscore');
+var moment = require('moment');
+var momentDurationFormatSetup = require("moment-duration-format");
 var git = require('git-rev');
 var useragent = require('useragent');
 
@@ -44,6 +46,10 @@ var pageMetadata = require('../libs/templateHelpers').pageMetadata;
 var pkg = require('../package.json');
 var userRoles = require('../models/userRoles.json');
 var strategies = require('./strategies.json');
+
+
+// Initializations
+momentDurationFormatSetup(moment);
 
 //---
 
@@ -467,6 +473,10 @@ exports.adminSessionActiveView = function (aReq, aRes, aNext) {
               cookie: {
                 since: oujsOptions.since ? new Date(oujsOptions.since) : oujsOptions.since,
                 expires: (cookie.expires ? new Date(cookie.expires) : false),
+                originalMaxAge: (cookie.originalMaxAge
+                  ? moment.duration(cookie.originalMaxAge, "milliseconds")
+                    .format('YYYY[y]DDD[d]H[h]m[m]', { trim: 'both' })
+                  : false),
                 secure: cookie.secure,
                 httpOnly: cookie.httpOnly,
                 sameSite: cookie.sameSite,

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "method-override": "2.3.10",
     "mime-db": "1.34.0",
     "moment": "2.22.2",
+    "moment-duration-format": "2.2.2",
     "mongodb": "3.0.10",
     "mongoose": "5.1.6",
     "morgan": "1.9.0",

--- a/views/includes/session.html
+++ b/views/includes/session.html
@@ -23,6 +23,9 @@
                 {{#cookie.sameSiteLax}}<i class="fa fa-adjust"></i>{{/cookie.sameSiteLax}}
                 {{^cookie.sameSite}}<i class="fa fa-circle-o"></i>{{/cookie.sameSite}}
               </span>
+              <span class="label label-{{#cookie.originalMaxAge}}success{{/cookie.originalMaxAge}}{{^cookie.originalMaxAge}}warning{{/cookie.originalMaxAge}}" title="originalMaxAge">
+                {{#cookie.originalMaxAge}}{{cookie.originalMaxAge}}{{/cookie.originalMaxAge}}{{^cookie.originalMaxAge}}&infin;{{/cookie.originalMaxAge}}
+              </span>
               {{#remoteAddress}}
               <span class="label label-info" title="remoteAddress">{{remoteAddress}}</span>
               {{/remoteAddress}}


### PR DESCRIPTION
* The cost of `interval` mode is too high plus it also has a similar, yet muffled, issue as `native`. Each session gets it's own server side *(OUJS)* timer and that can be really CPU intensive if too many users pop on board at the same time.
* MongoDB remote is not cleaning up expired sessions until many, many, many hours later... this may subside at a later date but something we need to live with at the moment until the main DB is migrated to a newer version *(probably one minor semver at a time)*. \*hint hint\* @sizzlemctwizzle
* Reoutput the `originalMaxAge` as a label.
* New dep extension *(plugin as they call it)* that extends *moment*
* Max extension age is n *(currently 6)* times 3... may change these values after some more consultation

Post #1471 ... related to #604