### PR TITLE
Change symbol

### DIFF
--- a/views/includes/session.html
+++ b/views/includes/session.html
@@ -24,7 +24,7 @@
                 {{^cookie.sameSite}}<i class="fa fa-circle-o"></i>{{/cookie.sameSite}}
               </span>
               <span class="label label-{{#cookie.originalMaxAge}}success{{/cookie.originalMaxAge}}{{^cookie.originalMaxAge}}warning{{/cookie.originalMaxAge}}" title="originalMaxAge">
-                {{#cookie.originalMaxAge}}{{cookie.originalMaxAge}}{{/cookie.originalMaxAge}}{{^cookie.originalMaxAge}}&infin;{{/cookie.originalMaxAge}}
+                {{#cookie.originalMaxAge}}{{cookie.originalMaxAge}}{{/cookie.originalMaxAge}}{{^cookie.originalMaxAge}}&and;{{/cookie.originalMaxAge}}
               </span>
               {{#remoteAddress}}
               <span class="label label-info" title="remoteAddress">{{remoteAddress}}</span>
@@ -39,7 +39,7 @@
         </div>
         <div class="session-post-contents row">
           <div class="session-data">
-            Expires {{#cookie.expires}}<time datetime="{{cookie.expiresISOFormat}}" title="{{cookie.expires}}">{{cookie.expiresHumanized}}</time>{{/cookie.expires}}{{^cookie.expires}}&infin;{{/cookie.expires}}.
+            Expires {{#cookie.expires}}<time datetime="{{cookie.expiresISOFormat}}" title="{{cookie.expires}}">{{cookie.expiresHumanized}}</time>{{/cookie.expires}}{{^cookie.expires}}&and;{{/cookie.expires}}.
           </div>
           <div class="pull-right">
             <form class="form-inline" action="/api/user/session/destroyOne" method="post">


### PR DESCRIPTION
* Only "infinity", sort of, exists in `interval` mode... each browser treats this differently. Mozilla based browsers, for example, sets to end of session. Chromium based browsers sets to 1 year *(which is too long imho)*. `native` is utilized better with this logical mathematical nomenclature to fit both modes of *connect-mongo*
* The "Wedge" symbol in this use is "ascending" to the maximum *(again avoiding strings to translate down the line... think of it as pointing towards the "ceiling" limit)*. The opposite is "Vel" which is `&or` which is "descending" or pointing towards the "floor" limit. Both are Delta's of finite change instead of infinite change.

Ref(s):
* https://www.wikipedia.org/wiki/Wedge_%28symbol%29
* https://www.wikipedia.org/wiki/Vel_%28symbol%29

Post #1471