### PR TITLE
Invert the TTL value and extend to fixed

### DIFF
--- a/app.js
+++ b/app.js
@@ -142,7 +142,7 @@ process.on('SIGINT', function () {
 var sessionStore = new MongoStore({
   mongooseConnection: db,
   autoRemove: 'native',
-  ttl: (6 * 3) * 60 * 60 // hours ; 14 * 24 * 60 * 60 = 14 days. Default
+  ttl: 10 * 60 // seconds to minutes ; 14 * 24 * 60 * 60 = 14 days. Default
 });
 
 // See https://hacks.mozilla.org/2013/01/building-a-node-js-server-that-wont-melt-a-node-js-holiday-season-part-5/

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -1031,7 +1031,15 @@ exports.userEditPreferencesPage = function (aReq, aRes, aNext) {
 
     // User session control
     tasks.push(function (aCallback) {
-      if (aReq.session.cookie.expires) {
+      if (!aReq.session.passport) {
+        aReq.session.passport = {};
+      }
+
+      if (!aReq.session.passport.oujsOptions) {
+        aReq.session.passport.oujsOptions = {};
+      }
+
+      if (!aReq.session.passport.oujsOptions.extended) {
         options.sessionControl = true;
       }
 

--- a/libs/modifySessions.js
+++ b/libs/modifySessions.js
@@ -96,20 +96,30 @@ exports.expand = function (aReq, aUser, aCallback) {
 
 // Extend a single session
 exports.extend = function (aReq, aUser, aCallback) {
+  var expiry = moment(aReq.session.cookie.expires);
+
   if (!aUser) {
     aCallback('No User');
     return;
   }
 
-  if (!aReq.session.cookie.expires) {
+  if (!aReq.session.passport) {
+    aReq.session.passport = {};
+  }
+
+  if (!aReq.session.passport.oujsOptions) {
+    aReq.session.passport.oujsOptions = {};
+  }
+
+  if (aReq.session.passport.oujsOptions.extended) {
     aCallback('Already extended');
     return;
   }
 
-  // NOTE: Currently allow on any session with
-  //   no additional User restrictions yet...
+  expiry = expiry.add(6 * 2, 'h'); // NOTE: Keep this addition to expanded timeout in sync with app.js
+  aReq.session.passport.oujsOptions.extended = true;
 
-  aReq.session.cookie.expires = false;
+  aReq.session.cookie.expires = expiry.toDate();
   aReq.session.save(aCallback);
 };
 

--- a/views/includes/session.html
+++ b/views/includes/session.html
@@ -24,7 +24,7 @@
                 {{^cookie.sameSite}}<i class="fa fa-circle-o"></i>{{/cookie.sameSite}}
               </span>
               <span class="label label-{{#cookie.originalMaxAge}}success{{/cookie.originalMaxAge}}{{^cookie.originalMaxAge}}warning{{/cookie.originalMaxAge}}" title="originalMaxAge">
-                {{#cookie.originalMaxAge}}{{cookie.originalMaxAgeHumanized}}{{/cookie.originalMaxAge}}{{^cookie.originalMaxAge}}&and;{{/cookie.originalMaxAge}}
+                {{#cookie.originalMaxAge}}{{#passport.oujsOptions.extended}}&and;{{/passport.oujsOptions.extended}}{{cookie.originalMaxAgeHumanized}}{{/cookie.originalMaxAge}}{{^cookie.originalMaxAge}}&and;{{/cookie.originalMaxAge}}
               </span>
               {{#passport.oujsOptions.remoteAddress}}
               <span class="label label-info" title="remoteAddress">{{passport.oujsOptions.remoteAddressMask}}</span>


### PR DESCRIPTION
* Now this is giving predictable results so far *(on dev which has newer MongoDB)*.

Refs:
* https://github.com/jdesboeufs/connect-mongo/blob/9f86f90/README.md#session-expiration
* https://github.com/jdesboeufs/connect-mongo/blob/9f86f90/README.md#remove-expired-sessions

NOTES:
These versions of the docs are ambiguous. The TTL is how often it reaches out to the DB... if it finds an expired session **or** a session cookie it will then remove it. So the inversion of the logic should fix this as it checks every 10ish minutes for expiry as well as session cookies and destroys them. Had a light bulb flip on with `interval` being doc'd at 10 minutes so I thought to try TTL at that... and voila. :)

This theoretically should solve #604 by sticking to this methodology *(until MongoDB changes something heh)*

When available will do some code condensing to reuse some more code if applicable.

Post #1471 ... related to #604