### PR TITLE
Abstract TTLs to settings Object

### DIFF
--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -154,8 +154,8 @@ exports.auth = function (aReq, aRes, aNext) {
 
       if (aErr) {
         console.error('Authfail with no User found of', username, aErr);
-//         aRes.redirect('/login?usernamefail');
-//         return;
+        aRes.redirect('/login?usernamefail');
+        return;
       }
 
       if (aUser) {

--- a/libs/modifySessions.js
+++ b/libs/modifySessions.js
@@ -8,6 +8,8 @@ var isDbg = require('../libs/debug').isDbg;
 //--- Library inclusions
 var moment = require('moment');
 
+var settings = require('../models/settings.json');
+
 //
 // This library allows for the modifications of user sessions
 var async = require('async');
@@ -68,7 +70,7 @@ exports.add = function (aReq, aUser, aCallback) {
 // Expand a single session
 exports.expand = function (aReq, aUser, aCallback) {
   var expiry = moment(aReq.session.cookie.expires);
-  var min = 5; // NOTE: Keep this initial timeout in sync with app.js
+  var min = settings.ttl.minimum;
 
   if (!aUser) {
     aCallback('No User');
@@ -87,7 +89,7 @@ exports.expand = function (aReq, aUser, aCallback) {
   }
 
   // NOTE: Expanded timeout minus initial timeout.
-  expiry = expiry.add(6, 'h').subtract(min, 'm');
+  expiry = expiry.add(settings.ttl.nominal, 'h').subtract(min, 'm');
 
   aReq.session.cookie.expires = expiry.toDate();
   aReq.session.cookie.sameSite = 'strict';
@@ -116,7 +118,7 @@ exports.extend = function (aReq, aUser, aCallback) {
     return;
   }
 
-  expiry = expiry.add(6 * 2, 'h'); // NOTE: Keep this addition to expanded timeout in sync with app.js
+  expiry = expiry.add(settings.ttl.maximum, 'h');
   aReq.session.passport.oujsOptions.extended = true;
 
   aReq.session.cookie.expires = expiry.toDate();

--- a/models/settings.json
+++ b/models/settings.json
@@ -1,5 +1,12 @@
 {
-  "secret" : "someSecretStringForSession",
-  "connect" : "mongodb://dev:oujs@ds041651.mongolab.com:41651/openuserjs_dev",
-  "maximum_upload_script_size": 1048576
+ "secret" : "someSecretStringForSession",
+ "connect" : "mongodb://dev:oujs@ds041651.mongolab.com:41651/openuserjs_dev",
+ "maximum_upload_script_size": 1048576,
+ "ttl": {
+  "minimum": 5,
+  "nominal": 6,
+  "timerSanity": 7,
+  "timerSanityExpiry": 11,
+  "maximum": 18
+ }
 }


### PR DESCRIPTION
* Adjust values to shorter, preferred, intervals
* Additional sanity check for idle session from browser blocked and query accept redirect with JavaScript disabled.
* Restore #1448 *(not found in stderr and new users are okay)*... ends mitigation from #1449 ... most likely a critical DB failure with mongolabs that should be trapped and handled
* Move destruction to stderr with debug mode only... Applies to #430

NOTE:
* Unit specific tests... if changed must keep in `m` and `h`. `nominal` replacement and `maximum` addition are in `h`... the rest are `m`

Post #1471 ... related to #604