### PR TITLE
Lower to `lax`

### DIFF
--- a/app.js
+++ b/app.js
@@ -361,7 +361,7 @@ app.use(session({
   cookie: {
     maxAge: 5 * 60 * 1000, // minutes in ms NOTE: Expanded after successful auth
     secure: (isPro && secured ? true : false),
-    sameSite: 'lax' // NOTE: OpenID necessity
+    sameSite: 'lax' // NOTE: Current auth necessity
   },
   rolling: true,
   secret: sessionSecret,

--- a/libs/modifySessions.js
+++ b/libs/modifySessions.js
@@ -98,7 +98,6 @@ exports.expand = function (aReq, aUser, aCallback) {
   expiry = expiry.add(settings.ttl.nominal, 'h').subtract(min, 'm');
 
   aReq.session.cookie.expires = expiry.toDate();
-  aReq.session.cookie.sameSite = 'strict';
   aReq.session.save(aCallback);
 };
 


### PR DESCRIPTION
* Chromium and newer Mozilla based browsers have an issue with `strict` and redirects in *express*. Also adding an auth from `strict` will probably cause an issue.

NOTE:
* Booting everyone off for this.

Post #1483