### PR TITLE
GDPR13

### DIFF
--- a/libs/helpers.js
+++ b/libs/helpers.js
@@ -204,3 +204,24 @@ exports.ensureIntegerOrNull = function (aEnvVar) {
 
   return aEnvVar;
 };
+
+exports.isSameOrigin = function (aUrl) {
+  var url = null;
+  var port = process.env.PORT || 8080;
+  var securePort = process.env.SECURE_PORT || 8081;
+  var rOrigin = new RegExp(
+    '^(https://openuserjs\.org(:' + securePort + ')?|http://(oujs\.org|localhost:' + port + '))$'
+  );
+  var sameOrigin = false;
+
+  try {
+    url = new URL(aUrl, 'https://openuserjs.org/');
+
+    if (rOrigin.test(url.origin)) {
+      sameOrigin = true;
+    }
+  } catch (aE) {
+  }
+
+  return sameOrigin;
+}

--- a/libs/htmlWhitelistPost.json
+++ b/libs/htmlWhitelistPost.json
@@ -67,10 +67,12 @@
       "class"
     ],
     "a": [
-      "href"
+      "href",
+      "referrerpolicy"
     ],
     "img": [
-      "src"
+      "src",
+      "referrerpolicy"
     ],
     "div": [
       "itemscope",


### PR DESCRIPTION
* Some tempering for SEO vs. GDPR
* Add a helper to be used for determining if is our site/pro/dev ... local pro will take some additional changes. Getting duplicated re's in several areas that do this. This is *node*@10.x specific using WHATWG instead of legacy. Loosely related to #1481

NOTE:
* `link` and `area` not currently whitelisted so ignoring but still mitigate possible security risk for GDPR

Ref(s):
* http://w3c.github.io/html/links.html#allowed-keywords-and-their-meanings
* https://www.w3.org/TR/2014/REC-html5-20141028/links.html#link-type-prefetch
* https://www.w3.org/TR/referrer-policy/#referrer-policy-same-origin