### PR TITLE
Swap to Goo relative profile scope

### DIFF
--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -86,7 +86,7 @@ exports.auth = function (aReq, aRes, aNext) {
     }
 
     if (strategy === 'google') {
-      authOpts.scope = ['https://www.googleapis.com/auth/plus.login'];
+      authOpts.scope = ['profile'];
     }
     authenticate = passport.authenticate(strategy, authOpts);
 

--- a/controllers/strategies.json
+++ b/controllers/strategies.json
@@ -17,7 +17,7 @@
   "google": {
     "name": "Google",
     "oauth": true,
-    "readonly": false
+    "readonly": true
   },
   "imgur": {
     "name": "Imgur",


### PR DESCRIPTION
* Setting goo auth to read only for a while until this is clarified at passport strategy

NOTE:
* Untested on pro but seems to work on dev

Applies to #1526