### PR TITLE
Tweak *bootstrap* gutter width

### DIFF
--- a/public/less/bootstrap/oujs-variables.less
+++ b/public/less/bootstrap/oujs-variables.less
@@ -293,7 +293,7 @@
 //** Number of columns in the grid.
 @grid-columns:              12;
 //** Padding between columns. Gets divided in half for the left and right.
-@grid-gutter-width:         15px;
+@grid-gutter-width:         14px;
 // Navbar collapse
 //** Point at which the navbar becomes uncollapsed.
 @grid-float-breakpoint:     @screen-sm-min;


### PR DESCRIPTION
* Hopefully this will keep the bottom scrollbar from appearing again on desktops in "All Discussions"

NOTES:
* Seems to be rounding up on `.make-row` which generates `-8px` instead of needed `-7px`