### PR TITLE
Add capability of donations

### DIFF
--- a/controllers/scriptStorage.js
+++ b/controllers/scriptStorage.js
@@ -1529,7 +1529,7 @@ exports.storeScript = function (aUser, aMeta, aBuf, aUpdate, aCallback) {
 
       icon = findMeta(aMeta, 'UserScript.icon.0.value');
       if (icon) {
-        if (!isFQUrl(icon, false, true)) {
+        if (!isFQUrl(icon, { canDataImg: true })) {
 
           // Not a web url... reject
           aInnerCallback(new statusError({
@@ -1636,7 +1636,7 @@ exports.storeScript = function (aUser, aMeta, aBuf, aUpdate, aCallback) {
 
       supportURL = findMeta(aMeta, 'UserScript.supportURL.0.value');
       if (supportURL) {
-        if (!isFQUrl(supportURL, true)) {
+        if (!isFQUrl(supportURL, { canMailto: true })) {
 
           // Not a web url... reject
           aInnerCallback(new statusError({
@@ -1645,6 +1645,27 @@ exports.storeScript = function (aUser, aMeta, aBuf, aUpdate, aCallback) {
           }), null);
           return;
         }
+      }
+
+      aInnerCallback(null);
+    },
+    function (aInnerCallback) {
+      // `@contributionURL` validation
+      var contributionURL = null;
+
+      contributionURL = findMeta(aMeta, 'UserScript.contributionURL.0.value');
+      if (contributionURL) {
+        if (!isFQUrl(contributionURL, { isSecure: true })) {
+
+          // Not a secure web url... reject
+          aInnerCallback(new statusError({
+            message: '`contributionURL` not a secure web url in the UserScript metadata block.',
+            code: 400
+          }), null);
+          return;
+        }
+
+        // TODO: Pre-filter on abuse
       }
 
       aInnerCallback(null);

--- a/libs/helpers.js
+++ b/libs/helpers.js
@@ -148,8 +148,10 @@ exports.updateUrlQueryString = function (aBaseUrl, aDict) {
   return url;
 };
 
-exports.isFQUrl = function (aString, aMailto, aDataImg) {
+exports.isFQUrl = function (aString, aOptions) {
   var URL = url.parse(aString); // TODO: Convert to non-legacy
+
+  var reTrusty = null;
 
   var protocol = URL.protocol;
   var username = URL.username; // NOTE: BUG: in current *node*
@@ -163,7 +165,13 @@ exports.isFQUrl = function (aString, aMailto, aDataImg) {
   var source = encodeURIComponent(aString);
   var target = null;
 
-  if (protocol && /^https?:$/.test(protocol)) {
+  if (!aOptions) {
+    aOptions = {};
+  }
+
+  reTrusty = aOptions.isSecure ? new RegExp('^https:$') : new RegExp('^https?:$');
+
+  if (protocol && reTrusty.test(protocol)) {
     if (hostname) {
       target = encodeURIComponent(protocol)
         + encodeURIComponent('//')
@@ -180,9 +188,9 @@ exports.isFQUrl = function (aString, aMailto, aDataImg) {
 
       return target === source;
     }
-  } else if (aMailto && /^mailto:\S+@\S+/.test(aString)) {
+  } else if (aOptions.canMailto && /^mailto:\S+@\S+/.test(aString)) {
     return true;
-  } else if (aDataImg && /^data:image\//.test(aString)) {
+  } else if (aOptions.canDataImg && /^data:image\//.test(aString)) {
     return true;
   }
 

--- a/libs/modelParser.js
+++ b/libs/modelParser.js
@@ -219,6 +219,7 @@ var parseScript = function (aScript) {
   var description = null;
   var icon = null;
   var supportURL = null;
+  var contributionURL = null;
 
   var downloadURL = null;
   var downloadUtf = null;
@@ -283,7 +284,7 @@ var parseScript = function (aScript) {
   // Support Url
   supportURL = findMeta(script.meta, 'UserScript.supportURL.0.value');
   if (supportURL) {
-    if (isFQUrl(supportURL, true)) {
+    if (isFQUrl(supportURL, { canMailto: true })) {
 
       script.hasSupport = true;
 
@@ -291,6 +292,19 @@ var parseScript = function (aScript) {
         url: supportURL,
         text: decode(supportURL),
         isSameOrigin: isSameOrigin(supportURL).result
+      }];
+
+    }
+  }
+
+  // Contribution Url
+  contributionURL = findMeta(script.meta, 'UserScript.contributionURL.0.value');
+  if (contributionURL) {
+    if (isFQUrl(contributionURL, { isSecure: true })) {
+      script.hasContribution = true;
+      script.contribution = [{
+        url: contributionURL,
+        text: decode(contributionURL)
       }];
 
     }

--- a/public/css/common.css
+++ b/public/css/common.css
@@ -495,6 +495,17 @@ ul.flaggedList {
     overflow-x: hidden;
 }
 
+.btn-donate {
+  color: #000;
+  background-color: #ffc439;
+  border-color: #f1b72a;
+  margin-top: 0.55em;
+}
+
+.btn-donate:hover {
+  background-color: #eab122;
+}
+
 /* Extend Ace */
 .ace_gutter-cell:hover {
   font-weight: bold;
@@ -503,3 +514,4 @@ ul.flaggedList {
 #editor .ace_gutter-cell:hover {
   cursor: pointer;
 }
+

--- a/public/pegjs/blockUserScript.pegjs
+++ b/public/pegjs/blockUserScript.pegjs
@@ -44,6 +44,7 @@ Test the generated parser with some input for peg.js site at https://pegjs.org/o
 // @match       http://example.net/*
 // @exclude   http://example.com/foo
 // @exclude   http://example.org/foo
+// @contributionURL https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=your.email@example.org&item_name=OpenUserJS+Author+Donation
 // ==/UserScript==
 
 */
@@ -128,7 +129,8 @@ item1 =
       'icon64' /
       'icon' /
       'downloadURL' /
-      'defaulticon'
+      'defaulticon' /
+      'contributionURL'
     )
   whitespace
   value: non_newline

--- a/views/includes/documents/Terms-of-Service.md
+++ b/views/includes/documents/Terms-of-Service.md
@@ -5,7 +5,7 @@
 * Staying on topic is a good thing to remember. Everyone has other duties to attend to at different times. Try to be succinct and don't obsess on a particular topic. Give others a chance to respond.
 * Intense conversations regarding "filling voids" should be avoided. Advocacy of one site or another should be minimal and gracefully done.
 * Passive aggressive behavior with abrasive commenting does not encourage teamwork even when it is coupled with genuine constructive feedback. Personal attacks may be eligible for account removal from OpenUserJS.org.
-* **"Open Source" is not the same as "the developers must do my bidding"**. A lot of generous time is donated by multiple developers in attempting to resolve any properly presented issues. However this does not mean there is an obligation to do it on any single persons time table. Until the OpenUserJS.org bills are paid by everyone involved it's a wise choice to be courteous instead of snarky.
+* **"Open Source" is not the same as "the developers must do my bidding"**. A lot of generous time is donated by multiple developers in attempting to resolve any properly presented issues. However this does not mean there is an obligation to do it on any single persons time table. Until the OpenUserJS.org bills are paid by everyone it is a wise choice to be courteous. Please **do not** be snarky.
 
 ### Abstraction
 

--- a/views/includes/footer.html
+++ b/views/includes/footer.html
@@ -3,7 +3,12 @@
     <div class="container-fluid">
       <div class="navbar-header">
         <button type="button" data-toggle="collapse" data-target=".navbar-collapse-bottom" class="navbar-toggle" onclick="$('html, body').animate({scrollTop: $(document).height()}, 'slow')"><i class="fa fa-bars"></i></button>
-        <a href="https://github.com/OpenUserJs" class="navbar-brand">&copy; 2013+ <span class="hidden-xs">OpenUserJS</span><span class="visible-xs-inline">OUJS</span> Group</a>
+        <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
+          <input type="hidden" name="cmd" value="_s-xclick">
+          <input type="hidden" name="hosted_button_id" value="F359CDZSR6L7W">
+          <input type="submit" value="Donate" class="btn btn-donate" title="Donations for the site are greatly appreciated via PayPal - A safer, easier, way to donate online.">
+          <a href="https://github.com/OpenUserJs" class="navbar-brand">&copy; 2013+ OpenUserJS</a>
+        </form>
       </div>
       <div class="navbar-collapse navbar-collapse-bottom collapse">
         <ul class="nav navbar-nav navbar-right">

--- a/views/pages/newScriptPage.html
+++ b/views/pages/newScriptPage.html
@@ -201,6 +201,7 @@
                 </div>
               </div>
             </div>
+
             <div class="panel panel-default">
               <div class="panel-heading">
                 <h5 class="panel-title">
@@ -211,6 +212,20 @@
               <div id="collapse-supporturl" class="panel-collapse collapse">
                 <div class="panel-body">
                   <p>A url of http, https or mailto protocol. Specially formatted on the script page.</p>
+                  <p>Last value shown.</p>
+                </div>
+              </div>
+            </div>
+            <div class="panel panel-default">
+              <div class="panel-heading">
+                <h5 class="panel-title">
+                  <a id="user-block-contributionurl" rel="bookmark"></a>
+                  <a data-toggle="collapse" data-parent="#accordion-userscript-block" href="#collapse-contributionurl"><code>@contributionURL url</code></a>
+                </h5>
+              </div>
+              <div id="collapse-contributionurl" class="panel-collapse collapse">
+                <div class="panel-body">
+                  <p>A url of https protocol only. Used for monetary requests for contributions. <code>@contributionAmount</code> is currently unsupported. Specially formatted on the script issues list and script issue page.</p>
                   <p>Last value shown.</p>
                 </div>
               </div>

--- a/views/pages/scriptIssueListPage.html
+++ b/views/pages/scriptIssueListPage.html
@@ -25,9 +25,8 @@
         {{#script.hasSupport}}
         {{#script.support}}
           {{^isSameOrigin}}
-          <div class="alert alert-success alert-dismissible small" role="alert">
-            <button type="button" class="close" data-dismiss="alert"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
-              <p><i class="fa fa-fw fa-support"></i> <b>Support:</b> <a href="{{{url}}}" rel="external noreferrer noopener nofollow" referrerpolicy="same-origin">{{text}}</a></p>
+          <div class="alert alert-success small" role="alert">
+            <p><i class="fa fa-fw fa-support"></i> <b>Support:</b> <a href="{{{url}}}" rel="external noreferrer noopener nofollow" referrerpolicy="same-origin">{{text}}</a></p>
             The script author requests that you use their preferred primary support method when filing an issue. Please consider using that for regular issues.
           </div>
           {{/isSameOrigin}}
@@ -57,6 +56,17 @@
               <li class="{{#allIssues}}active{{/allIssues}}"><a href="{{{category.categoryPageUrl}}}/all">All</a></li>
             </ul>
           </div>
+          {{#script.hasContribution}}
+          {{#script.contribution}}
+          <div class="panel-footer">
+            <div class="btn-group btn-group-justified">
+              <a rel="external nofollow" referrerpolicy="strict-origin" href="{{{url}}}" class="btn btn-donate" title="External web payment processor URL for monetary donations to this Author">
+                <i class="fa fa-fw fa-money"></i><span class=""> Donate</span>
+              </a>
+            </div>
+          </div>
+          {{/script.contribution}}
+          {{/script.hasContribution}}
         </div>
       </div>
     </div>

--- a/views/pages/scriptIssuePage.html
+++ b/views/pages/scriptIssuePage.html
@@ -55,6 +55,19 @@
       </div>
       <div class="container-fluid col-sm-4">
         {{> includes/searchBarPanel.html }}
+        {{#script.hasContribution}}
+        {{#script.contribution}}
+        <div class="panel">
+          <div class="panel-body">
+            <div class="btn-group btn-group-justified">
+              <a rel="external nofollow" referrerpolicy="strict-origin" href="{{{url}}}" class="btn btn-donate" title="External web payment processor URL for monetary donations to this Author">
+                <i class="fa fa-fw fa-money"></i><span class=""> Donate</span>
+              </a>
+            </div>
+          </div>
+          {{/script.contribution}}
+          {{/script.hasContribution}}
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
* Site donations
* Adopt `@contributionURL` ... must be secure web address... expandable to filtering if needed.
* Remove dismiss ability on `@supportURL`
* Option'ify the `isFQUrl` since it's getting bigger on args
* Add current to add script page docs
* Users will need to update their script to show this... may run through the DB and recollect this but that's bandwidth intensive... so don't count on it atm.
* Needs potential followup for possible `referrerpolicy` change for Author donation URLs.
* Slight wording change under etiquette since we are accepting donations now.
NOTES:
* `@contributionAmount` is kind of pointless since it can be anything... could be a text label but if utilized other than a label, currency conversion is an issue... for the time being leaving this at the orphanage.
* Donate for Authors is located on the Issues page of script Authors... one should see what's sort of praise, bugs, etc. before donating.
* Tried to make this as unobtrusive as possible without sacrificing emphasis.