### PR TITLE
GDPR14

### DIFF
--- a/libs/modelParser.js
+++ b/libs/modelParser.js
@@ -301,7 +301,7 @@ var parseScript = function (aScript) {
   contributionURL = findMeta(script.meta, 'UserScript.contributionURL.0.value');
   if (contributionURL) {
     if (isFQUrl(contributionURL, { isSecure: true })) {
-      script.hasContribution = true;
+      script.canDonate = true;
       script.contribution = [{
         url: contributionURL,
         text: decode(contributionURL)

--- a/views/includes/footer.html
+++ b/views/includes/footer.html
@@ -3,12 +3,10 @@
     <div class="container-fluid">
       <div class="navbar-header">
         <button type="button" data-toggle="collapse" data-target=".navbar-collapse-bottom" class="navbar-toggle" onclick="$('html, body').animate({scrollTop: $(document).height()}, 'slow')"><i class="fa fa-bars"></i></button>
-        <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
-          <input type="hidden" name="cmd" value="_s-xclick">
-          <input type="hidden" name="hosted_button_id" value="F359CDZSR6L7W">
-          <input type="submit" value="Donate" class="btn btn-donate" title="Donations for the site are greatly appreciated via PayPal - A safer, easier, way to donate online.">
-          <a href="https://github.com/OpenUserJs" class="navbar-brand">&copy; 2013+ OpenUserJS</a>
-        </form>
+        <a rel="external noreferrer noopener nofollow" referrerpolicy="same-origin" href="#" data-toggle="modal" data-target="#donateSiteModal" class="btn btn-donate" title="Monetary donations for this site">
+          <i class="fa fa-fw fa-money"></i><span class=""> Donate</span>
+        </a>
+        <a href="https://github.com/OpenUserJs" class="navbar-brand">&copy; 2013+ OpenUserJS</a>
       </div>
       <div class="navbar-collapse navbar-collapse-bottom collapse">
         <ul class="nav navbar-nav navbar-right">
@@ -28,6 +26,7 @@
 <script type="text/javascript" charset="UTF-8" src="/redist/npm/jquery/dist/jquery.js"></script>
 <script type="text/javascript" charset="UTF-8" src="/redist/npm/bootstrap/dist/js/bootstrap.js"></script>
 
+{{> includes/siteModals.html }}
 {{> includes/scripts/hideReminders.html }}
 
 {{^isDev}}

--- a/views/includes/scriptModals.html
+++ b/views/includes/scriptModals.html
@@ -19,13 +19,37 @@
     </div>
   </div>
 </div>
+{{#script.canDonate}}
+<div class="modal fade" id="donateScriptModal">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+        <h4 class="modal-title"><i class="fa fa-fw fa-money"></i> Donate for {{script.fullName}}</h4>
+      </div>
+      <div class="modal-body">
+        <p>Are you sure you want to go to an external site to donate a monetary value?</p>
+        <div class="alert alert-warning" role="alert">
+          <i class="fa fa-fw fa-exclamation-triangle"></i> WARNING: Some countries laws may supersede the payment processors policy such as the GDPR and PayPal. While it is highly appreciated to donate, please check with your countries privacy and identity laws regarding privacy of information first. Use at your utmost discretion.
+        </div>
+      </div>
+      <div class="modal-footer">
+          <button type="button" class="btn btn-default" data-dismiss="modal"><i class="fa fa-fw fa-close"></i> Close</button>
+          {{#script.contribution}}
+          <a rel="external noreferrer noopener nofollow" referrerpolicy="same-origin" href="{{url}}" class="btn btn-danger" role="button" title="Send a monetary Thank You!">Donate</a>
+          {{/script.contribution}}
+      </div>
+    </div>
+  </div>
+</div>
+{{/script.canDonate}}
 {{#authorTools}}
 <div class="modal fade" id="deleteScriptModal">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-        <h4 class="modal-title">Delete {{script.fullName}}</h4>
+        <h4 class="modal-title"><i class="fa fa-fw fa-trash-o"></i> Delete {{script.fullName}}</h4>
       </div>
       <div class="modal-body">
         <p>Are you sure you want to delete this script? You cannot undo this.</p>
@@ -34,7 +58,7 @@
         <form action="{{{script.scriptEditMetadataPageUrl}}}" method="post">
           <button type="button" class="btn btn-default" data-dismiss="modal"><i class="fa fa-fw fa-close"></i> Close</button>
           <input type="hidden" name="remove" value="true">
-          <button type="submit" class="btn btn-danger"><i class="fa fa-fw fa-trash-o"></i> Delete</button>
+          <button type="submit" class="btn btn-danger">Delete</button>
         </form>
       </div>
     </div>

--- a/views/includes/scriptUserToolsPanel.html
+++ b/views/includes/scriptUserToolsPanel.html
@@ -11,6 +11,7 @@
         <div style="width: {{script.flagsPercent}}%" class="progress-bar progress-bar-danger">{{#script.flags.critical}}{{script.flags.critical}} <i class="fa fa-fw fa-flag-o"></i>{{/script.flags.critical}}</div>
       </div>
     </div>
+    {{#canFlag}}
     <ul class="nav nav-pills nav-justified">
       <li>
         <div class="text-center">
@@ -26,5 +27,6 @@
         </div>
       </li>
     </ul>
+    {{/canFlag}}
   </div>
 </div>

--- a/views/includes/siteModals.html
+++ b/views/includes/siteModals.html
@@ -1,0 +1,24 @@
+<div class="modal fade" id="donateSiteModal">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+        <h4 class="modal-title"><i class="fa fa-fw fa-money"></i> Donate for the site OpenUserJS</h4>
+      </div>
+      <div class="modal-body">
+        <p>Are you sure you want to go to an external site to donate a monetary value?</p>
+        <div class="alert alert-warning" role="alert">
+          <i class="fa fa-fw fa-exclamation-triangle"></i> WARNING: Some countries laws may supersede the payment processors policy such as the GDPR and PayPal. While it is highly appreciated to donate, please check with your countries privacy and identity laws regarding privacy of information first. Use at your utmost discretion.
+        </div>
+      </div>
+      <div class="modal-footer">
+        <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
+          <input type="hidden" name="cmd" value="_s-xclick">
+          <input type="hidden" name="hosted_button_id" value="F359CDZSR6L7W">
+          <button type="button" class="btn btn-default" data-dismiss="modal"><i class="fa fa-fw fa-close"></i> Close</button>
+          <input type="submit" value="Donate" class="btn btn-danger" title="Send a monetary Thank You via PayPal!">
+        </form>
+      </div>
+    </div>
+  </div>
+</div>

--- a/views/includes/userModals.html
+++ b/views/includes/userModals.html
@@ -3,7 +3,7 @@
     <div class="modal-content">
       <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-        <h4 class="modal-title">Flag {{user.name}}</h4>
+        <h4 class="modal-title"><i class="fa fa-fw fa-flag"></i> Flag {{user.name}}</h4>
       </div>
       <div class="modal-body">
         <p>Are you sure you want to flag this user for potential inspection by a Moderator?</p>
@@ -13,7 +13,7 @@
           <input type="text" class="form-control" name="reason" placeholder="Reason for moderation inspection.">
           <button type="button" class="btn btn-default" data-dismiss="modal"><i class="fa fa-fw fa-close"></i> Close</button>
           <input type="hidden" name="flag" value="true">
-          <button type="submit" class="btn btn-danger{{^canFlag}} disabled{{/canFlag}}"><i class="fa fa-fw fa-flag"></i> Flag</button>
+          <button type="submit" class="btn btn-danger{{^canFlag}} disabled{{/canFlag}}">Flag</button>
         </form>
       </div>
     </div>
@@ -25,7 +25,7 @@
     <div class="modal-content">
       <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-        <h4 class="modal-title">Remove {{user.name}}</h4>
+        <h4 class="modal-title"><i class="fa fa-fw fa-ban"></i> Remove {{user.name}}</h4>
       </div>
       <div class="modal-body">
         <p>Are you sure you want to remove this user? You cannot undo this.</p>
@@ -41,7 +41,7 @@
           <br />
           <button type="button" class="btn btn-default" data-dismiss="modal"><i class="fa fa-fw fa-close"></i> Close</button>
           <input type="hidden" name="remove" value="true">
-          <button type="submit" class="btn btn-danger"><i class="fa fa-fw fa-ban"></i> Remove</button>
+          <button type="submit" class="btn btn-danger">Remove</button>
         </form>
       </div>
     </div>

--- a/views/includes/userUserToolsPanel.html
+++ b/views/includes/userUserToolsPanel.html
@@ -1,3 +1,4 @@
+{{#canFlag}}
 <div class="panel panel-default">
   <div class="panel-body">
     <ul class="nav nav-pills nav-justified">
@@ -17,3 +18,4 @@
     </ul>
   </div>
 </div>
+{{/canFlag}}

--- a/views/pages/scriptIssueListPage.html
+++ b/views/pages/scriptIssueListPage.html
@@ -56,21 +56,22 @@
               <li class="{{#allIssues}}active{{/allIssues}}"><a href="{{{category.categoryPageUrl}}}/all">All</a></li>
             </ul>
           </div>
-          {{#script.hasContribution}}
+          {{#script.canDonate}}
           {{#script.contribution}}
           <div class="panel-footer">
             <div class="btn-group btn-group-justified">
-              <a rel="external nofollow" referrerpolicy="strict-origin" href="{{{url}}}" class="btn btn-donate" title="External web payment processor URL for monetary donations to this Author">
+              <a rel="external noreferrer noopener nofollow" referrerpolicy="same-origin" href="#" data-toggle="modal" data-target="#donateScriptModal" class="btn btn-donate" title="Monetary donations for this Author">
                 <i class="fa fa-fw fa-money"></i><span class=""> Donate</span>
               </a>
             </div>
           </div>
           {{/script.contribution}}
-          {{/script.hasContribution}}
+          {{/script.canDonate}}
         </div>
       </div>
     </div>
   </div>
+  {{> includes/scriptModals.html }}
   {{> includes/footer.html }}
   {{> includes/scripts/tableTrLinkScript.html }}
   {{#paginationRendered}}

--- a/views/pages/scriptIssuePage.html
+++ b/views/pages/scriptIssuePage.html
@@ -55,23 +55,24 @@
       </div>
       <div class="container-fluid col-sm-4">
         {{> includes/searchBarPanel.html }}
-        {{#script.hasContribution}}
+        {{#script.canDonate}}
         {{#script.contribution}}
         <div class="panel">
           <div class="panel-body">
             <div class="btn-group btn-group-justified">
-              <a rel="external nofollow" referrerpolicy="strict-origin" href="{{{url}}}" class="btn btn-donate" title="External web payment processor URL for monetary donations to this Author">
+              <a rel="external noreferrer noopener nofollow" referrerpolicy="same-origin" href="#" data-toggle="modal" data-target="#donateScriptModal" class="btn btn-donate" title="Monetary donations for this Author">
                 <i class="fa fa-fw fa-money"></i><span class=""> Donate</span>
               </a>
             </div>
           </div>
           {{/script.contribution}}
-          {{/script.hasContribution}}
+          {{/script.canDonate}}
         </div>
       </div>
     </div>
   </div>
 
+  {{> includes/scriptModals.html }}
   {{> includes/footer.html }}
   {{#paginationRendered}}
       {{> includes/scripts/showTopPagination.html }}


### PR DESCRIPTION
* Modal donation buttons with a confirmation prompt
* Increase security on referrer and opener for payment processors. If it doesn't work then you won't be returned. Current PP policy is to handle the "callback" *(similar to the auth strategies)* in the account. e.g. no need to let PP, and others know where you are coming from.
* Remove flag UI notice if not able to... this should be in line with comments so they don't accidently/purposely get turned on without establishing owner approval. Modal is still output because of a logic error in what comes first versus the view... probably in the controller as a post op outside of `modelParser`... omitting for now.
* Change text for PP as it may not be safe in other countries. Never liked the stock PP text in the first place.
* Rework some icons... form values can't accept static HTML so stripping it out and placing in modal titlebar
* Rework some mustache names from prior PR. Easier to distinguish/search from a human perspective e.g. code readability

Applies to #1538 #1537 ... loosely related to #1385