### PR TITLE
Repair lockdown meta url notice on Source Code page

### DIFF
--- a/controllers/script.js
+++ b/controllers/script.js
@@ -382,11 +382,6 @@ exports.view = function (aReq, aRes, aNext) {
       options.isMod = authedUser && authedUser.isMod;
       options.isAdmin = authedUser && authedUser.isAdmin;
 
-      // Lockdown
-      options.lockdown = {};
-      options.lockdown.scriptStorageRO = process.env.READ_ONLY_SCRIPT_STORAGE === 'true';
-      options.lockdown.updateURLCheck = process.env.FORCE_BUSY_UPDATEURL_CHECK === 'true';
-
       // Script
       options.script = script = modelParser.parseScript(aScript);
       options.isOwner = authedUser && authedUser._id == script._authorId;

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -2059,6 +2059,11 @@ exports.editScript = function (aReq, aRes, aNext) {
           return;
         }
 
+        // Lockdown
+        options.lockdown = {};
+        options.lockdown.scriptStorageRO = process.env.READ_ONLY_SCRIPT_STORAGE === 'true';
+        options.lockdown.updateURLCheck = process.env.FORCE_BUSY_UPDATEURL_CHECK === 'true';
+
         // Script
         options.script = script = modelParser.parseScript(aScript);
 

--- a/views/pages/documentPage.html
+++ b/views/pages/documentPage.html
@@ -20,7 +20,7 @@
             <p>Welcome to {{#pkg.name}}{{pkg.name}} <em>(OUJS)</em>{{#pkg.version}} v{{pkg.version}}{{/pkg.version}}{{/pkg.name}}{{#process.version}} using Node {{process.version}}{{/process.version}}{{#lastRestart}} last restarted <time datetime="{{lastRestartISOFormat}}" title="{{lastRestart}}">{{lastRestartHumanized}}</time>.{{/lastRestart}}</p>
             <ul>
               {{#lockdown.scriptStorageRO}}<li>Read-Only Script storage mode is in effect.</li>{{/lockdown.scriptStorageRO}}
-              {{#lockdown.updateURLCheck}}<li>UserScript metadata block <code>// @updateURL</code> is required.</li>{{/lockdown.updateURLCheck}}
+              {{#lockdown.updateURLCheck}}<li>UserScript metadata block <code>// @updateURL</code> is required. See <a href="/about/Frequently-Asked-Questions#q-does-openuserjs-org-have-meta-">this FAQ</a>.</li>{{/lockdown.updateURLCheck}}
               <li><em>No other site status messages at this time.</em></li>
             </ul>
             <h3><a id="mission" rel="bookmark"></a>Mission<a class="anchor" href="#mission"><em class="fa fa-link"></em></a></h3>


### PR DESCRIPTION
* Link in the FAQ for this

Post #944 #970 #389 ... missed somewhere around #976 to #1208 *(vaguely recall this was on the script homepage originally and moved to source code page)*. Needed for #1548 to calm network traffic issues which appear to be global with Level3. Over 17,000 sites are down according to pingdom.