### PR TITLE
Use URL WHATWG for *mongoose*

### DIFF
--- a/app.js
+++ b/app.js
@@ -69,11 +69,13 @@ var dbOptions = {};
 var defaultPoolSize = 5;
 if (isPro) {
   dbOptions = {
+    useNewUrlParser: true,
     secondaryAcceptableLatencyMS: 15,
     poolSize: defaultPoolSize * 3
   }
 } else {
   dbOptions = {
+    useNewUrlParser: true,
     poolSize: defaultPoolSize,
     reconnectTries: 30,
     reconnectInterval: 1000


### PR DESCRIPTION
* Hopefully this will squash some warning messages.
* We still have on legacy URL API call to migrate but waiting a bit

Ref:
* https://mongoosejs.com/docs/connections.html#use-mongo-client

Applies to #1516