### PR TITLE
Point dev to newer hosted DB version

### DIFF
--- a/models/settings.json
+++ b/models/settings.json
@@ -1,6 +1,6 @@
 {
  "secret" : "someSecretStringForSession",
- "connect" : "mongodb://dev:oujs@ds041651.mongolab.com:41651/openuserjs_dev",
+ "connect" : "mongodb://dev:oujs123@ds131963.mlab.com:31963/openuserjs_devel",
  "maximum_upload_script_size": 1048576,
  "ttl": {
   "minimum": 5,


### PR DESCRIPTION
* This is very close to production version but since it is shared it's a crap shoot when creating a sandboxed *(free but limited btw)* DB. Interesting feature of mLabs. May try again to see if we can match it. First creation wasn't close enough; 2nd time it is close.

NOTES:
* Will leave old dev db up for a bit until full retesting occurs. Basic seems to be okay with new dev db.
* The FQDN name has changed for dev mLabs at some point in history. Probably offloaded onto a different server is an educated guess via DNS.
* pwd has to be at least 6 characters and include alphanumerics now... making as general as possible
* Can only import exported collections from here. Full DB import from export isn't happy which is okay as long as metadata `_since` is preserved. Probably has to do with db name conflict and mLabs.
* Metadata `_since` is preserved however it did complain about indexes on one collection:

``` console
2019-01-03T16:20:45.014-0700    Failed: openuserjs_devel.scripts: error creating indexes for openuserjs_devel.scripts: createIndex error: The field 'safe' is not valid for an index specification. Specification: { background: true, safe: null, name: "name_1", ns: "openuserjs_devel.scripts", key: { name: 1 } }
```

* 12 system indexes in new vs old which had 17. From v1 to v2. db name auto-adjusted.
* nodejitsu user index item not inclusive. Talk about a blast from the past.
*  Some misc indexes that I'm not sure why they are there were not auto-imported.
* Btw we are Eastern served... so not quite sure why the traceroute tests were going West other than general internet misdirection at this time in the backbones.
* Btw if we take this info to the VPS we may lose the dev db and probably need to establish additional limited sub-accounts

Ref:
* https://docs.mlab.com/ops/#q-why-cant-i-change-the-mongodb-version-thats-running-on-my-sandbox-database

Applies to #1548 #262