### PR TITLE
Some dep updates

### DIFF
--- a/app.js
+++ b/app.js
@@ -71,7 +71,8 @@ if (isPro) {
   dbOptions = {
     useNewUrlParser: true,
     secondaryAcceptableLatencyMS: 15,
-    poolSize: defaultPoolSize
+    poolSize: defaultPoolSize,
+    socketTimeoutMS: 90000 // Mitigation of #1548
   }
 } else {
   dbOptions = {

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "OpenUserJS.org",
   "description": "An open source user scripts repo built using Node.js",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "main": "app",
   "dependencies": {
     "ace-builds": "git://github.com/ajaxorg/ace-builds.git#0d62c26",
     "ansi-colors": "3.2.3",
     "async": "2.6.1",
-    "aws-sdk": "2.382.0",
+    "aws-sdk": "2.384.0",
     "base62": "2.0.0",
     "body-parser": "1.18.3",
     "bootstrap": "3.3.7",
@@ -15,7 +15,7 @@
     "clipboard": "2.0.4",
     "compression": "1.7.3",
     "connect-mongo": "2.0.3",
-    "diff": "3.5.0",
+    "diff": "4.0.1",
     "express": "4.16.4",
     "express-minify": "1.0.0",
     "express-rate-limit": "3.3.2",
@@ -32,14 +32,14 @@
     "jsdom": "13.1.0",
     "jwt-simple": "0.5.5",
     "less-middleware": "3.0.1",
-    "marked": "0.5.2",
+    "marked": "0.6.0",
     "media-type": "0.3.1",
     "method-override": "3.0.0",
     "mime-db": "1.37.0",
     "moment": "2.23.0",
     "moment-duration-format": "2.2.2",
     "mongodb": "3.1.10",
-    "mongoose": "5.4.1",
+    "mongoose": "5.4.2",
     "morgan": "1.9.1",
     "mu2": "0.5.21",
     "octicons": "4.4.0",
@@ -63,7 +63,7 @@
     "select2-bootstrap-css": "1.4.6",
     "serve-favicon": "2.5.0",
     "spdx-license-ids": "3.0.3",
-    "terser": "3.13.1",
+    "terser": "3.14.1",
     "toobusy-js": "0.5.1",
     "underscore": "1.9.1",
     "useragent": "2.3.0"
@@ -83,8 +83,8 @@
     "clean": "node dev/clean.js"
   },
   "engines": {
-    "node": ">=10.5.0 <11.0.0",
-    "npm": ">=6.1.0"
+    "node": ">=11.6.0 <12.0.0",
+    "npm": ">=6.5.0"
   },
   "private": true
 }

--- a/views/includes/scripts/scriptEditor.html
+++ b/views/includes/scripts/scriptEditor.html
@@ -194,7 +194,7 @@
           editor.renderer.setShowGutter(false);
 
           editor.getSession().setValue(
-            JsDiff.createTwoFilesPatch(
+            Diff.createTwoFilesPatch(
             '{{script.scriptViewSourcePageUrl}}'
               + '@{{script.meta.UserScript.version.0.value}}+{{script.hashShort}}',
             '{{script.scriptViewSourcePageUrl}}',


### PR DESCRIPTION
* Bump project version... shouldn't be going back from this point DB wise. We have a few days of backups already with most changes made.
* Official change to odd numbered *node* version to partially work-around mitigate #1548 . Somewhere around May 2019 is when 12 becomes current. 10 just "isn't doing it" for the moment. This should be reversible but not a guarantee. We are still having timeouts to AWS/mLabs.
* Official mitigation of *mongoose* See https://github.com/Automattic/mongoose/issues/7355#issuecomment-449767217 . This may be helping a little but not much. Declining slope in mLabs but could be decline in user interaction too.
* Please read their CHANGELOGs
* Delete op retested
* Repair, yet to be documented, *diff* breaking change with `JsDiff` to `Diff` Object reference. See https://github.com/kpdecker/jsdiff/issues/199#issuecomment-451990311 . Issued at kpdecker/jsdiff#243