### PR TITLE
Squash a deprecation in our Code base

### DIFF
--- a/libs/modifySessions.js
+++ b/libs/modifySessions.js
@@ -294,17 +294,11 @@ exports.findSessionData = function (aQuery, aStore, aOptions, aCallback) {
 
     aOptions.sessionList = [];
 
-    aUserSessions.each(function (aErr, aSessionData) {
+    aUserSessions.forEach(function (aSessionData) {
       var data = null;
       var rQuery = null;
 
-      if (aErr) {
-        aCallback(aErr);
-        return;
-      }
-
       if (!aSessionData) {
-        aCallback();
         return;
       }
 
@@ -340,6 +334,8 @@ exports.findSessionData = function (aQuery, aStore, aOptions, aCallback) {
 
       }
 
+    }, function (aErr) {
+      aCallback(aErr);  // done or err
     });
   });
 }


### PR DESCRIPTION
* Utilize this method for mongodb native... `async`/`await` with `hasNext()`/`next()` tested and can also work but part of ES6+

NOTE:
* Code looks more uniform with this method e.g. always wondered why there wasn't a final `aCallback`

Ref:
* https://stackoverflow.com/questions/25507866/how-can-i-use-a-cursor-foreach-in-mongodb-using-node-js#answer-25508173

Applies to #1516