### PR TITLE
Ignore source translation requests

### DIFF
--- a/views/pages/scriptViewSourcePage.html
+++ b/views/pages/scriptViewSourcePage.html
@@ -30,7 +30,7 @@
       <div class="col-md-12">
       {{/owner}}
         {{^newScript}}{{> includes/scriptPageHeader.html }}{{/newScript}}
-        <pre id="editor">{{source}}</pre>
+        <pre class="notranslate" translate="no" id="editor">{{source}}</pre>
         {{^readOnly}}
         <form action="{{#isLib}}/user/add/lib/new{{/isLib}}{{^isLib}}/user/add/scripts/new{{/isLib}}" id="code_form" method="post">
           <input type="hidden" id="source" name="source" value="" />


### PR DESCRIPTION
* This could theoretically cause major issues on forking.
* This is also the cause of the double spacing between `x` `.` `y`

NOTE:
* One or the other may not work depending on browser backend