### PR TITLE
Fix scripts with incorrect counts and only one

### DIFF
--- a/libs/modelParser.js
+++ b/libs/modelParser.js
@@ -575,6 +575,10 @@ var parseGroup = function (aGroup) {
         group.rating = getRating(aScripts);
       }
 
+      if (aScripts && aScripts.length === 1) {
+        group.size = aScripts.length;
+      }
+
       if (aScripts && aScripts.length === 0) {
         group.remove(function (aErr, aGroup) {
           if (aErr) {


### PR DESCRIPTION
NOTE:
* Don't fully understand sizzle logic here with rating but this fixes `Size` and keeps the `Rating` at last known value until another script is added. `bongacams` has only `1` but never gets updated from `2`. Presume there is more. will have to go through them all again.

Applies to #93