### PR TITLE
(Mean + Median)/2 fix

### DIFF
--- a/libs/modelParser.js
+++ b/libs/modelParser.js
@@ -575,8 +575,10 @@ var parseGroup = function (aGroup) {
         group.rating = getRating(aScripts);
       }
 
+      // `aScripts` may change dynamically so check again
       if (aScripts && aScripts.length === 1) {
         group.size = aScripts.length;
+        group.rating = 0;
       }
 
       if (aScripts && aScripts.length === 0) {


### PR DESCRIPTION
* Referred to as a collective rating in the code... this value should be zero according to that routine.
* That routine already has this but I assume it's a "double check?" since `aScripts` can change on the fly... anyhow... groups with 1 script should have a "collective rating" of zero according to the function... so mirroring

Applies to #93 and post #1581