### PR TITLE
Fix bug with `votes` count

### DIFF
--- a/controllers/flag.js
+++ b/controllers/flag.js
@@ -13,6 +13,7 @@ var formidable = require('formidable');
 
 //--- Model inclusions
 var Flag = require('../models/flag').Flag;
+
 var User = require('../models/user').User;
 var Script = require('../models/script').Script;
 
@@ -109,6 +110,7 @@ exports.flag = function (aReq, aRes, aNext) {
             });
 
         });
+
         break;
       case 'users':
         username = aReq.params[1];

--- a/controllers/vote.js
+++ b/controllers/vote.js
@@ -8,14 +8,111 @@ var isDbg = require('../libs/debug').isDbg;
 //
 
 //--- Dependency inclusions
+var formidable = require('formidable');
 
 //--- Model inclusions
+var Script = require('../models/script').Script;
 
 //--- Controller inclusions
+var scriptStorage = require('./scriptStorage');
+
 
 //--- Library inclusions
 var voteLib = require('../libs/vote');
 
+var modelParser = require('../libs/modelParser');
+
+var statusCodePage = require('../libs/templateHelpers').statusCodePage;
+
 //--- Configuration inclusions
 
 //---
+
+// Controller for Script voting
+exports.vote = function (aReq, aRes, aNext) {
+  var form = null;
+
+  // Check to make sure multipart form data submission header is present
+  if (!/multipart\/form-data/.test(aReq.headers['content-type'])) {
+    statusCodePage(aReq, aRes, aNext, {
+      statusCode: 400,
+      statusMessage: 'Missing required header.'
+    });
+    return;
+  }
+
+  form = new formidable.IncomingForm();
+  form.parse(aReq, function (aErr, aFields) {
+    // WARNING: No err handling
+
+    var vote = aFields.vote;
+    var unvote = false;
+
+    var type = aReq.params[0];
+    var isLib = null;
+
+    var installNameBase = null;
+    var authedUser = aReq.session.user;
+
+    switch (vote) {
+      case 'up':
+        // fallthrough
+      case 'down':
+        // fallthrough
+      case 'un':
+        break;
+      default:
+        statusCodePage(aReq, aRes, aNext, {
+          statusCode: 400,
+          statusMessage: 'Missing required field value.'
+        });
+        return;
+    }
+
+    switch (type) {
+      case 'libs':
+        isLib = true;
+        // fallthrough
+      case 'scripts':
+        aReq.params.username = aReq.params[2];
+        aReq.params.scriptname = aReq.params[3]
+
+        installNameBase = scriptStorage.getInstallNameBase(aReq);
+
+        Script.findOne({
+          installName: scriptStorage.caseSensitive(installNameBase +
+            (isLib ? '.js' : '.user.js'))
+          }, function (aErr, aScript) {
+            var fn = voteLib[vote + 'vote'];
+
+            // ---
+            if (aErr || !aScript) {
+              aRes.redirect((isLib ? '/libs/' : '/scripts/') + scriptStorage.getInstallNameBase(
+                aReq, { encoding: 'uri' }));
+              return;
+            }
+
+            fn(aScript, authedUser, function (aErr) {
+              var script = null;
+
+              if (vote === 'down') {
+                script = modelParser.parseScript(aScript);
+
+                // Gently encourage browsing/creating an issue with a down vote
+                aRes.redirect(script.scriptIssuesPageUri);
+
+              } else {
+                aRes.redirect((isLib ? '/libs/' : '/scripts/') + scriptStorage.getInstallNameBase(
+                  aReq, { encoding: 'uri' }));
+              }
+            });
+
+        });
+
+        break;
+      default:
+        aNext();
+        return;
+    }
+  });
+};

--- a/libs/flag.js
+++ b/libs/flag.js
@@ -70,7 +70,10 @@ function getFlag(aModel, aContent, aUser, aCallback) {
 function getAuthor(aContent, aCallback) {
   User.findOne({ _id: aContent._authorId }, function (aErr, aAuthor) {
     // Content without an author shouldn't exist
-    if (aErr || !aAuthor) { return aCallback(null); }
+    if (aErr || !aAuthor) {
+      aCallback(null);
+      return;
+    }
 
     aCallback(aAuthor);
   });
@@ -152,6 +155,8 @@ function flag(aModel, aContent, aUser, aAuthor, aReason, aCallback) {
   });
 
   flag.save(function (aErr, aFlag) {
+    // WARNING: No err handling
+
     if (!aContent.flags) {
       aContent.flags = {};
     }

--- a/libs/modelParser.js
+++ b/libs/modelParser.js
@@ -380,6 +380,10 @@ var parseScript = function (aScript) {
   // Urls: Moderation
   script.scriptRemovePageUrl = '/remove' + (script.isLib ? '/libs/' : '/scripts/') +
     script.installNameSlugUrl;
+
+  script.scriptVotePageUrl = '/vote' + (script.isLib ? '/libs/' : '/scripts/') +
+    script.installNameSlugUrl;
+
   script.scriptFlagPageUrl = '/flag' + (script.isLib ? '/libs/' : '/scripts/') +
     script.installNameSlugUrl;
 

--- a/libs/vote.js
+++ b/libs/vote.js
@@ -5,4 +5,252 @@ var isPro = require('../libs/debug').isPro;
 var isDev = require('../libs/debug').isDev;
 var isDbg = require('../libs/debug').isDbg;
 
-//
+//--- Model inclusions
+var User = require('../models/user').User;
+var Vote = require('../models/vote').Vote;
+var Script = require('../models/script').Script;
+
+//--- Library inclusions
+var flagLib = require('../libs/flag');
+
+//---
+
+// Determine whether content can be voted by a user.
+function voteable(aScript, aUser, aCallback) {
+  // No script
+  if (!aScript) {
+    aCallback(false);
+    return;
+  }
+  // Not logged in
+  if (!aUser) {
+    aCallback(false);
+    return;
+  }
+
+  getAuthor(aScript, function (aAuthor) {
+    // Script without an author shouldn't exist
+    if (!aAuthor) {
+      aCallback(false);
+      return;
+    }
+
+    // You can't vote on your own Script
+    if (aAuthor._id == aUser._id) {
+      aCallback(false);
+      return;
+    }
+
+    // Always try to get a Vote
+    getVote(aScript, aUser, function (aVote) {
+      aCallback(true, aAuthor, aVote);
+      return;
+    });
+  });
+}
+exports.voteable = voteable;
+
+function getVote(aScript, aUser, aCallback) {
+  Vote.findOne({
+    '_scriptId': aScript._id,
+    '_userId': aUser._id
+  }, function (aErr, aVote) {
+    if (aErr) {
+      console.error('DB: getVote failure. aErr :=', aErr);
+      // fallthrough
+    }
+
+    aCallback(aErr || (!aVote ? null : aVote));
+  });
+}
+
+function getAuthor(aScript, aCallback) {
+  User.findOne({ _id: aScript._authorId }, function (aErr, aAuthor) {
+    // Script without an author shouldn't exist
+    if (aErr) {
+      console.error('DB: getAuthor failure. aErr :=', aErr);
+      aCallback(null);
+      return;
+    }
+    if (!aAuthor) {
+      console.error('DB: Script has no Author', aScript._id);
+      aCallback(null);
+      return;
+    }
+
+    aCallback(aAuthor);
+  });
+}
+exports.getAuthor = getAuthor;
+
+
+function saveScript(aScript, aAuthor, aFlags, aCallback) {
+  if (!aScript) {
+    aCallback(false);
+    return;
+  }
+
+  if (!aFlags) {
+    aScript.save(function (aErr, aScript) {
+      if (aErr) {
+        console.error('DB: saveScript failure. aErr :=', aErr);
+        aCallback('DB: saveScript failed to save flags in voteLib');
+        return;
+      }
+
+      if (!aScript) {
+        console.error('DB: saveScript failure with no Script');
+        aCallback('DB: saveScript failed to save flags in voteLib with no Script');
+        return;
+      }
+
+      aCallback(null);
+      return;
+    });
+    return;
+  }
+
+  flagLib.saveContent(Script, aScript, aAuthor, aFlags, false, function (aFlagged) {
+    aCallback(null);
+  });
+}
+exports.saveScript = saveScript;
+
+function newVote(aScript, aUser, aAuthor, aCasting, aCallback) {
+  var vote = new Vote({
+    vote: aCasting,
+    _scriptId: aScript._id,
+    _userId: aUser._id
+  });
+
+  vote.save(function (aErr, aNewVote) {
+    var flags = null;
+
+    if (aErr) {
+      console.error('DB: Failed to save new Vote', aErr);
+      aCallback(false);
+      return;
+    }
+
+    if (!aNewVote) {
+      console.error('DB: New vote not saved. aScript._id :=', aScript._id);
+      aCallback(false);
+      return;
+    }
+
+    aScript.rating += (aCasting ? 1 : -1);
+    aScript.votes = aScript.votes + (aCasting ? 1 : -1);
+    if (aCasting) {
+      flags = -1;
+    }
+
+    saveScript(aScript, aAuthor, flags, aCallback);
+  });
+}
+
+exports.unvote = function (aScript, aUser, aCallback) {
+  voteable(aScript, aUser, function (aCanVote, aAuthor, aVote) {
+    var votes = null;
+    var flags = null;
+    var casted = null;
+
+    if (!aCanVote || !aVote) {
+      aCallback(false);
+      return;
+    }
+    if (!aScript.rating) {
+      aScript.rating = 0;
+    }
+
+    if (!aScript.votes) {
+      aScript.votes = 0;
+    }
+
+    votes = aScript.votes;
+    flags = 0;
+    casted = aVote.vote;
+
+    aVote.remove(function (aErr, aRemovedVote) {
+      if (aErr) {
+        console.error('DB: Vote removal failure aErr :=', aErr);
+        aCallback(false);
+        return;
+      }
+
+      if (!aRemovedVote) {
+        console.error('DB: Nothing removed for Vote. aScript._id :=', aScript._id);
+        aCallback(false);
+        return;
+      }
+
+      aScript.rating += (casted ? -1 : 1);
+      aScript.votes = (votes <= 0 ? 0 : votes - 1);
+      if (casted) {
+        flags = 1;
+      }
+
+      saveScript(aScript, aAuthor, flags, aCallback);
+    });
+
+  });
+}
+
+function vote(aCasting, aScript, aUser, aCallback) {
+  voteable(aScript, aUser, function (aCanVote, aAuthor, aVote) {
+    var votes = null;
+    var flags = 0;
+
+    if (!aCanVote) {
+      aCallback(false);
+      return;
+    }
+
+    if (!aScript.rating) {
+      aScript.rating = 0;
+    }
+
+    if (!aScript.votes) {
+      aScript.votes = 0;
+    }
+
+    votes = aScript.votes;
+
+    if (aVote) {
+      if (aVote.vote !== aCasting) {
+        aVote.vote = aCasting;
+        aScript.rating += (aCasting ? 2 : -2);
+        aScript.votes = aScript.votes + (aCasting ? 2 : -2);
+        flags = aCasting ? -1 : 1;
+
+      }
+
+      aVote.save(function (aErr, aSavedVote) {
+        if (aErr) {
+          console.error('DB: Vote saving failure aErr :=', aErr);
+          aCallback(false);
+          return;
+        }
+
+        if (!aSavedVote) {
+          console.error('DB: Nothing saved for Vote. aScript._id :=', aScript._id);
+          return;
+        }
+
+        saveScript(aScript, aAuthor, flags, aCallback);
+      });
+
+    } else {
+      newVote(aScript, aUser, aAuthor, aCasting, aCallback);
+    }
+
+  });
+}
+
+exports.upvote = function (aScript, aUser, aCallback) {
+  vote(true, aScript, aUser, aCallback);
+}
+
+exports.downvote = function (aScript, aUser, aCallback) {
+  vote(false, aScript, aUser, aCallback);
+}
+

--- a/routes.js
+++ b/routes.js
@@ -15,6 +15,7 @@ var admin = require('./controllers/admin');
 var user = require('./controllers/user');
 var script = require('./controllers/script');
 var flag = require('./controllers/flag');
+var vote = require('./controllers/vote');
 var remove = require('./controllers/remove');
 var moderation = require('./controllers/moderation');
 var group = require('./controllers/group');
@@ -183,12 +184,10 @@ module.exports = function (aApp) {
   aApp.route('/mod/removed').get(authentication.validateUser, moderation.removedItemListPage);
   aApp.route('/mod/removed/:id').get(authentication.validateUser, moderation.removedItemPage);
 
-  // Vote routes
-  // TODO: Single vote route + POST
-  aApp.route('/vote/scripts/:username/:scriptname/:vote').get(authentication.validateUser, script.vote);
-  aApp.route('/vote/libs/:username/:scriptname/:vote').get(authentication.validateUser, script.lib(script.vote));
+  // Vote route
+  aApp.route(/^\/vote\/(users|scripts|libs)\/((.+?)(?:\/(.+))?)$/).post(authentication.validateUser, vote.vote);
 
-  // Flag routes
+  // Flag route
   aApp.route(/^\/flag\/(users|scripts|libs)\/((.+?)(?:\/(.+))?)$/).post(authentication.validateUser, flag.flag);
 
   // Remove route

--- a/views/includes/scriptModToolsPanel.html
+++ b/views/includes/scriptModToolsPanel.html
@@ -10,9 +10,11 @@
     {{#script}}
     {{> includes/flagModelSnippet.html }}
     {{/script}}
+    {{#canRemove}}
     <ul class="nav nav-pills nav-justified">
-      <li><a rel="nofollow" href="#" data-toggle="modal" data-target="#removeScriptModal" class="{{^canRemove}}disabled{{/canRemove}}"><i class="fa fa-ban"></i> Remove Script</a></li>
+      <li><a rel="nofollow" href="#" data-toggle="modal" data-target="#removeScriptModal"><i class="fa fa-ban"></i> Remove Script</a></li>
     </ul>
+    {{/canRemove}}
   </div>
 </div>
 {{/modTools}}

--- a/views/includes/scriptUserToolsPanel.html
+++ b/views/includes/scriptUserToolsPanel.html
@@ -2,8 +2,16 @@
   <div class="panel-body">
     <div class="row">
       <div class="pull-left vote-area">
-        <a rel="nofollow" href="{{^votedUp}}{{{voteUpUrl}}}{{/votedUp}}{{#votedUp}}{{{unvoteUrl}}}{{/votedUp}}" class="btn-vote {{^voteable}}disabled{{/voteable}} {{#votedUp}}active{{/votedUp}}"><i class="fa fa-2x fa-caret-up"></i></a>
-        <a rel="nofollow" href="{{^votedDown}}{{{voteDownUrl}}}{{/votedDown}}{{#votedDown}}{{{unvoteUrl}}}{{/votedDown}}" class="btn-vote {{^voteable}}disabled{{/voteable}} {{#votedDown}}active{{/votedDown}}"><i class="fa fa-2x fa-caret-down"></i></a>
+        {{#canVote}}
+        <form action="{{{script.scriptVotePageUrl}}}" method="post" enctype="multipart/form-data">
+          <input type="hidden" name="vote" value="{{^votedUp}}up{{/votedUp}}{{#votedUp}}un{{/votedUp}}">
+          <button class="btn-link btn-vote{{#votedUp}} active{{/votedUp}}" type="submit"><i class="fa fa-2x fa-caret-up"></i></button>
+        </form>
+        <form action="{{{script.scriptVotePageUrl}}}" method="post" enctype="multipart/form-data">
+          <input type="hidden" name="vote" value="{{^votedDown}}down{{/votedDown}}{{#votedDown}}un{{/votedDown}}">
+          <button class="btn-link btn-vote{{#votedDown}} active{{/votedDown}}" type="submit"><i class="fa fa-2x fa-caret-down"></i></button>
+        </form>
+        {{/canVote}}
       </div>
       <p><i class="fa fa-fw fa-heartbeat"></i> <b>Rating:</b> {{script.rating}}</p>
       <div class="progress">
@@ -18,11 +26,11 @@
           {{#flagged}}
           <form action="{{{script.scriptFlagPageUrl}}}" method="post" enctype="multipart/form-data">
             <input type="hidden" name="flag" value="false">
-            <button class="btn btn-link" type="submit" class="{{^canFlag}} disabled{{/canFlag}}" title="Unflag from moderation review"><i class="fa fa-fw fa-flag"></i> Unflag</button>
+            <button class="btn btn-link" type="submit" title="Unflag from moderation review"><i class="fa fa-fw fa-flag"></i> Unflag</button>
           </form>
           {{/flagged}}
           {{^flagged}}
-          <a rel="nofollow" href="#" data-toggle="modal" data-target="#flagScriptModal" class="{{^canFlag}}disabled{{/canFlag}}" title="Flag for moderation review"><i class="fa fa-flag-o"></i> Flag</a>
+          <a rel="nofollow" href="#" data-toggle="modal" data-target="#flagScriptModal" title="Flag for moderation review"><i class="fa fa-flag-o"></i> Flag</a>
           {{/flagged}}
         </div>
       </li>

--- a/views/includes/userModToolsPanel.html
+++ b/views/includes/userModToolsPanel.html
@@ -10,9 +10,11 @@
     {{#user}}
     {{> includes/flagModelSnippet.html }}
     {{/user}}
+    {{#canRemove}}
     <ul class="nav nav-pills nav-justified">
-      <li><a rel="nofollow" href="#" data-toggle="modal" data-target="#removeUserModal" class="{{^canRemove}}disabled{{/canRemove}}"><i class="fa fa-ban"></i> Remove User</a></li>
+      <li><a rel="nofollow" href="#" data-toggle="modal" data-target="#removeUserModal"><i class="fa fa-ban"></i> Remove User</a></li>
     </ul>
+    {{/canRemove}}
   </div>
 </div>
 {{/modTools}}


### PR DESCRIPTION
* Script up to down or down to up improperly counts script votes and messes up good/bad bar. Shouldn't affect Rating in Script or Group but will recheck a few.
* At the same time move to MVC *(Currently isolated to Script e.g. parallel change)*... Fixes TODO in routes.js
* Some styleguide.md conformance
* Simplify some views. e.g. turn some things off when they aren't able to be used. Save b/w and possibly improve understanding for most
* Still would prefer returning `err` *(aErr)* with libs but that's probably a separate PR since there are still inconsistent return callback parms
* Some filling in for #1548
* Some additions for #430. e.g. we want to know if a DB action fails currently

NOTES:
* Structure mirrored and altered from `flagsLib`
Applies to #262 and Active Maintainer override (Sorry sizzle but needed to be done so it doesn't mess up other areas down the line)
* Will run through scripts and mitigate any script `votes` counts.