### PR TITLE
Migrate to *node*@12.0.0

### DIFF
--- a/app.js
+++ b/app.js
@@ -279,6 +279,9 @@ if (isSecured) {
     cert: fs.readFileSync(fullchain, 'utf8'),
     ca: fs.readFileSync(chain, 'utf8'),
     ciphers: [
+      'TLS_AES_256_GCM_SHA384',
+      'TLS_CHACHA20_POLY1305_SHA256',
+      'TLS_AES_128_GCM_SHA256',
       'ECDHE-RSA-AES128-GCM-SHA256',
       'ECDHE-ECDSA-AES128-GCM-SHA256',
       'ECDHE-RSA-AES256-GCM-SHA384',
@@ -301,8 +304,7 @@ if (isSecured) {
       '!SRP',
       '!CAMELLIA'
     ].join(':'),
-    honorCipherOrder: true,
-    secureOptions: crypto.constants.SSL_OP_NO_TLSv1
+    honorCipherOrder: true
   };
 
   try {

--- a/package.json
+++ b/package.json
@@ -82,8 +82,8 @@
     "clean": "node dev/clean.js"
   },
   "engines": {
-    "node": ">=11.6.0 <12.0.0",
-    "npm": ">=6.5.0"
+    "node": ">=12.0.0 <13.0.0",
+    "npm": ">=6.9.0"
   },
   "private": true
 }


### PR DESCRIPTION
* Adjust default cipher order to match. Support for TLS 1.3 is added in this version.
* Remove restriction on TLSv1.0 since it's presumably disabled by default.

NOTE:
* This is about a year early from the March-April'ish 2020 recommended deadline.