### PR TITLE
Always show the comment reply form

### DIFF
--- a/views/includes/commentForm.html
+++ b/views/includes/commentForm.html
@@ -26,7 +26,7 @@
               <div class="submit-panel btn-toolbar">
                 <a href="/about/Frequently-Asked-Questions"><i class="fa fa-question-circle" title="FAQ"></i></a>
                 <a href="https://guides.github.com/features/mastering-markdown/"><i class="octicon octicon-markdown" title="GitHub Flavor Markdown compatible"></i></a>
-                <button class="btn-sm btn btn-success pull-right" type="submit"><i class="fa fa-reply"></i> Reply</button>
+                <button class="btn-sm btn btn-success pull-right" type="submit" {{^authedUser}}disabled="disabled"{{/authedUser}}><i class="fa fa-reply"></i> Reply</button>
               </div>
             </div>
           </form>

--- a/views/pages/discussionPage.html
+++ b/views/pages/discussionPage.html
@@ -36,11 +36,9 @@
                   </div>
                   {{/paginationRendered}}
                 </section>
-                {{#authedUser}}
                 <section class="topic-area list-group">
                     {{> includes/commentForm.html }}
                 </section>
-                {{/authedUser}}
               </div>
             </div>
           </div>
@@ -57,10 +55,8 @@
     {{> includes/scripts/showTopPagination.html }}
   {{/paginationRendered}}
   {{> includes/scripts/formControlClear.html }}
-  {{#authedUser}}
-    {{> includes/scripts/markdownEditor.html }}
-    {{> includes/scripts/commentReplyScript.html }}
-  {{/authedUser}}
+  {{> includes/scripts/markdownEditor.html }}
+  {{> includes/scripts/commentReplyScript.html }}
   {{^authedUser}}
     {{> includes/scripts/commentReplyTooltip.html }}
   {{/authedUser}}

--- a/views/pages/scriptIssuePage.html
+++ b/views/pages/scriptIssuePage.html
@@ -79,10 +79,8 @@
   {{/paginationRendered}}
   {{> includes/scripts/lazyIconScript.html }}
   {{> includes/scripts/formControlClear.html }}
-  {{#authedUser}}
-    {{> includes/scripts/markdownEditor.html }}
-    {{> includes/scripts/commentReplyScript.html }}
-  {{/authedUser}}
+  {{> includes/scripts/markdownEditor.html }}
+  {{> includes/scripts/commentReplyScript.html }}
   {{^authedUser}}
     {{> includes/scripts/commentReplyTooltip.html }}
   {{/authedUser}}


### PR DESCRIPTION
* Allows some browser back button to work in certain browsers due to logoff condition. Edge use case.

NOTE:
* This is a **work-around** for those browsers not implementing back-browser action in a consistent non-destructive manner. Currently present in Chromium back-ends but not Mozilla based or Safari based. Nice inconsistency google! Perhaps this is a bug to add to their collection. Probable refetch instead of cache pull *(and listen)* in those affected browsers which can be another imposed DoS vector.
* No known current way, w/o additional DoS vector added, to address for newTopic logoff condition e.g. out of luck atm.

Post #1204

Refs:
* https://openuserjs.org/scripts/AltoRetrato/IMDb_My_Movies_enhancer/issues/does_it_still_work!#comment-16af97e508e *(subtle report not yet done on development)*
* https://stackoverflow.com/questions/39920118/chrome-forces-page-refresh-on-window-history-back *(unanswered and long time issue)*
* https://github.com/OpenUserJS/OpenUserJS.org/issues/1548#issuecomment-474667560  *(about:flags note ... perhaps there is another one to disable bad browser acting)*