### PR TITLE
A dep update/change

### DIFF
--- a/controllers/scriptStorage.js
+++ b/controllers/scriptStorage.js
@@ -128,12 +128,11 @@ if (isPro) {
 } else {
   DEV_AWS_URL = process.env.DEV_AWS_URL || 'http://localhost:10001';
   AWS.config.update({
-    accessKeyId: 'fakeId',
-    secretAccessKey: 'fakeKey',
-    httpOptions: {
-      proxy: DEV_AWS_URL,
-      agent: http.globalAgent
-    }
+    accessKeyId: 'S3RVER',
+    secretAccessKey: 'S3RVER',
+    endpoint: DEV_AWS_URL,
+    sslEnabled: false,
+    s3ForcePathStyle: true
   });
 
   devAWSURL = new URL(DEV_AWS_URL);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "OpenUserJS.org",
   "description": "An open source user scripts repo built using Node.js",
-  "version": "0.2.5",
+  "version": "0.3.0",
   "main": "app",
   "dependencies": {
     "ace-builds": "git://github.com/ajaxorg/ace-builds.git#5fe4368",
@@ -56,7 +56,7 @@
     "rate-limit-mongo": "1.0.3",
     "request": "2.88.0",
     "rfc2047": "2.0.1",
-    "s3rver": "2.2.9",
+    "s3rver": "3.2.0",
     "sanitize-html": "1.20.1",
     "select2": "3.5.2-browserify",
     "select2-bootstrap-css": "1.4.6",


### PR DESCRIPTION
* Force update *s3rver* migration
* This is a breaking change for dev. Project version bump. All dev sources previously there must be reimported/rewritten/reuploaded *(again, from when we left *fakes3* in #1520 )*. e.g. this is not forward or backward compatible.
* Bucket configuration and CORS config doesn't appear to be needed on *s3rver*

NOTES:
* Untested on pro but should probably work since it's been working this way. Dev Source Code tab pulls and no bucket errs. Will test momentarily on pro to ensure it is 100%.
* Documentation is still dispersed for this dependency and partially pulled from example folder
* Seems to be more inline with pro options for *aws-sdk*