### PR TITLE
Rollback back-end *node* engine support to LTS

### DIFF
--- a/app.js
+++ b/app.js
@@ -74,8 +74,9 @@ if (isPro) {
     reconnectInterval: 1000,
     family: 4,
 
-    useNewUrlParser: true,  // #1516
-    useFindAndModify: false // #1516
+    useNewUrlParser: true,   // #1516
+    useFindAndModify: false, // #1516
+    useCreateIndex: true     // #1516
   }
 } else {
   dbOptions = {
@@ -84,8 +85,9 @@ if (isPro) {
     reconnectInterval: 1000,
     family: 4,
 
-    useNewUrlParser: true,  // #1516
-    useFindAndModify: false // #1516
+    useNewUrlParser: true,   // #1516
+    useFindAndModify: false, // #1516
+    useCreateIndex: true     // #1516
   }
 }
 
@@ -310,7 +312,8 @@ if (isSecured) {
       '!SRP',
       '!CAMELLIA'
     ].join(':'),
-    honorCipherOrder: true
+    honorCipherOrder: true,
+    secureOptions: crypto.constants.SSL_OP_NO_TLSv1_1 | crypto.constants.SSL_OP_NO_TLSv1
   };
 
   try {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "clean": "node dev/clean.js"
   },
   "engines": {
-    "node": ">=12.0.0 <13.0.0",
+    "node": ">=10.16.0 <11.0.0",
     "npm": ">=6.9.0"
   },
   "private": true


### PR DESCRIPTION
* Keeping applicable TLS restricted for eventual 12.x+ compatibility
* Search query *(modelQuery)* on, at the very least, `about` field causes maximum CPU usage in *node*@12.0.0 through *node*@12.5.0 but not v11.x or v10.x. This causes severe lag for everyone up to observed sustained 20+ seconds on queries.
* Restarting and exposing with transforming to secondary indexing for Script model as per all [*mongoose*/MongoDB documentation](https://mongoosejs.com/docs/guide.html#indexes). Use `syncIndexes` to maintain DB indexes.
* Squash new deprecation warning for #1516

NOTES:
* This is going to be a major issue when v10.x is EOL'd if *node* and related dep issues *(mongoose, mongodb)* aren't resolved
* For some reason *mongoose* is emitting the `index` event twice when used globally... unknown reason atm. Picking local disable in favor.

Applies to #1548 and post #1603 with observed issue since then.

Refs:
* https://mongoosejs.com/docs/guide.html#indexes

Dev startup:

``` console
$ node app.js
Starting application...
Disabling GitHub `hooks` in unsecure mode
S3rver initialized
error: Error creating bucket. Bucket "openuserjs.org" already exists
info: PUT /openuserjs.org 409 11ms -
Default dev S3 bucket already exists
MongoDB connection is opened
Connected to MongoDB v3.6.12
GitHub client authenticated
Index event triggered/trapped for Script model
Script indexes:
 [ { v: 2,
    key: { _id: 1 },
    name: '_id_',
    ns: 'openuserjs_devel.scripts' },
  { v: 2,
    key: { _authorId: 1, flagged: 1, isLib: 1 },
    name: '_authorId_1_flagged_1_isLib_1',
    ns: 'openuserjs_devel.scripts',
    background: true },
  { v: 2,
    key: { installName: 1 },
    name: 'installName_1',
    ns: 'openuserjs_devel.scripts',
    background: true },
  { v: 2,
    key: { isLib: 1, author: 1, name: 1 },
    name: 'isLib_1_author_1_name_1',
    ns: 'openuserjs_devel.scripts',
    background: true } ]
```

Recent db stats:

``` console
> db.scripts.aggregate( [ { $indexStats: { } } ] );
{ "name" : "_id_", "key" : { "_id" : 1 }, "host" : "<db>:<port>", "accesses" : { "ops" : NumberLong(12842), "since" : ISODate("2019-06-27T04:10:25.453Z") } }
{ "name" : "isLib_1_author_1_name_1", "key" : { "isLib" : 1, "author" : 1, "name" : 1 }, "host" : "<db>:<port>", "accesses" : { "ops" : NumberLong(7348), "since" : ISODate("2019-06-27T12:26:13.574Z") } }
{ "name" : "installName_1", "key" : { "installName" : 1 }, "host" : "<db>:<port>", "accesses" : { "ops" : NumberLong(144052), "since" : ISODate("2019-06-27T04:10:25.453Z") } }
{ "name" : "_authorId_1_flagged_1_isLib_1", "key" : { "_authorId" : 1, "flagged" : 1, "isLib" : 1 }, "host" : "<db>:<port>", "accesses" : { "ops" : NumberLong(16691), "since" : ISODate("2019-06-27T04:10:25.453Z") } }
```