### PR TITLE
More limits (Plan B)

### DIFF
--- a/controllers/script.js
+++ b/controllers/script.js
@@ -324,7 +324,7 @@ exports.view = function (aReq, aRes, aNext) {
       function preRender() {
         if (script.groups) {
           pageMetadata(options, ['About', script.name, (script.isLib ? 'Libraries' : 'Userscripts')],
-            script.description, _.pluck(script.groups, 'name'));
+            script._description, _.pluck(script.groups, 'name'));
         }
       }
 
@@ -382,7 +382,7 @@ exports.view = function (aReq, aRes, aNext) {
 
       // Page metadata
       pageMetadata(options, ['About', script.name, (script.isLib ? 'Libraries' : 'Userscripts')],
-        script.description);
+        script._description);
       options.isScriptPage = true;
 
       // SearchBar
@@ -469,6 +469,7 @@ exports.edit = function (aReq, aRes, aNext) {
       } else if (typeof aReq.body.about !== 'undefined') {
         // POST
         aScript.about = aReq.body.about;
+        aScript._about = (aScript.about ? aScript.about.substr(0, 512) : null);
         scriptGroups = (aReq.body.groups || '');
         scriptGroups = scriptGroups.split(/,/);
         addScriptToGroups(aScript, scriptGroups, function () {

--- a/libs/modelParser.js
+++ b/libs/modelParser.js
@@ -266,6 +266,10 @@ var parseScript = function (aScript) {
         script.description = aElement.value;
       }
     });
+
+    if (script.description && script._description && script.description.length > script._description.length) {
+      script.hasLongDescription = true;
+    }
   }
 
   // Icons

--- a/libs/modelQuery.js
+++ b/libs/modelQuery.js
@@ -113,7 +113,7 @@ var parseModelListSearchQuery = function (aModelListQuery, aQuery, aSearchOption
 
 var parseScriptSearchQuery = function (aScriptListQuery, aQuery) {
   parseModelListSearchQuery(aScriptListQuery, aQuery, {
-    partialWordMatchFields: ['name', 'author', 'about', 'meta.UserScript.description.value'],
+    partialWordMatchFields: ['name', '_description', 'author', '_about' ],
     fullWordMatchFields: ['meta.UserScript.include.value', 'meta.UserScript.match.value']
   });
 };

--- a/models/script.js
+++ b/models/script.js
@@ -14,11 +14,13 @@ var Schema = mongoose.Schema;
 var scriptSchema = new Schema({
   // Visible
   name: String,
+  _description: String,
   author: String,
   installs: { type: Number, default: 0 },
   installsSinceUpdate: { type: Number, default: 0 },
   rating: Number,
   about: String,
+  _about: String,
   updated: Date,
   hash: String,
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "OpenUserJS.org",
   "description": "An open source user scripts repo built using Node.js",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "main": "app",
   "dependencies": {
     "ace-builds": "git://github.com/ajaxorg/ace-builds.git#7489e42",

--- a/views/includes/scriptList.html
+++ b/views/includes/scriptList.html
@@ -23,7 +23,7 @@
         <span class="script-version label label-default">{{value}}</span>
         {{/meta.UserScript.version}}
         <span class="inline-block">by <a href="{{{author.userPageUrl}}}">{{author.name}}</a></span>
-        {{#description}}<p>{{description}}</p>{{/description}}
+        {{#_description}}<p>{{_description}}{{#hasLongDescription}}<strong>&hellip;</strong>{{/hasLongDescription}}</p>{{/_description}}
       </td>
       {{^librariesOnly}}
       <td class="text-center td-fit">


### PR DESCRIPTION
* Limit a few more things to possibly curtail some 431's
* Ease up on MongoDB having issues with script querying and CPU load. Limit to first copied block of characters in `about`. This amount may get smaller and is currently in flux.
* Create new clipped searchable fields. I spent a lot of time to see if MongoDB/*mongoose* had a limiter on their indexer and couldn't find one so we get to do it manually.

NOTE:
* This will temporarily remove everyone's Summary but it will be manually migrated in the DB in a while. If you are impatient... edit your script *(no changes necessary)* and resave it... that will do the migration also.

Post #1628 and applies to #1548