### PR TITLE
Show script notices a little more prominently

### DIFF
--- a/views/includes/scriptList.html
+++ b/views/includes/scriptList.html
@@ -14,6 +14,7 @@
     {{#scriptList}}
     <tr class="tr-link">
       <td>
+        {{#showSourceNotices}}<span class="pull-right"><i class="fa fa-fw fa-exclamation-triangle" title="Source Code notices"></i></span>{{/showSourceNotices}}
         {{#_issueCount}}<span class="pull-right"><a href="{{{scriptIssuesPageUri}}}/open" title="Open issue discussions"><i class="fa fa-fw fa-commenting"></i>{{_issueCount}}</a></span>{{/_issueCount}}
         <span class="script-icon hidden-xs" {{#icon16Url}}data-icon-src="{{{icon16Url}}}" data-icon-size="16"{{/icon16Url}}>
           {{#isLib}}<i class="fa fa-fw fa-file-excel-o"></i>{{/isLib}}{{^isLib}}<i class="fa fa-fw fa-file-code-o"></i>{{/isLib}}

--- a/views/includes/scriptPageHeader.html
+++ b/views/includes/scriptPageHeader.html
@@ -2,21 +2,21 @@
   {{#isScriptPage}}
     {{^script.isLib}}
     <div class="btn-group pull-right">
-      <a href="{{{script.scriptInstallPageUrl}}}" class="btn btn-info">
+      <a href="{{{script.scriptInstallPageUrl}}}" class="btn btn-{{^script.showSourceNotices}}info{{/script.showSourceNotices}}{{#script.showSourceNotices}}warning{{/script.showSourceNotices}}">
         <i class="fa fa-download"></i> Install
       </a>
-      <button type="button" class="btn btn-info dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      <button type="button" class="btn btn-{{^script.showSourceNotices}}info{{/script.showSourceNotices}}{{#script.showSourceNotices}}warning{{/script.showSourceNotices}} dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         <span class="caret"></span>
         <span class="sr-only">Toggle Dropdown</span>
       </button>
       <ul class="dropdown-menu dropdown-menu-right">
         <li>
           <div class="btn-group btn-group-justified">
-            <a href="{{{script.scriptInstallPageXUrl}}}.min.user.js" class="btn btn-{{#script.showMinficationNotices}}warning{{/script.showMinficationNotices}}{{^script.showMinficationNotices}}primary{{/script.showMinficationNotices}}" title="EXPERIMENTAL INSTALLATION FORKING"><i class="fa fa-fw fa-download"></i> Install {{#script.hasAlternateDownloadURL}}once {{/script.hasAlternateDownloadURL}} with minification</a>
+            <a href="{{{script.scriptInstallPageXUrl}}}.min.user.js" class="btn btn-{{#script.showSourceNotices}}warning{{/script.showSourceNotices}}{{^script.showSourceNotices}}info{{/script.showSourceNotices}}" title="EXPERIMENTAL INSTALLATION FORKING"><i class="fa fa-fw fa-download"></i> Install {{#script.hasAlternateDownloadURL}}once {{/script.hasAlternateDownloadURL}} with minification</a>
           </div>
-          {{#script.showMinficationNotices}}
-          {{> includes/scriptPageHeaderMinificationNotices.html }}
-          {{/script.showMinficationNotices}}
+          {{#script.showSourceNotices}}
+          {{> includes/scriptPageHeaderSourceNotices.html }}
+          {{/script.showSourceNotices}}
         </li>
         <li role="separator" class="divider"></li>
         <li><a href="/about/Userscript-Beginners-HOWTO"><em class="fa fa-fw fa-question-circle"></em> Userscript Beginners HOWTO</a></li>
@@ -26,21 +26,21 @@
   {{/isScriptPage}}
   {{#isScriptViewSourcePage}}
     <div class="btn-group pull-right">
-      <a href="{{{script.scriptRawPageUrl}}}" class="btn btn-info">
+      <a href="{{{script.scriptRawPageUrl}}}" class="btn btn-{{^script.showSourceNotices}}info{{/script.showSourceNotices}}{{#script.showSourceNotices}}warning{{/script.showSourceNotices}}">
         <i class="fa fa-file-{{#script.isLib}}excel{{/script.isLib}}{{^script.isLib}}code{{/script.isLib}}-o"></i> Raw Source
       </a>
-      <button type="button" class="btn btn-info dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      <button type="button" class="btn btn-{{^script.showSourceNotices}}info{{/script.showSourceNotices}}{{#script.showSourceNotices}}warning{{/script.showSourceNotices}} dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         <span class="caret"></span>
         <span class="sr-only">Toggle Dropdown</span>
       </button>
       <ul class="dropdown-menu dropdown-menu-right">
         <li>
           <div class="btn-group btn-group-justified">
-            <a href="{{{script.scriptRawPageXUrl}}}" class="btn btn-{{#script.showMinficationNotices}}warning{{/script.showMinficationNotices}}{{^script.showMinficationNotices}}primary{{/script.showMinficationNotices}}" title="EXPERIMENTAL"><i class="fa fa-file-{{#script.isLib}}excel{{/script.isLib}}{{^script.isLib}}code{{/script.isLib}}-o"></i> Minified Source</a>
+            <a href="{{{script.scriptRawPageXUrl}}}" class="btn btn-{{#script.showSourceNotices}}warning{{/script.showSourceNotices}}{{^script.showSourceNotices}}info{{/script.showSourceNotices}}" title="EXPERIMENTAL"><i class="fa fa-file-{{#script.isLib}}excel{{/script.isLib}}{{^script.isLib}}code{{/script.isLib}}-o"></i> Minified Source</a>
           </div>
-          {{#script.showMinficationNotices}}
-          {{> includes/scriptPageHeaderMinificationNotices.html }}
-          {{/script.showMinficationNotices}}
+          {{#script.showSourceNotices}}
+          {{> includes/scriptPageHeaderSourceNotices.html }}
+          {{/script.showSourceNotices}}
         </li>
       </ul>
     </div>

--- a/views/includes/scriptPageHeaderSourceNotices.html
+++ b/views/includes/scriptPageHeaderSourceNotices.html
@@ -1,7 +1,12 @@
 <div class="alert alert-warning" role="alert">
+  {{#script.hasInvalidUpdateURL}}
+    <p>
+      <i class="fa fa-fw fa-exclamation-triangle"></i> Invalid update target
+    </p>
+  {{/script.hasInvalidUpdateURL}}
   {{#script.hasInvalidDownloadURL}}
     <p>
-      <i class="fa fa-fw fa-exclamation"></i> Invalid download target
+      <i class="fa fa-fw fa-exclamation-triangle"></i> Invalid download target
     </p>
   {{/script.hasInvalidDownloadURL}}
   {{#script.hasUnstableMinify}}

--- a/views/pages/scriptPage.html
+++ b/views/pages/scriptPage.html
@@ -18,7 +18,7 @@
               <div class="input-group col-xs-12">
                 <span class="input-group-btn">
                   <button class="btn btn-info" id="require-raw" data-clipboard-text="// @require {{{script.scriptPermalinkInstallPageUrl}}}" title="Copy key and raw URL to clipboard"><i class="octicon octicon-clippy"></i> // @require</button>
-                  <button class="btn btn-warning" id="require-min" data-clipboard-text="// @require {{{script.scriptPermalinkInstallPageXUrl}}}.min.js" title="EXPERIMENTAL: Copy key and minified URL to clipboard"><i class="octicon octicon-clippy"></i></button>
+                  <button class="btn btn-info" id="require-min" data-clipboard-text="// @require {{{script.scriptPermalinkInstallPageXUrl}}}.min.js" title="EXPERIMENTAL: Copy key and minified URL to clipboard"><i class="octicon octicon-clippy"></i></button>
                 </span>
                 <input type="text" class="form-control" id="require" value="{{{script.scriptPermalinkInstallPageUrl}}}" readonly="readonly">
               </div>


### PR DESCRIPTION
* Change a few classes around for UI coloring and display
* Shows exclamation on script homepage and script lists that there **may** be user initiated, system initiated, etc. notices on the Install button or Raw Source button e.g. the Source Code tab contents.
* Few mustache identifier name changes for symmetry

Applies to #1548 #432