### PR TITLE
Repair some meta and relax detection a bit.

### DIFF
--- a/controllers/scriptStorage.js
+++ b/controllers/scriptStorage.js
@@ -92,6 +92,15 @@ if (!mediaDB['image/jxr']) {
   });
 }
 
+// Allow some Chromium based browsers to test
+if (!mediaDB['application/signed-exchange']) {
+  mediaDB = _.extend(mediaDB, {
+    'application/signed-exchange' : {
+      source: 'google',
+      extensions: []
+    }
+  });
+}
 
 if (!mediaDB['*/*']) {
   mediaDB = _.extend(mediaDB, {'*/*' : { source: 'iana'}});
@@ -550,7 +559,7 @@ exports.sendScript = function (aReq, aRes, aNext) {
     let matches = null;
     let rAnyLocalMetaUrl = new RegExp(
       '^' + patternHasSameOrigin +
-        '/(?:meta|install|src/scripts)/(.+?)/(.+?)\.meta\.js$'
+        '/(?:meta|install|src/scripts)/(.+?)/(.+?)\.(?:meta|user)\.js$'
     );
     let hasAlternateLocalUpdateURL = false;
 

--- a/libs/modelParser.js
+++ b/libs/modelParser.js
@@ -233,7 +233,7 @@ var parseScript = function (aScript) {
   );
   var rAnyLocalMetaUrl = new RegExp(
     '^' + patternHasSameOrigin +
-      '/(?:meta|install|src/scripts)/(.+?)/(.+?)\.meta\.js$'
+      '/(?:meta|install|src/scripts)/(.+?)/(.+?)\.(?:meta|user)\.js$'
   );
 
   var rSameOrigin =  new RegExp(


### PR DESCRIPTION
* Chromium 75.0.3770.90 started spewing this out and it's not in *mime-db* dep (yet?)... Relates to `/install/<username>/<scriptname>.meta.js`. Don't think it has an extension spec based off skimming doc
* Relaxing is temporary atm in lieu of more aggressive re

Post #1633 #1632 #944 and applies to #1548 #432