### PR TITLE
Enable default to Mozilla JS *(5.1) syntax

### DIFF
--- a/views/includes/scripts/scriptEditor.html
+++ b/views/includes/scripts/scriptEditor.html
@@ -357,6 +357,7 @@
                 // See https://jshint.com/docs/options/
                 'newcap': false,
                 'sub': true,
+                'moz': true,
                 'globals': globals
               }]);
             }


### PR DESCRIPTION
* Since JavaScript 1.7 *(the form before ES6)* has been around since about 2006 and GM is nearby to that (2005 03 28).
* Adding the `/* jshint esversion: 6 */` is compatible with the arrow `=>` and this setting.

NOTES:
* Eliminates `let`, destructuring, and a few others... See https://developer.mozilla.org/docs/Web/JavaScript/New_in_JavaScript/1.7

Post #1641