### PR TITLE
More JSHint opts

### DIFF
--- a/views/includes/scripts/scriptEditor.html
+++ b/views/includes/scripts/scriptEditor.html
@@ -359,7 +359,9 @@
                 'globals': globals,
                 'moz': true,
                 'newcap': false,
-                'sub': true
+                'sub': true,
+                '-I003': true, // "ES5 option is now set per default"
+                '-W014': true  // "Bad line breaking before '{a}'."
               }]);
             }
           }


### PR DESCRIPTION
* Perfectly acceptable to use newline then operator e.g. `+` or `?` with `:` pairing
* Disable default of ES5 message

NOTE:
* I could do this all day and night but just getting some of the most common triangles quieted. Plus Ace *(ace-builds)* is behind on JSHint inclusion that EOL's some that have been observed e.g. `I003`

Post #1641