### PR TITLE
Disable `Bad escaping of EOL. Use option multistr if needed.`

### DIFF
--- a/views/includes/scripts/scriptEditor.html
+++ b/views/includes/scripts/scriptEditor.html
@@ -362,7 +362,8 @@
                 'eqnull': true,
                 'sub': true,
                 '-I003': true, // "ES5 option is now set per default"
-                '-W014': true  // "Bad line breaking before '{a}'."
+                '-W014': true, // "Bad line breaking before '{a}'."
+                '-W043': true  // "Bad escaping of EOL. Use option multistr if needed.",
               }]);
             }
           }


### PR DESCRIPTION
* Multi-line strings like this, especially in the original JavaScript spec, are still valid and supported although Template Literals (Strings) are a bit easier to read. e.g. don't nag with this.


Post #1641