### PR TITLE
Change beautify

### DIFF
--- a/views/includes/scripts/scriptEditor.html
+++ b/views/includes/scripts/scriptEditor.html
@@ -96,7 +96,8 @@
       }
 
       function beautifyThis(aString) {
-        return js_beautify(aString.replace(/[“”]/g, '"').replace(/\t/g, '  '), {
+        return js_beautify(aString.replace(/\t/g, '  '), {
+
           indent_size: 2,
           indent_char: ' ',
           max_preserve_newlines: 2,


### PR DESCRIPTION
* This replacement doesn't appear to be needed anymore. JSHint picks up on it too.

NOTE:
* If re-needed utilize `.replace(/\u201C/g, '\\u201C').replace(/\u201D/g, '\\u201D')`

Post #437