### PR TITLE
GDPR14

### DIFF
--- a/libs/passportVerify.js
+++ b/libs/passportVerify.js
@@ -80,7 +80,7 @@ exports.verify = function (aId, aStrategy, aUsername, aLoggedIn, aDone) {
                 'name': aUsername,
                 'auths': [digest],
                 'strategies': [aStrategy],
-                'role': userRoles.length - 1,
+                'role': userRoles.length - 2,  // NOTE: Last array element value is system Reserved
                 'about': '',
                 'ghUsername': null
               });

--- a/models/userRoles.json
+++ b/models/userRoles.json
@@ -4,5 +4,6 @@
   "Admin",
   "Moderator",
   "Author",
-  "User"
+  "User",
+  "Reserved"
 ]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "OpenUserJS.org",
   "description": "An open source user scripts repo built using Node.js",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "main": "app",
   "dependencies": {
     "ace-builds": "git://github.com/ajaxorg/ace-builds.git#7489e42",

--- a/views/includes/documents/Terms-of-Service.md
+++ b/views/includes/documents/Terms-of-Service.md
@@ -33,7 +33,8 @@ Within moderation we understand the occasional necessity to conserve device stor
 
 #### Reserved Rights
 
-* OpenUserJs.org reserves including but not limited to the implied right to publish, distribute, and terminate access to your published works and code snippets to maintain the integrity of OpenUserJS.org.
+* OpenUserJs.org reserves including, but not limited to, the implied right to publish, distribute, and terminate access to your published works and code snippets to maintain the integrity of OpenUserJS.org.
+* OpenUserJS.org reserves the right to rename, or remove, your account. Usually this action is in the event a naming conflict.
 * OpenUserJs.org allows all published works on OpenUserJS.org to be forked via OpenUserJS.org forking capabilities.
 
 #### Fair Use Rationale


### PR DESCRIPTION
* Create system reserved role type
* Bump DB/project version as this is not backwards compatible and a breaking change
* Amend TOS for an explicit instead of implied reserved right for renaming access. This is useful to notify the author including possible account name change requests.
* When OUJS needs to reserve a future (or current) specific name to continue the Sites integrity, especially from "bad actors", this is useful to have for a reservation with rename. Perhaps useful later on as well for some additional feature. These instance should be rare but declare none-the-less.

Post #1137 #735 *(inverse)*