### PR TITLE
A dep update with migration bug fixes

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -1679,7 +1679,9 @@ exports.uploadScript = function (aReq, aRes, aNext) {
     }
 
     // Reject non-js file
+    console.log(script.type);
     switch (script.type) {
+      case 'application/x-javascript': // #872 #1661
       case 'application/javascript':   // #1599
       case 'text/javascript':          // Default
         break; // Acceptable
@@ -2020,7 +2022,10 @@ exports.editScript = function (aReq, aRes, aNext) {
 
   function asyncComplete(aErr) {
     if (aErr) {
-      aNext();
+      statusCodePage(aReq, aRes, aNext, {
+        statusCode: (aErr instanceof statusError ? aErr.status.code : aErr.code),
+        statusMessage: (aErr instanceof statusError ? aErr.status.message : aErr.code)
+      });
       return;
     }
 
@@ -2049,7 +2054,12 @@ exports.editScript = function (aReq, aRes, aNext) {
   tasks.push(function (aCallback) {
     getExistingScript(aReq, options, authedUser, function (aOpts) {
       options = aOpts;
-      aCallback(!aOpts);
+
+      aCallback(!aOpts ? new statusError({
+        message: 'Error while getting existing script.',
+        code: 500
+      }) : null);
+
     });
   });
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "ace-builds": "git://github.com/ajaxorg/ace-builds.git#7489e42",
     "ansi-colors": "4.1.1",
-    "async": "2.6.2",
+    "async": "3.1.0",
     "aws-sdk": "2.513.0",
     "base62": "2.0.1",
     "body-parser": "1.19.0",


### PR DESCRIPTION
* *async*@3.x migration
* Using a more applicable statusCodePage for DB S3 connection issue... the error message is still rather vague since it's abstracted several times between function calls but was tested and landed on 404 during *fakeS3* usage. At some point when all callback signatures can be set to `aErr`, `aResults` this should be more explicit... until then preserving existing vagueness.
* Revert #1599 as Fx still uses this in 68.x. TLSv1 EOL will still prevent Opera Presto from even visiting the site.

NOTES:
* Apparently version 3.x migration is extremely picky now about how Err is generated. i.e. it doesn't allow `true`/`false` anymore like it did in version 2.x. This causes the request to never complete with `async.parallel`. The web spinner and no source is retrieved even though **it was successfully retrieved**.
* Been probing/testing dev manually and it seems to be non-sluggish atm with Fx 68.x... perhaps a change from 3.0 to 3.1 of this dep... or even Chromium report since distro version is/was a bit buggy at the time of testing.

Post #1607 #1520