### PR TITLE
Add a generic UA for sites that are being picky

### DIFF
--- a/controllers/scriptStorage.js
+++ b/controllers/scriptStorage.js
@@ -1516,7 +1516,12 @@ exports.storeScript = function (aUser, aMeta, aBuf, aUpdate, aCallback) {
           }
         } else {
           chunks = [];
-          req = request.get(icon)
+          req = request.get({
+            url: icon,
+            headers: {
+              'User-Agent': 'request'
+            }
+          })
             .on('response', function (aRes) {
               // TODO: Probably going to be something here
             })


### PR DESCRIPTION
NOTE:
* This could potentially still throw ECONNRESET if that server blocks `request`. This is called browser sniffing and usually isn't a wise thing to do. Not sure if all nginx servers do this.

Applies to https://openuserjs.org/garage/Cant_add_my_script