### PR TITLE
Another loosely related same topic url collision check

### DIFF
--- a/controllers/discussion.js
+++ b/controllers/discussion.js
@@ -469,6 +469,12 @@ function postTopic(aUser, aCategory, aTopic, aContent, aIssue, aUserAgent, aCall
     return;
   }
 
+  // Retest for trailing underscore with numeric digits with cleaned and reject
+  if( /_\d+$/.test(urlTopic)) {
+    aCallback();
+    return;
+  }
+
   Discussion.findOne({ path: path }, null, params, function (aErr, aDiscussion) {
     var newDiscussion = null;
     var props = {

--- a/public/css/common.css
+++ b/public/css/common.css
@@ -200,6 +200,7 @@ textarea {
 }
 
 input#discussion-topic {
+  display: inline-block;
   width: calc(100% - 18px - 4px);
 }
 

--- a/views/pages/newDiscussionPage.html
+++ b/views/pages/newDiscussionPage.html
@@ -17,7 +17,7 @@
                 <ol class="breadcrumb col-xs-12">
                   <li><a href="/forum">Forum</a></li>
                   <li><a href="{{{category.categoryPageUrl}}}">{{category.name}}</a></li>
-                  <li><input type="text" id="discussion-topic" name="discussion-topic" size="60" placeholder="Topic" required="required"></li>
+                  <li><input type="text" class="form-control" id="discussion-topic" name="discussion-topic" size="100" placeholder="Topic" required="required" maxlength="100"></li>
                 </ol>
               </div>
               <div class="container-fluid comments">

--- a/views/pages/scriptNewIssuePage.html
+++ b/views/pages/scriptNewIssuePage.html
@@ -18,7 +18,7 @@
                   <li><a href="{{{script.scriptPageUrl}}}">{{script.name}}</a></li>
                   <li><a href="{{{category.categoryPageUrl}}}">{{category.name}}</a></li>
                   <li class="col-xs-12">
-                    <input type="text" id="discussion-topic" name="discussion-topic" size="60" placeholder="Topic" required="required">
+                    <input type="text" class="form-control" id="discussion-topic" name="discussion-topic" size="100" placeholder="Topic" required="required" maxlength="100">
                   </li>
                 </ol>
               </div>


### PR DESCRIPTION
* Stumbled upon this accidentally on dev
* Denote topic length with `maxlength`... this doesn't always prevent in every browser atm but we check manually w cleaned. Post #1608
* *bootstrap*ify the inputs for topic and increase their size to maxlength

NOTE:
* Signature callback really needs to be normalized to `aErr`, `aResult` so we can create some statusError at some point instead of general redirections. i.e. inform the user what they did incorrectly

Post #350