### PR TITLE
If prior turn on notices were set retain setting

### DIFF
--- a/libs/modelParser.js
+++ b/libs/modelParser.js
@@ -529,7 +529,9 @@ var parseScript = function (aScript) {
             );
 
             script.showSourceNotices = true;
-            script.showSourceNoticesCritical = updateURLForceCheck;
+            script.showSourceNoticesCritical = script.showSourceNoticesCritical
+              ? true
+              : updateURLForceCheck;
           }
         } else {
           // Allow offsite checks
@@ -570,8 +572,10 @@ var parseScript = function (aScript) {
           : script.hasInvalidUpdateURL
       );
 
-      script.showSourceNotices = updateURLForceCheck;
-      script.showSourceNoticesCritical = updateURLForceCheck;
+      script.showSourceNotices = script.showSourceNotices ? true : updateURLForceCheck;
+      script.showSourceNoticesCritical = script.showSourceNoticesCritical
+        ? true
+        : updateURLForceCheck;
     }
   }
 

--- a/views/includes/scriptPageHeaderSourceNotices.html
+++ b/views/includes/scriptPageHeaderSourceNotices.html
@@ -5,7 +5,7 @@
     </p>
   {{/script.hasInvalidUpdateURL}}
   {{#script.hasAlternateUpdateURL}}
-    <p{{^isScriptViewSourcePage}} title="{{script.meta.UserScript.updateURL.0.value}}"{{/isScriptViewSourcePage}}>
+    <p title="{{script.meta.UserScript.updateURL.0.value}}">
       <i class="fa fa-fw fa-exclamation-triangle"></i> Alternate update check target.
     </p>
   {{/script.hasAlternateUpdateURL}}
@@ -15,12 +15,12 @@
     </p>
   {{/script.hasInvalidDownloadURL}}
   {{#script.hasAlternateDownloadURL}}
-    <p{{^isScriptViewSourcePage}} title="{{script.meta.UserScript.downloadURL.0.value}}"{{/isScriptViewSourcePage}}>
+    <p title="{{script.meta.UserScript.downloadURL.0.value}}">
       <i class="fa fa-fw fa-exclamation-triangle"></i> Alternate download source target.
     </p>
   {{/script.hasAlternateDownloadURL}}
   {{#script.hasUnstableMinify}}
-    <p{{^isScriptViewSourcePage}} title="{{script.meta.OpenUserJS.unstableMinify.0.value}}"{{/isScriptViewSourcePage}}>
+    <p title="{{script.meta.OpenUserJS.unstableMinify.0.value}}">
       <i class="fa fa-fw fa-exclamation-triangle"></i> The script author suggests that minification of this script may be unstable.
     <p>
   {{/script.hasUnstableMinify}}


### PR DESCRIPTION
* Also don't presume that metadata blocks are at the beginning *(easily findable)* and always set the tooltip.

NOTE:
* Fixes notice non-display of https://openuserjs.org/scripts/jesus2099/mb._MASS_MERGE_RECORDINGS

Post #1632