### PR TITLE
Add `@downloadURL` common values to Script Author Tools

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -2076,6 +2076,7 @@ exports.editScript = function (aReq, aRes, aNext) {
         var script = null;
         var scriptOpenIssueCountQuery = null;
         var collaborators = null;
+        var downloadURL = null;
         var licenses = null;
         var licensePrimary = null;
         var copyrights = null;
@@ -2125,18 +2126,64 @@ exports.editScript = function (aReq, aRes, aNext) {
           || collaborators.indexOf(authedUser.name) > -1);
         modelParser.renderScript(script);
         script.installNameSlug = installNameBase;
+
         script.scriptPermalinkInstallPageUrl = 'https://' + aReq.get('host') +
           script.scriptInstallPageUrl;
-        script.scriptPermalinkInstallPageXUrl = 'https://' + aReq.get('host') +
-          script.scriptInstallPageXUrl;
+        script.scriptPermalinkInstallPageUrlMin = 'https://' + aReq.get('host') +
+          script.scriptInstallPageXUrl + ".min.user.js";
+
         script.scriptRawPageUrl = '/src/' + (isLib ? 'libs' : 'scripts') + '/' +
           scriptStorage.getInstallNameBase(aReq, { encoding: 'uri' }) +
-            (isLib ? '.js#' : '.user.js#');
+            (isLib ? '.js' : '.user.js');
         script.scriptRawPageXUrl = '/src/' + (isLib ? 'libs' : 'scripts') + '/' +
           scriptStorage.getInstallNameBase(aReq, { encoding: 'uri' }) +
-            (isLib ? '.min.js#' : '.min.user.js#');
+            (isLib ? '.min.js' : '.min.user.js');
+
+        script.scriptPermalinkRawPageUrl = 'https://' + aReq.get('host') +
+          script.scriptRawPageUrl;
+        script.scriptPermalinkRawPageUrlMin = 'https://' + aReq.get('host') +
+          script.scriptRawPageXUrl;
+
         script.scriptPermalinkMetaPageUrl = 'https://' + aReq.get('host') +
           script.scriptMetaPageUrl;
+
+        script.availableScriptPermalinkInstallPageUrl = [];
+
+        downloadURL = scriptStorage.findMeta(script.meta, 'UserScript.downloadURL.0.value');
+        if (downloadURL) {
+          switch (downloadURL) {
+            case script.scriptPermalinkInstallPageUrl:
+              /* falls through */
+            case script.scriptPermalinkInstallPageUrlMin:
+              /* falls through */
+            case script.scriptPermalinkRawPageUrl:
+              /* falls through */
+            case script.scriptPermalinkRawPageUrlMin:
+              break;
+            default:
+              script.availableScriptPermalinkInstallPageUrl.push({
+                label: 'Custom',
+                url: downloadURL
+              });
+          }
+        }
+        script.availableScriptPermalinkInstallPageUrl.push({
+          label: 'Normal',
+          url: script.scriptPermalinkInstallPageUrl,
+          default: !downloadURL
+        });
+        script.availableScriptPermalinkInstallPageUrl.push({
+          label: 'Minified',
+          url: script.scriptPermalinkInstallPageUrlMin
+        });
+        script.availableScriptPermalinkInstallPageUrl.push({
+          label: 'Normal with counter skip',
+          url: script.scriptPermalinkRawPageUrl
+        });
+        script.availableScriptPermalinkInstallPageUrl.push({
+          label: 'Minified with counter skip',
+          url: script.scriptPermalinkRawPageUrlMin
+        });
 
         script.scriptAcceptableOSILicense = [];
         SPDX.forEach(function (aElement, aIndex, aArray) {

--- a/views/includes/scriptAuthorToolsPanel.html
+++ b/views/includes/scriptAuthorToolsPanel.html
@@ -33,6 +33,28 @@
         </span>
       </div>
     </div>
+
+    <div class="form-group">
+      <div class="input-group col-xs-12">
+        <span class="input-group-btn">
+          <button class="btn btn-default" id="downloadurl-raw" data-clipboard-text="// @downloadURL {{#script.meta.UserScript.downloadURL}}{{{script.meta.UserScript.downloadURL.0.value}}}{{/script.meta.UserScript.downloadURL}}{{^script.meta.UserScript.downloadURL}}{{{script.scriptPermalinkInstallPageUrl}}}{{/script.meta.UserScript.downloadURL}}" title="Copy key and raw URL to clipboard"><i class="octicon octicon-clippy"></i> // @downloadURL</button>
+        </span>
+        <input type="text" class="form-control" id="downloadurl" value="{{#script.meta.UserScript.downloadURL}}{{{script.meta.UserScript.downloadURL.0.value}}}{{/script.meta.UserScript.downloadURL}}{{^script.meta.UserScript.downloadURL}}{{{script.scriptPermalinkInstallPageUrl}}}{{/script.meta.UserScript.downloadURL}}" readonly="readonly">
+        <span class="input-group-btn dropup">
+          <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" title="Alternate download source targets"><span class="caret"></span> <span class="sr-only">Toggle Dropdown</span> </button>
+          <ul class="dropdown-menu scrollable-menu dropdown-menu-right" id="install-targets">
+            {{#script.availableScriptPermalinkInstallPageUrl}}<li {{#default}}class="active"{{/default}}><a href="#" title="{{{url}}">{{label}}</a></li>{{/script.availableScriptPermalinkInstallPageUrl}}
+          </ul>
+        </span>
+        <span class="input-group-btn">
+          <a class="btn btn-default"
+            title="How do I use this?"
+            href="/about/Frequently-Asked-Questions#q-is-there-a-way-to-not-count-script-updates-with-this-sites-install-counter-">
+              <i class="fa fa-question-circle"></i>
+          </a>
+        </span>
+      </div>
+    </div>
     {{/newScript}}
     {{/script.isLib}}
 

--- a/views/includes/scriptPageHeader.html
+++ b/views/includes/scriptPageHeader.html
@@ -26,7 +26,7 @@
   {{/isScriptPage}}
   {{#isScriptViewSourcePage}}
     <div class="btn-group pull-right">
-      <a href="{{{script.scriptRawPageUrl}}}" class="btn btn-{{^script.showSourceNoticesCritical}}info{{/script.showSourceNoticesCritical}}{{#script.showSourceNoticesCritical}}danger{{/script.showSourceNoticesCritical}}">
+      <a href="{{{script.scriptRawPageUrl}}}#" class="btn btn-{{^script.showSourceNoticesCritical}}info{{/script.showSourceNoticesCritical}}{{#script.showSourceNoticesCritical}}danger{{/script.showSourceNoticesCritical}}">
         <i class="fa fa-file-{{#script.isLib}}excel{{/script.isLib}}{{^script.isLib}}code{{/script.isLib}}-o"></i> Raw Source
       </a>
       <button type="button" class="btn btn-{{^script.showSourceNotices}}info{{/script.showSourceNotices}}{{#script.showSourceNotices}}{{^script.showSourceNoticesCritical}}warning{{/script.showSourceNoticesCritical}}{{#script.showSourceNoticesCritical}}danger{{/script.showSourceNoticesCritical}}{{/script.showSourceNotices}} dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
@@ -36,7 +36,7 @@
       <ul class="dropdown-menu dropdown-menu-right">
         <li>
           <div class="btn-group btn-group-justified">
-            <a href="{{{script.scriptRawPageXUrl}}}" class="btn btn-{{#script.showSourceNotices}}{{^script.showSourceNoticesCritical}}warning{{/script.showSourceNoticesCritical}}{{#script.showSourceNoticesCritical}}danger{{/script.showSourceNoticesCritical}}{{/script.showSourceNotices}}{{^script.showSourceNotices}}info{{/script.showSourceNotices}}" title="EXPERIMENTAL"><i class="fa fa-file-{{#script.isLib}}excel{{/script.isLib}}{{^script.isLib}}code{{/script.isLib}}-o"></i> Minified Source</a>
+            <a href="{{{script.scriptRawPageXUrl}}}#" class="btn btn-{{#script.showSourceNotices}}{{^script.showSourceNoticesCritical}}warning{{/script.showSourceNoticesCritical}}{{#script.showSourceNoticesCritical}}danger{{/script.showSourceNoticesCritical}}{{/script.showSourceNotices}}{{^script.showSourceNotices}}info{{/script.showSourceNotices}}" title="EXPERIMENTAL"><i class="fa fa-file-{{#script.isLib}}excel{{/script.isLib}}{{^script.isLib}}code{{/script.isLib}}-o"></i> Minified Source</a>
           </div>
           {{#script.showSourceNotices}}
           {{> includes/scriptPageHeaderSourceNotices.html }}

--- a/views/includes/scripts/clipboard.html
+++ b/views/includes/scripts/clipboard.html
@@ -7,6 +7,7 @@
 
     var allowedIds = [
       '#copyright-raw',
+      '#downloadurl-raw',
       '#groupid-raw',
       '#groupid-urn',
       '#license-raw',

--- a/views/includes/scripts/selectInstall.html
+++ b/views/includes/scripts/selectInstall.html
@@ -1,0 +1,53 @@
+<script type="text/javascript">
+  (function () {
+
+    {{> includes/scripts/polyfillElementClosest.js }}
+
+    function onClick(aEv) {
+      aEv.preventDefault();
+
+      var containerNode = aEv.target.closest('li');
+      var listInstallTargets = document.querySelectorAll('#install-targets li');
+      var inputInstall = document.querySelector('#downloadurl');
+      var copyDownloadURLButton = document.querySelector('#downloadurl-raw');
+      var i = null;
+      var thisItem = null;
+
+      if (containerNode && listInstallTargets && inputInstall && copyDownloadURLButton) {
+        inputInstall.value = aEv.target.title;
+        copyDownloadURLButton.setAttribute(
+          'data-clipboard-text',
+          '// @downloadURL ' + aEv.target.title
+        );
+
+        for (i = 0; thisItem = listInstallTargets[i++];) {
+          if (thisItem.classList.contains('active')) {
+            thisItem.classList.remove('active');
+          }
+        }
+
+        containerNode.classList.add('active');
+      }
+    }
+
+    function onDOMContentLoaded(aEv) {
+      var listInstallTargets = document.querySelectorAll('#install-targets li');
+      var thisItem = null;
+      var i = null;
+      var thisAnchor = null;
+
+      for (i = 0; thisItem = listInstallTargets[i++];) {
+        thisItem.addEventListener('click', onClick);
+
+        thisAnchor = thisItem.querySelector('a');
+
+        if (thisAnchor.title === '{{script.meta.UserScript.downloadURL.0.value}}') {
+          thisItem.classList.add('active');
+        }
+      }
+    }
+
+    document.addEventListener('DOMContentLoaded', onDOMContentLoaded);
+
+  })();
+</script>

--- a/views/pages/scriptViewSourcePage.html
+++ b/views/pages/scriptViewSourcePage.html
@@ -62,6 +62,7 @@
   {{> includes/scripts/lazyIconScript.html }}
   {{> includes/scripts/clipboard.html }}
   {{#authorTools}}
+    {{ > includes/scripts/selectInstall.html}}
     {{ > includes/scripts/selectSPDX.html}}
   {{/authorTools}}
   {{> includes/scripts/scriptEditor.html }}


### PR DESCRIPTION
* Some Authors are copying the trailing `#` from raw view... so give them the correct ones for .user.js engines. Also inclusive of minification routine.

Post #1654 and additional for #432