### PR TITLE
Small rework of verify hijack

### DIFF
--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -219,21 +219,25 @@ exports.callback = function (aReq, aRes, aNext) {
   // Hijack the private verify method so we can mess stuff up freely
   // We use this library for things it was never intended to do
   if (openIdStrategies[strategy]) {
-    if (strategy === 'steam') {
-      strategyInstance._verify = function (aIgnore, aId, aDone) {
-        verifyPassport(aId, strategy, username, aReq.session.user, aDone);
-      };
-    } else {
-      strategyInstance._verify = function (aId, aDone) {
-        verifyPassport(aId, strategy, username, aReq.session.user, aDone);
-      };
+    switch(strategy) {
+      case 'steam':
+        strategyInstance._verify = function (aIgnore, aId, aDone) {
+          verifyPassport(aId, strategy, username, aReq.session.user, aDone);
+        };
+        break;
+      default:
+        strategyInstance._verify = function (aId, aDone) {
+          verifyPassport(aId, strategy, username, aReq.session.user, aDone);
+        };
     }
   } else {
-    strategyInstance._verify =
-      function (aToken, aRefreshOrSecretToken, aProfile, aDone) {
-        aReq.session.profile = aProfile;
-        verifyPassport(aProfile.id, strategy, username, aReq.session.user, aDone);
-      };
+    switch(strategy) {
+      default:
+        strategyInstance._verify = function (aToken, aRefreshOrSecretToken, aProfile, aDone) {
+          aReq.session.profile = aProfile;
+          verifyPassport(aProfile.id, strategy, username, aReq.session.user, aDone);
+        };
+    }
   }
 
   // This callback will happen after the verify routine


### PR DESCRIPTION
* Too many nested if/else's makes it highly unreadable between OAuth and OpenID i.e. easier commit history searching. Been thinking about doing this since removal commit... doing it.
* Probable location to add `aToken` to  which is actually `aAccessToken` in dep README's. Possible location could be `aReq.session.accessToken` Applies to #1705

Post #889 #564