### PR TITLE
Non-breaking space filter

### DIFF
--- a/public/pegjs/blockOpenUserJS.pegjs
+++ b/public/pegjs/blockOpenUserJS.pegjs
@@ -62,7 +62,7 @@ item1 =
       unique: true,
 
       key: upmix(keyword),
-      value: value.replace(/\s+$/, '')
+      value: value.trim()
     };
   }
 
@@ -76,6 +76,6 @@ items1 =
   {
     return {
       key: upmix(keyword),
-      value: value.replace(/\s+$/, '')
+      value: value.trim()
     };
   }

--- a/public/pegjs/blockUserLibrary.pegjs
+++ b/public/pegjs/blockUserLibrary.pegjs
@@ -69,7 +69,7 @@ item1 =
       unique: true,
 
       key: upmix(keyword),
-      value: value.replace(/\s+$/, '')
+      value: value.trim()
     };
   }
 
@@ -91,7 +91,7 @@ item1Localized =
       unique: true,
 
       key: keywordUpmixed,
-      value: value.replace(/\s+$/, '')
+      value: value.trim()
     }
 
     if (locale) {
@@ -115,6 +115,6 @@ items1 =
   {
     return {
       key: upmix(keyword),
-      value: value.replace(/\s+$/, '')
+      value: value.trim()
     };
   }

--- a/public/pegjs/blockUserScript.pegjs
+++ b/public/pegjs/blockUserScript.pegjs
@@ -139,7 +139,7 @@ item1 =
       unique: true,
 
       key: upmix(keyword),
-      value: value.replace(/\s+$/, '')
+      value: value.trim()
     };
   }
 
@@ -161,7 +161,7 @@ item1Localized =
       unique: true,
 
       key: keywordUpmixed,
-      value: value.replace(/\s+$/, '')
+      value: value.trim()
     }
 
     if (locale) {
@@ -194,7 +194,7 @@ items1 =
   {
     return {
       key: upmix(keyword),
-      value: value.replace(/\s+$/, '')
+      value: value.trim()
     };
   }
 
@@ -208,7 +208,7 @@ items2 =
   whitespace
   value2: non_newline
   {
-    var value2trimmed = value2.replace(/\s+$/, '');
+    var value2trimmed = value2.trim();
 
     return {
       key: upmix(keyword),


### PR DESCRIPTION
* Fix a pre non-breaking space issue with pegjs and original/current GM syntax
* Trim both sides of value. This will probably spawn a new script for those thinking they got away with something. ;) ... or a thanks for pointing it out indirectly
* TM allows this... violates long-standing spec technically but we should at least store the meta trimmed for our validation and investigate if GM is aware of this action.