### PR TITLE
A dep downgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "highlight.js": "9.18.1",
     "image-size": "0.8.3",
     "ip-range-check": "0.2.0",
-    "jquery": "3.5.0",
+    "jquery": "3.4.1",
     "js-beautify": "1.11.0",
     "jsdom": "16.2.2",
     "less-middleware": "3.1.0",


### PR DESCRIPTION
* *jquery* failure from last update with *boostrap* pop-over menus. *(on portable devices and small viewports)*

Related #904 #1714