### PR TITLE
Move dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ These also may use [shields.io][shieldsHomepage] where applicable for more expli
 ##### Dynamic
 Repository | Reference | Recent Version
 --- | --- | ---
-[ace-builds][ace-buildsGHUrl] [&#x00b9;][aceGHUrl] | [Documentation][ace-buildsDOCUrl] [&#x00b9;][aceDOCUrl] | [1.4.12][ace-buildsGHHASHUrl] [RELEASES][ace-buildsGHRELEASESUrl]
+[ace-builds][ace-buildsGHUrl] [&#x00b9;][aceGHUrl] | [Documentation][ace-buildsDOCUrl] [&#x00b9;][aceDOCUrl] | [![NPM version][ace-buildsNPMVersionImage]][ace-buildsNPMUrl]
 [ansi-colors][ansi-colorsGHUrl] | [Documentation][ansi-colorsDOCUrl] | [![NPM version][ansi-colorsNPMVersionImage]][ansi-colorsNPMUrl]
 [async][asyncGHUrl] | [Documentation][asyncDOCUrl] | [![NPM version][asyncNPMVersionImage]][asyncNPMUrl]
 [aws-sdk][aws-sdkGHUrl] | [Documentation][aws-sdkDOCUrl] | [![NPM version][aws-sdkNPMVersionImage]][aws-sdkNPMUrl]
@@ -126,9 +126,9 @@ Outdated dependencies list can also be achieved with `$ npm outdated`
 [shieldsHomepage]: http://shields.io/
 
 [ace-buildsGHUrl]: https://github.com/ajaxorg/ace-builds/tree/master/src
-[ace-buildsGHHASHUrl]: https://github.com/ajaxorg/ace-builds/tree/a4103cb
-[ace-buildsGHRELEASESUrl]: https://github.com/ajaxorg/ace-builds/releases
 [ace-buildsDOCUrl]: https://github.com/ajaxorg/ace-builds/blob/master/README.md
+[ace-buildsNPMUrl]: https://www.npmjs.com/package/ace-builds
+[ace-buildsNPMVersionImage]: https://img.shields.io/npm/v/ace-builds.svg?style=flat
 [aceGHUrl]: https://github.com/ajaxorg/ace "ace"
 [aceDOCUrl]: http://ace.c9.io/#nav=api "ace"
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.5.0",
   "main": "app",
   "dependencies": {
-    "ace-builds": "git://github.com/ajaxorg/ace-builds.git#a4103cb",
+    "ace-builds": "1.4.12",
     "ansi-colors": "4.1.1",
     "async": "3.2.0",
     "aws-sdk": "2.713.0",


### PR DESCRIPTION
*ace-builds* was _finally_ *(a few years back and rechecked now)* officially collaborated on npmjs so move package there.

See
* https://github.com/ajaxorg/ace-builds/issues/88#issuecomment-361855553 comment from nightwing.