### PR TITLE
Pseudo cross-browser styling for readonly Auth Strategies

### DIFF
--- a/controllers/index.js
+++ b/controllers/index.js
@@ -246,7 +246,8 @@ exports.register = function (aReq, aRes) {
     if (!aStrategy.oauth) {
       options.strategies.push({
         'strat': aStrategyKey,
-        'display': aStrategy.name
+        'display': aStrategy.name,
+        'disabled': aStrategy.readonly
       });
     }
   });
@@ -265,7 +266,8 @@ exports.register = function (aReq, aRes) {
       aAvailableStrategies.forEach(function (aStrategy) {
         options.strategies.push({
           'strat': aStrategy.name,
-          'display': aStrategy.display
+          'display': aStrategy.display,
+          'disabled': aStrategy.readonly
         });
       });
 

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -992,12 +992,14 @@ exports.userEditPreferencesPage = function (aReq, aRes, aNext) {
           if (userStrats.indexOf(aStrat.name) > -1) {
             options.usedStrategies.push({
               'strat': aStrat.name,
-              'display': aStrat.display
+              'display': aStrat.display,
+              'disabled': aStrat.readonly
             });
           } else {
             options.openStrategies.push({
               'strat': aStrat.name,
-              'display': aStrat.display
+              'display': aStrat.display,
+              'disabled': aStrat.readonly
             });
           }
         });
@@ -1010,12 +1012,14 @@ exports.userEditPreferencesPage = function (aReq, aRes, aNext) {
             if (userStrats.indexOf(name) > -1) {
               options.usedStrategies.push({
                 'strat': name,
-                'display': strategy.name
+                'display': strategy.name,
+                'disabled': strategy.readonly
               });
             } else {
               options.openStrategies.push({
                 'strat': name,
-                'display': strategy.name
+                'display': strategy.name,
+                'disabled': strategy.readonly
               });
             }
           }

--- a/views/pages/loginPage.html
+++ b/views/pages/loginPage.html
@@ -29,7 +29,7 @@
           </div>
           <select name="auth" class="form-control">
             {{#strategies}}
-            <option value="{{strat}}" {{#selected}}selected="selected"{{/selected}}>{{display}}</option>
+            <option value="{{strat}}" {{#selected}}selected="selected"{{/selected}}{{#disabled}} disabled="disabled"{{/disabled}}>{{display}}</option>
             {{/strategies}}
           </select>
           <div style="width: 100%;">

--- a/views/pages/userEditPreferencesPage.html
+++ b/views/pages/userEditPreferencesPage.html
@@ -54,7 +54,7 @@
                       </span>
                       <select name="auth" class="form-control">
                         {{#openStrategies}}
-                        <option value="{{strat}}">{{display}}</option>
+                        <option value="{{strat}}"{{#disabled}} disabled="disabled"{{/disabled}}>{{display}}</option>
                         {{/openStrategies}}
                       </select>
                       <div style="width: 100%;">


### PR DESCRIPTION
* Using this as a subtle notice that a strategy has been disabled in case someone isn't watching dev
* Fx still doesn't support styling unfortunately *( https://bugzilla.mozilla.org/show_bug.cgi?id=910022 )* so plain disable it. Should cut down on b/w but also possible Code testing increase with visible delineation in dev.

Post #1174 and reminder-ed in #1189 ... related to #1732 #1733