### PR TITLE
Change status code for script not found

### DIFF
--- a/controllers/scriptStorage.js
+++ b/controllers/scriptStorage.js
@@ -1881,9 +1881,8 @@ exports.storeScript = function (aUser, aMeta, aBuf, aUpdate, aCallback) {
           return;
         } else if (!aScript && aUpdate) {
           aCallback(new statusError({
-            message: 'Updating but no script found. Reference: '
-              + installName + ' ; '+ caseSensitive(installName),
-            code: 500 // Status code unknown... could be user error too
+            message: 'Updating but no script found.',
+            code: 404
           }), null);
           return;
         } else if (!aScript) {


### PR DESCRIPTION
Instances:
1. Author has webhook enabled and GH sends update notice before imported on OUJS.
2. Author deleted OUJS script and still receiving webhook notice.

There's still the extremely rare chance that this could be a 500, if *mongoose*,*mongodb*, and S3 has a catastrophic connection error.

Since the bulk of this is usually client error denoting as such in case GH is paying attention and possibly doing something on their end by killing further notices. If true then this part "could be" related to #1730

Post #1731