### PR TITLE
Remove `_since` and favour `created`

### DIFF
--- a/app.js
+++ b/app.js
@@ -479,11 +479,11 @@ require('./routes')(app);
 // Timers
 function tripServerOnCertExpire(aValidToString) {
   var tlsDate = new Date(aValidToString);
-  var nowDate = new Date();
+  var now = new Date();
 
   var tripDate = new Date(tlsDate.getTime() - (2 * 60 * 60 * 1000)); // ~2 hours before fault
 
-  if (nowDate.getTime() >= tripDate.getTime()) {
+  if (now.getTime() >= tripDate.getTime()) {
     console.error(colors.red('Certificates expiring very soon. Tripping server to unsecure mode'));
 
     isSecured = false;

--- a/controllers/discussion.js
+++ b/controllers/discussion.js
@@ -477,14 +477,15 @@ function postTopic(aUser, aCategory, aTopic, aContent, aIssue, aUserAgent, aCall
 
   Discussion.findOne({ path: path }, null, params, function (aErr, aDiscussion) {
     var newDiscussion = null;
+    var now = new Date();
     var props = {
       topic: aTopic,
       category: aCategory,
       comments: 0,
       author: aUser.name,
-      created: new Date(),
+      created: now,
       lastCommentor: aUser.name,
-      updated: new Date(),
+      updated: now,
       rating: 0,
       flagged: false,
       path: path,

--- a/controllers/flag.js
+++ b/controllers/flag.js
@@ -185,7 +185,7 @@ exports.getFlaggedListForContent = function (aModelName, aOptions, aCallback) {
           contentList[aContentKey].flaggedList.push({
             name: aUser.name,
             reason: aFlagList[aFlagKey].reason,
-            since: aFlagList[aFlagKey]._since
+            since: aFlagList[aFlagKey].created
           });
           aEachInnerCallback();
         });

--- a/controllers/group.js
+++ b/controllers/group.js
@@ -132,10 +132,12 @@ exports.addScriptToGroups = function (aScript, aGroupNames, aCallback) {
     // Create a custom group for the script
     if (!aScript._groupId && newGroup) {
       tasks.push(function (aCallback) {
+        var now = new Date();
         var group = new Group({
           name: newGroup,
           rating: 0,
-          updated: new Date(),
+          created: now,
+          updated: now,
           _scriptIds: [aScript._id]
         });
 

--- a/controllers/scriptStorage.js
+++ b/controllers/scriptStorage.js
@@ -1866,6 +1866,7 @@ exports.storeScript = function (aUser, aMeta, aBuf, aUpdate, aCallback) {
       function (aAlive, aScript, aRemoved) {
         var script = null;
         var s3 = null;
+        var now = null;
 
         if (aRemoved) {
           aCallback(new statusError({
@@ -1887,6 +1888,7 @@ exports.storeScript = function (aUser, aMeta, aBuf, aUpdate, aCallback) {
           return;
         } else if (!aScript) {
           // New script
+          now = new Date();
           aScript = new Script({
             name: thisName,
             _description: (
@@ -1899,7 +1901,8 @@ exports.storeScript = function (aUser, aMeta, aBuf, aUpdate, aCallback) {
             rating: 0,
             about: '',
             _about: '',
-            updated: new Date(),
+            created: now,
+            updated: now,
             hash: crypto.createHash('sha512').update(aBuf).digest('hex'),
             votes: 0,
             flags: { critical: 0, absolute: 0 },

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -2162,7 +2162,7 @@ exports.editScript = function (aReq, aRes, aNext) {
   var installNameBase = null;
   var isLib = aReq.params.isLib;
   var tasks = [];
-  var nowDate = null;
+  var now = null;
 
   // Session
   options.authedUser = authedUser = modelParser.parseUser(authedUser);
@@ -2201,7 +2201,7 @@ exports.editScript = function (aReq, aRes, aNext) {
         var licensePrimary = null;
         var copyrights = null;
         var copyrightPrimary = null;
-        var sinceDate = null;
+        var createdDate = null;
 
         //---
         if (aErr || !aScript) {
@@ -2236,8 +2236,8 @@ exports.editScript = function (aReq, aRes, aNext) {
           script.copyrightPrimary = copyrightPrimary;
         } else {
           if (authedUser) {
-            sinceDate = new Date(script._sinceISOFormat);
-            script.copyrightPrimary = sinceDate.getFullYear() + ', ' + authedUser.name +
+            createdDate = new Date(script.createdISOFormat);
+            script.copyrightPrimary = createdDate.getFullYear() + ', ' + authedUser.name +
               ' (' + helpers.baseOrigin + authedUser.userPageUrl + ')';
           }
         }
@@ -2344,8 +2344,8 @@ exports.editScript = function (aReq, aRes, aNext) {
     options.script.licensePrimary = 'MIT'; // NOTE: Site default
 
     if (authedUser) {
-      nowDate = new Date();
-      options.script.copyrightPrimary = nowDate.getFullYear() + ', ' + authedUser.name +
+      now = new Date();
+      options.script.copyrightPrimary = now.getFullYear() + ', ' + authedUser.name +
         ' (' + helpers.baseOrigin + authedUser.userPageUrl + ')';
     }
 

--- a/libs/flag.js
+++ b/libs/flag.js
@@ -163,11 +163,13 @@ function saveContent(aModel, aContent, aAuthor, aFlags, aIsFlagging, aCallback) 
 exports.saveContent = saveContent;
 
 function flag(aModel, aContent, aUser, aAuthor, aReason, aCallback) {
+  var now = new Date();
   var flag = new Flag({
     'model': aModel.modelName,
     '_contentId': aContent._id,
     '_userId': aUser._id,
-    'reason': aReason
+    'reason': aReason,
+    'created': now
   });
 
   flag.save(function (aErr, aFlag) {

--- a/libs/modelParser.js
+++ b/libs/modelParser.js
@@ -485,13 +485,13 @@ var parseScript = function (aScript) {
 
 
   // Dates
+  parseDateProperty(script, 'created');
   parseDateProperty(script, 'updated');
-  parseDateProperty(script, '_since'); // Virtual
 
   // Hash
   script.hashShort = script.hash ? script.hash.substr(0, 7) : 'undefined';
 
-  if (script._since && script.updated && script._since.toString() !== script.updated.toString()) {
+  if (script.created && script.updated && script.created.toString() !== script.updated.toString()) {
     script.isUpdated = true;
   }
 
@@ -695,7 +695,7 @@ var parseUser = function (aUser) {
   user.canSync = user.hasGithub;
 
   // Dates
-  parseDateProperty(user, '_since'); // Virtual
+  parseDateProperty(user, 'created');
 
   return user;
 };
@@ -805,8 +805,8 @@ var parseDiscussion = function (aDiscussion) {
   parseDateProperty(discussion, 'created');
   parseDateProperty(discussion, 'updated');
 
-  if (discussion._since && discussion.updated
-    && discussion._since.toString() !== discussion.updated.toString()) {
+  if (discussion.created && discussion.updated
+    && discussion.created.toString() !== discussion.updated.toString()) {
     discussion.isUpdated = discussion.comments > 1 ? true : false;
   }
 

--- a/libs/passportVerify.js
+++ b/libs/passportVerify.js
@@ -49,6 +49,7 @@ exports.verify = function (aId, aStrategy, aUsername, aLoggedIn, aDone) {
 
       if (!aUser) {
         User.findOne({ 'name': aUsername }, function (aErr, aUser) {
+          var now = new Date();
           // WARNING: No err handling
 
           if (aUser && aLoggedIn) {
@@ -78,6 +79,7 @@ exports.verify = function (aId, aStrategy, aUsername, aLoggedIn, aDone) {
               // Create a new user
               aUser = new User({
                 'name': aUsername,
+                'created': now,
                 'auths': [digest],
                 'strategies': [aStrategy],
                 'role': userRoles.length - 2,  // NOTE: Last array element value is system Reserved

--- a/libs/vote.js
+++ b/libs/vote.js
@@ -117,8 +117,10 @@ function saveScript(aScript, aAuthor, aFlags, aCallback) {
 exports.saveScript = saveScript;
 
 function newVote(aScript, aUser, aAuthor, aCasting, aCallback) {
+  var now = new Date();
   var vote = new Vote({
     vote: aCasting,
+    created: now,
     _scriptId: aScript._id,
     _userId: aUser._id
   });

--- a/models/discussion.js
+++ b/models/discussion.js
@@ -37,10 +37,6 @@ var discussionSchema = new Schema({
   _authorId: Schema.Types.ObjectId
 });
 
-discussionSchema.virtual('_since').get(function () {
-  return this._id.getTimestamp();
-});
-
 var Discussion = mongoose.model('Discussion', discussionSchema);
 
 exports.Discussion = Discussion;

--- a/models/flag.js
+++ b/models/flag.js
@@ -15,11 +15,9 @@ var flagSchema = new Schema({
   model: String,
   reason: String,
   _contentId: Schema.Types.ObjectId,
-  _userId: Schema.Types.ObjectId
-});
+  _userId: Schema.Types.ObjectId,
 
-flagSchema.virtual('_since').get(function () {
-  return this._id.getTimestamp();
+  created: Date
 });
 
 var Flag = mongoose.model('Flag', flagSchema);

--- a/models/group.js
+++ b/models/group.js
@@ -15,13 +15,10 @@ var ObjectId = Schema.Types.ObjectId;
 var groupSchema = new Schema({
   name: { type: String },
   rating: { type: Number, default: 0 },
-  updated: { type: Date, default: Date.now },
+  created: { type: Date },
+  updated: { type: Date },
   _scriptIds: [{ type: ObjectId, ref: 'Script' }],
   size: { type: Number, default: 0 }
-});
-
-groupSchema.virtual('_since').get(function () {
-  return this._id.getTimestamp();
 });
 
 var Group = mongoose.model('Group', groupSchema);

--- a/models/script.js
+++ b/models/script.js
@@ -21,6 +21,7 @@ var scriptSchema = new Schema({
   rating: Number,
   about: String,
   _about: String,
+  created: Date,
   updated: Date,
   hash: String,
 
@@ -43,10 +44,6 @@ var scriptSchema = new Schema({
 },
 {
   autoIndex: false
-});
-
-scriptSchema.virtual('_since').get(function () {
-  return this._id.getTimestamp();
 });
 
 /*

--- a/models/user.js
+++ b/models/user.js
@@ -15,6 +15,7 @@ var userSchema = new Schema({
   // Visible
   name: String,
   about: String,
+  created: Date,
 
   // A user can link multiple accounts to their OpenUserJS account
   consented: Boolean,
@@ -33,10 +34,6 @@ var userSchema = new Schema({
   },
   flagged: Boolean,
   sessionIds: [String]
-});
-
-userSchema.virtual('_since').get(function () {
-  return this._id.getTimestamp();
 });
 
 var User = mongoose.model('User', userSchema);

--- a/models/vote.js
+++ b/models/vote.js
@@ -13,6 +13,8 @@ var Schema = mongoose.Schema;
 
 var voteSchema = new Schema({
   vote: Boolean,
+  created: Date,
+
   _scriptId: Schema.Types.ObjectId,
   _userId: Schema.Types.ObjectId
 });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "OpenUserJS.org",
   "description": "An open source user scripts repo built using Node.js",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "main": "app",
   "dependencies": {
     "ace-builds": "1.4.12",

--- a/views/includes/userStatsPanel.html
+++ b/views/includes/userStatsPanel.html
@@ -9,7 +9,7 @@
   <div class="panel-body">
     <dl class="dl-horizontal">
       <dt>Member since</dt>
-      <dd><time datetime="{{user._sinceISOFormat}}" title="{{user._since}}">{{user._sinceHumanized}}</time></dd>
+      <dd><time datetime="{{user.createdISOFormat}}" title="{{user.created}}">{{user.createdHumanized}}</time></dd>
       <dt>Number of userscripts</dt>
       <dd>{{stats.totalScripts}}</dd>
       <dt>Number of libraries</dt>

--- a/views/pages/scriptPage.html
+++ b/views/pages/scriptPage.html
@@ -26,7 +26,7 @@
             {{/script.isLib}}
 
             <div class="script-meta">
-              <p><i class="fa fa-fw fa-clock-o"></i> <b>Published:</b> <time datetime="{{script._sinceISOFormat}}" title="{{script._since}}">{{script._sinceHumanized}}</time></p>
+              <p><i class="fa fa-fw fa-clock-o"></i> <b>Published:</b> <time datetime="{{script.createdISOFormat}}" title="{{script.created}}">{{script.createdHumanized}}</time></p>
               <p><i class="fa fa-fw fa-history"></i> <b>Version:</b> <code>{{script.meta.UserScript.version.0.value}}<span title="SHA-512 {{script.hash}}">+{{script.hashShort}}</span></code>{{#script.isUpdated}} updated <time class="script-updated" datetime="{{script.updatedISOFormat}}" title="{{script.updated}}">{{script.updatedHumanized}}</time>{{/script.isUpdated}}</p>
               {{#script.description}}<p><i class="fa fa-fw fa-info"></i> <b>Summary:</b> {{script.description}}</p>{{/script.description}}
               {{#script.hasGroups}}


### PR DESCRIPTION
* `_since` has a precision issue and possible extended time failure due to lack of bits
* Fix a few timing issues
* Best not to set default date in groups model as it can cover up errors and was doing it twice
* Some identifier symmetry
* All models should have base `created` with the exception of `removed` since once gone that's technically creation of nothingness.
* Bump package version since older backups won't be valid after migration

Applies to #349