### PR TITLE
Add "Since" column to Users

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -427,7 +427,8 @@ exports.userListPage = function (aReq, aRes, aNext) {
   pageMetadata(options, 'Users');
 
   // Order dir
-  orderDir(aReq, options, 'name', 'desc');
+  orderDir(aReq, options, 'name', 'asc');
+  orderDir(aReq, options, 'created', 'desc');
   orderDir(aReq, options, 'role', 'asc');
 
   // userListQuery

--- a/views/includes/userList.html
+++ b/views/includes/userList.html
@@ -2,7 +2,8 @@
   <thead>
     <tr>
       <th class="{{#orderedByName}}active{{/orderedByName}}"><a href="?orderBy=name&orderDir={{orderDir.name}}{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}{{#isFlagged}}&flagged={{isFlagged}}{{/isFlagged}}">Name</a></th>
-      <th class="td-fit{{#orderedByRole}} active{{/orderedByRole}}"><a href="?orderBy=role&orderDir={{orderDir.role}}{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}{{#isFlagged}}&flagged={{isFlagged}}{{/isFlagged}}">Rank</a></th>
+      <th class="text-center td-fit{{#orderedByCreated}} active{{/orderedByCreated}}"><a href="?orderBy=created&orderDir={{orderDir.created}}{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}{{#isFlagged}}&flagged={{isFlagged}}{{/isFlagged}}">Since</a></th>
+      <th class="text-center td-fit{{#orderedByRole}} active{{/orderedByRole}}"><a href="?orderBy=role&orderDir={{orderDir.role}}{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}{{#isFlagged}}&flagged={{isFlagged}}{{/isFlagged}}">Rank</a></th>
       {{#hasFlagged}}
       <th title="Flagger"><span class="visible-lg visible-md">Flagger</span><span class="hidden-lg hidden-md"><i class="fa fa-flag"></i></span></a></th>
       {{/hasFlagged}}
@@ -16,7 +17,10 @@
           <a href="{{{userPageUrl}}}" class="tr-link-a">{{name}}</a>
         </b>
       </td>
-      <td class="td-fit">
+      <td class="text-center td-fit">
+        <time datetime="{{createdISOFormat}}" title="{{created}}" class="iconic">{{{createdHumanizedIconic}}}</time>
+      </td>
+      <td class="text-center td-fit">
         <p>
           <span class="label label-default">{{roleName}}</span>
         </p>
@@ -37,7 +41,7 @@
     {{/userList}}
     {{^userList}}
     <tr class="tr-link">
-      <td colspan="3">
+      <td colspan="4">
         <em>{{userListIsEmptyMessage}}</em>
       </td>
     </tr>


### PR DESCRIPTION
* Change some UI centering.
* If new columns for `created` and/or `updated` are wanted please open a new issue with relativity.
* Since queries can be CPU intensive continue to limit some of these in the UI.
* MongoDB 4.x has the ability to auto-create these per save/creation however finite control is usually needed rather than all the time/everywhere.

Applies to #485 and closes #349