### PR TITLE
Add `syncIndexes` to all models JIC

### DIFF
--- a/app.js
+++ b/app.js
@@ -22,6 +22,9 @@ var chain = require('./libs/debug').chain;
 var path = require('path');
 var crypto = require('crypto');
 
+var events = require('events');
+events.EventEmitter.defaultMaxListeners = 15;
+
 var express = require('express');
 var toobusy = require('toobusy-js');
 var statusCodePage = require('./libs/templateHelpers').statusCodePage;

--- a/models/comment.js
+++ b/models/comment.js
@@ -36,4 +36,20 @@ var commentSchema = new Schema({
 
 var Comment = mongoose.model('Comment', commentSchema);
 
+Comment.syncIndexes(function () {
+  Comment.collection.getIndexes({
+    full: true
+  }).then(function(aIndexes)  {
+    console.log('Comment indexes:\n', aIndexes);
+  }).catch(console.error);
+});
+
+Comment.on('index', function (aErr) {
+  if (aErr) {
+    console.error(aErr);
+  } else {
+    console.log('Index event triggered/trapped for Comment model');
+  }
+});
+
 exports.Comment = Comment;

--- a/models/discussion.js
+++ b/models/discussion.js
@@ -39,4 +39,20 @@ var discussionSchema = new Schema({
 
 var Discussion = mongoose.model('Discussion', discussionSchema);
 
+Discussion.syncIndexes(function () {
+  Discussion.collection.getIndexes({
+    full: true
+  }).then(function(aIndexes)  {
+    console.log('Discussion indexes:\n', aIndexes);
+  }).catch(console.error);
+});
+
+Discussion.on('index', function (aErr) {
+  if (aErr) {
+    console.error(aErr);
+  } else {
+    console.log('Index event triggered/trapped for Discussion model');
+  }
+});
+
 exports.Discussion = Discussion;

--- a/models/flag.js
+++ b/models/flag.js
@@ -22,4 +22,20 @@ var flagSchema = new Schema({
 
 var Flag = mongoose.model('Flag', flagSchema);
 
+Flag.syncIndexes(function () {
+  Flag.collection.getIndexes({
+    full: true
+  }).then(function(aIndexes)  {
+    console.log('Flag indexes:\n', aIndexes);
+  }).catch(console.error);
+});
+
+Flag.on('index', function (aErr) {
+  if (aErr) {
+    console.error(aErr);
+  } else {
+    console.log('Index event triggered/trapped for Flag model');
+  }
+});
+
 exports.Flag = Flag;

--- a/models/group.js
+++ b/models/group.js
@@ -23,4 +23,20 @@ var groupSchema = new Schema({
 
 var Group = mongoose.model('Group', groupSchema);
 
+Group.syncIndexes(function () {
+  Group.collection.getIndexes({
+    full: true
+  }).then(function(aIndexes)  {
+    console.log('Group indexes:\n', aIndexes);
+  }).catch(console.error);
+});
+
+Group.on('index', function (aErr) {
+  if (aErr) {
+    console.error(aErr);
+  } else {
+    console.log('Index event triggered/trapped for Group model');
+  }
+});
+
 exports.Group = Group;

--- a/models/remove.js
+++ b/models/remove.js
@@ -24,4 +24,20 @@ var removeSchema = new Schema({
 
 var Remove = mongoose.model('Remove', removeSchema);
 
+Remove.syncIndexes(function () {
+  Remove.collection.getIndexes({
+    full: true
+  }).then(function(aIndexes)  {
+    console.log('Remove indexes:\n', aIndexes);
+  }).catch(console.error);
+});
+
+Remove.on('index', function (aErr) {
+  if (aErr) {
+    console.error(aErr);
+  } else {
+    console.log('Index event triggered/trapped for Remove model');
+  }
+});
+
 exports.Remove = Remove;

--- a/models/strategy.js
+++ b/models/strategy.js
@@ -20,4 +20,20 @@ var strategySchema = new Schema({
 
 var Strategy = mongoose.model('Strategy', strategySchema);
 
+Strategy.syncIndexes(function () {
+  Strategy.collection.getIndexes({
+    full: true
+  }).then(function(aIndexes)  {
+    console.log('Strategy indexes:\n', aIndexes);
+  }).catch(console.error);
+});
+
+Strategy.on('index', function (aErr) {
+  if (aErr) {
+    console.error(aErr);
+  } else {
+    console.log('Index event triggered/trapped for Strategy model');
+  }
+});
+
 exports.Strategy = Strategy;

--- a/models/sync.js
+++ b/models/sync.js
@@ -27,4 +27,20 @@ var syncSchema = new Schema({
 
 var Sync = mongoose.model('Sync', syncSchema);
 
+Sync.syncIndexes(function () {
+  Sync.collection.getIndexes({
+    full: true
+  }).then(function(aIndexes)  {
+    console.log('Sync indexes:\n', aIndexes);
+  }).catch(console.error);
+});
+
+Sync.on('index', function (aErr) {
+  if (aErr) {
+    console.error(aErr);
+  } else {
+    console.log('Index event triggered/trapped for Sync model');
+  }
+});
+
 exports.Sync = Sync;

--- a/models/user.js
+++ b/models/user.js
@@ -38,5 +38,21 @@ var userSchema = new Schema({
 
 var User = mongoose.model('User', userSchema);
 
+User.syncIndexes(function () {
+  User.collection.getIndexes({
+    full: true
+  }).then(function(aIndexes)  {
+    console.log('User indexes:\n', aIndexes);
+  }).catch(console.error);
+});
+
+User.on('index', function (aErr) {
+  if (aErr) {
+    console.error(aErr);
+  } else {
+    console.log('Index event triggered/trapped for User model');
+  }
+});
+
 exports.User = User;
 

--- a/models/vote.js
+++ b/models/vote.js
@@ -21,4 +21,20 @@ var voteSchema = new Schema({
 
 var Vote = mongoose.model('Vote', voteSchema);
 
+Vote.syncIndexes(function () {
+  Vote.collection.getIndexes({
+    full: true
+  }).then(function(aIndexes)  {
+    console.log('Vote indexes:\n', aIndexes);
+  }).catch(console.error);
+});
+
+Vote.on('index', function (aErr) {
+  if (aErr) {
+    console.error(aErr);
+  } else {
+    console.log('Index event triggered/trapped for Vote model');
+  }
+});
+
 exports.Vote = Vote;


### PR DESCRIPTION
* Possible recommendation as `expires` alias to `expireAfterSeconds` may need this to properly set values of an index that is created app side to sync with back-end.
* Increase event `emitter.setMaxListeners` to accommodate additional MongoDB usage with error thrown:

``` console
Index event triggered/trapped for User model
Index event triggered/trapped for Discussion model
Index event triggered/trapped for Strategy model
Index event triggered/trapped for Remove model
Index event triggered/trapped for Comment model
Index event triggered/trapped for Group model
Index event triggered/trapped for Flag model
Index event triggered/trapped for Vote model
(node:10567) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 open listeners added to [NativeConnection]. Use emitter.setMaxListeners() to increase limit
```

Applies to #1744 #1730 and followup for #1516 ... followup needed on mLab for index that's already there *(which I didn't put there)*