### PR TITLE
Tag UA for GH requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Repository | Reference | Recent Version
 [font-awesome][font-awesomeGHUrl] | [Documentation][font-awesomeDOCUrl] | [![NPM version][font-awesomeNPMVersionImage]][font-awesomeNPMUrl]
 [formidable][formidableGHUrl] | [Documentation][formidableDOCUrl] | [![NPM version][formidableNPMVersionImage]][formidableNPMUrl]
 [git-rev][git-revGHUrl] | [Documentation][git-revDOCUrl] | [![NPM version][git-revNPMVersionImage]][git-revNPMUrl]
+[git-rev-sync][git-rev-syncGHUrl] | [Documentation][git-rev-syncDOCUrl] | [![NPM version][git-rev-syncNPMVersionImage]][git-rev-syncNPMUrl]
 [highlight.js][highlight.jsGHUrl] | [Documentation][highlight.jsDOCUrl][ᴸᴬᴺᴳ][highlight.jsLANGUrl] | [![NPM version][highlight.jsNPMVersionImage]][highlight.jsNPMUrl]
 [image-size][image-sizeGHUrl] | [Documentation][image-sizeDOCUrl] | [![NPM version][image-sizeNPMVersionImage]][image-sizeNPMUrl]
 [ip-range-check][ip-range-checkGHUrl] | [Documentation][ip-range-checkDOCUrl] | [![NPM version][ip-range-checkNPMVersionImage]][ip-range-checkNPMUrl]
@@ -226,6 +227,11 @@ Outdated dependencies list can also be achieved with `$ npm outdated`
 [git-revDOCUrl]: https://github.com/tblobaum/git-rev/blob/master/README.md
 [git-revNPMUrl]: https://www.npmjs.com/package/git-rev
 [git-revNPMVersionImage]: https://img.shields.io/npm/v/git-rev.svg?style=flat
+
+[git-rev-syncGHUrl]: https://github.com/kurttheviking/git-rev-sync-js
+[git-rev-syncDOCUrl]: https://github.com/kurttheviking/git-rev-sync-js/blob/master/README.md
+[git-rev-syncNPMUrl]: https://www.npmjs.com/package/git-rev-sync
+[git-rev-syncNPMVersionImage]: https://img.shields.io/npm/v/git-rev-sync.svg?style=flat
 
 [highlight.jsGHUrl]: https://github.com/isagalaev/highlight.js
 [highlight.jsDOCUrl]: http://highlightjs.readthedocs.org

--- a/app.js
+++ b/app.js
@@ -13,6 +13,8 @@ var isPro = require('./libs/debug').isPro;
 var isDev = require('./libs/debug').isDev;
 var isDbg = require('./libs/debug').isDbg;
 
+var uaOUJS = require('./libs/debug').uaOUJS;
+
 var isSecured = require('./libs/debug').isSecured;
 var privkey = require('./libs/debug').privkey;
 var fullchain = require('./libs/debug').fullchain;
@@ -524,7 +526,10 @@ function pingCert() {
       (isPro && app.get('securePort')
         ? ':' + app.get('securePort')
         : ':' + app.get('port'))
-          + '/api'
+          + '/api',
+    headers: {
+      'User-Agent': uaOUJS + '.' + process.env.UA_SECRET
+    }
   }, function (aErr, aRes, aBody) {
     if (aErr) {
       if (aErr.cert) {

--- a/controllers/scriptStorage.js
+++ b/controllers/scriptStorage.js
@@ -5,6 +5,7 @@ var isPro = require('../libs/debug').isPro;
 var isDev = require('../libs/debug').isDev;
 var isDbg = require('../libs/debug').isDbg;
 var isSecured = require('../libs/debug').isSecured;
+var uaOUJS = require('../libs/debug').uaOUJS;
 var statusError = require('../libs/debug').statusError;
 
 //
@@ -193,7 +194,7 @@ if (isSecured) {
   request({
     url: 'https://api.github.com/meta',
     headers: {
-      'User-Agent': 'OpenUserJS'
+      'User-Agent': uaOUJS + '.' + process.env.UA_SECRET
     }
   }, function (aErr, aRes, aBody) {
     var meta = null;
@@ -1519,7 +1520,7 @@ exports.storeScript = function (aUser, aMeta, aBuf, aUpdate, aCallback) {
           req = request.get({
             url: icon,
             headers: {
-              'User-Agent': 'request'
+              'User-Agent': 'request' // NOTE: Anonymous intended
             }
           })
             .on('response', function (aRes) {

--- a/dev/preinstall.js
+++ b/dev/preinstall.js
@@ -1,10 +1,5 @@
 'use strict';
 
-// Define some pseudo module globals
-var isPro = require('../libs/debug').isPro;
-var isDev = require('../libs/debug').isDev;
-var isDbg = require('../libs/debug').isDbg;
-
 //
 // NOTE: Only use native *node* `require`s in this file
 //   since dependencies may not be installed yet

--- a/libs/debug.js
+++ b/libs/debug.js
@@ -1,6 +1,12 @@
 'use strict';
 
 var fs = require('fs');
+var os = require('os');
+
+var git = require('git-rev-sync');
+
+var pkg = require('../package.json');
+pkg.org = pkg.name.substring(0, pkg.name.indexOf('.'));
 
 var isPro = process.env.NODE_ENV === 'production';
 var isDev = !isPro;
@@ -10,6 +16,11 @@ var isSecure = null;
 var privkey = null;
 var fullchain = null;
 var chain = null;
+
+
+var uaOUJS = null;
+var hash = null;
+
 
 try {
   // Check for primary keys
@@ -54,6 +65,14 @@ try {
 exports.isPro = isPro;
 exports.isDev = isDev;
 exports.isDbg = isDbg;
+
+
+hash = git.short(); // NOTE: Synchronous
+uaOUJS = pkg.org + '/' + pkg.version
+  + ' (' + os.type() + '; ' + os.arch() + '; rv:'
+    + hash + ') ' + 'OUJS/20131106 ' + pkg.name + '/' + hash;
+exports.uaOUJS = uaOUJS;
+
 
 // ES6+ in use to eliminate extra property
 class statusError extends Error {

--- a/libs/githubClient.js
+++ b/libs/githubClient.js
@@ -4,6 +4,7 @@
 var isPro = require('../libs/debug').isPro;
 var isDev = require('../libs/debug').isDev;
 var isDbg = require('../libs/debug').isDbg;
+var uaOUJS = require('../libs/debug').uaOUJS;
 
 //
 var GitHubApi = require("github");
@@ -67,7 +68,12 @@ var githubUserContentGetBlobAsUtf8 = function (aMsg, aCallback) {
   async.waterfall([
     function (aCallback) {
       var url = githubUserContentBuildUrl(aMsg.user, aMsg.repo, aMsg.path);
-      request.get(url, aCallback);
+      request.get({
+        url: url,
+        headers: {
+          'User-Agent': uaOUJS + '.' + process.env.UA_SECRET
+        }
+      }, aCallback);
     },
     function (aResponse, aBody, aCallback) {
       if (aResponse.statusCode !== 200)

--- a/libs/repoManager.js
+++ b/libs/repoManager.js
@@ -4,6 +4,7 @@
 var isPro = require('../libs/debug').isPro;
 var isDev = require('../libs/debug').isDev;
 var isDbg = require('../libs/debug').isDbg;
+var uaOUJS = require('../libs/debug').uaOUJS;
 var statusError = require('../libs/debug').statusError;
 
 //--- Dependency inclusions
@@ -60,7 +61,7 @@ function fetchRaw(aHost, aPath, aCallback, aOptions) {
     path: aPath,
     method: 'GET',
     headers: {
-      'User-Agent': 'Node.js'
+      'User-Agent': uaOUJS + '.' + process.env.UA_SECRET
     }
   };
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "font-awesome": "4.7.0",
     "formidable": "1.2.2",
     "git-rev": "0.2.1",
+    "git-rev-sync": "3.0.1",
     "github": "git://github.com/octokit/rest.js.git#29dedb3",
     "highlight.js": "10.1.2",
     "image-size": "0.8.3",


### PR DESCRIPTION
* Additional confirmation is needed when GH contacts us with a predefined secret
* New dep... synchronous git-rev *(forked by another)* ... needed because some of our code is too fast for the asynchronous return dep.
* Add missing UA in one request for the GH client ... pinging the certificate doesn't really need one but symmetry.

Applies to #1730