### PR TITLE
Workaround for current Fx Browser and WebExtensions

### DIFF
--- a/controllers/scriptStorage.js
+++ b/controllers/scriptStorage.js
@@ -706,6 +706,16 @@ exports.sendScript = function (aReq, aRes, aNext) {
             return;
           }
 
+          // Don't count installs from tagged XHR
+          if (aReq.get('x-requested-with')) {
+            return;
+          }
+
+          // Don't count installs from Fx XHR
+          if (aReq.get('accept') === '*/*') { // NOTE: Watchpoint
+            return;
+          }
+
           // Update the install count
           ++aScript.installs;
           ++aScript.installsSinceUpdate;

--- a/views/includes/scriptPageHeader.html
+++ b/views/includes/scriptPageHeader.html
@@ -2,7 +2,7 @@
   {{#isScriptPage}}
     {{^script.isLib}}
     <div class="btn-group pull-right">
-      <a href="{{{script.scriptInstallPageUrl}}}" class="btn btn-{{^script.showSourceNoticesCritical}}info{{/script.showSourceNoticesCritical}}{{#script.showSourceNoticesCritical}}danger{{/script.showSourceNoticesCritical}}">
+      <a href="{{{script.scriptInstallPageUrl}}}" class="btn btn-{{^script.showSourceNoticesCritical}}info{{/script.showSourceNoticesCritical}}{{#script.showSourceNoticesCritical}}danger{{/script.showSourceNoticesCritical}}" type="text/javascript">
         <i class="fa fa-download"></i> Install
       </a>
       <button type="button" class="btn btn-{{^script.showSourceNotices}}info{{/script.showSourceNotices}}{{#script.showSourceNotices}}{{^script.showSourceNoticesCritical}}warning{{/script.showSourceNoticesCritical}}{{#script.showSourceNoticesCritical}}danger{{/script.showSourceNoticesCritical}}{{/script.showSourceNotices}} dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">


### PR DESCRIPTION
* Fx has been hitting us twice on installs via at least TM and GM. This is a work-around atm. Limiting will **not** be adjusted accordingly by design.
* Add a hint at the type expected to the UI ... this doesn't do much atm but there for testing.
* Add common tagged XHR check too for frameworks

NOTES:
* Tested okay in SM and Chromium... will check Safari shortly