### PR TITLE
Limit username length

### DIFF
--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -150,6 +150,11 @@ exports.auth = function (aReq, aRes, aNext) {
     return;
   }
 
+  if (username.length > 64) {
+    aRes.redirect('/login?toolong');
+    return;
+  }
+
   // Store the username in the session so we still have it when they
   // get back from authentication
   if (!aReq.session.username) {


### PR DESCRIPTION
* This prevents some flooding
* Can tweak this a little bit but we'll see
* Checked with `db.users.find({$where:'this.name.length > 65'}).pretty();`