### PR TITLE
Backend renewal check for expired certs

### DIFF
--- a/libs/debug.js
+++ b/libs/debug.js
@@ -36,6 +36,7 @@ try {
   exports.fullchain = fullchain;
   exports.chain = chain;
   exports.isSecured = true;
+  exports.isRenewable = false;
 
 } catch (aE) {
   // Check for backup alternate keys
@@ -52,6 +53,7 @@ try {
     exports.fullchain = fullchain;
     exports.chain = chain;
     exports.isSecured = true;
+    exports.isRenewable = !!process.env.ATTEMPT_RENEWAL;
 
   } catch (aE) {
     // Ensure that all items are nulled or equivalent
@@ -59,6 +61,7 @@ try {
     exports.fullchain = null;
     exports.chain = null;
     exports.isSecured = false;
+    exports.isRenewable = !!process.env.ATTEMPT_RENEWAL;
   }
 }
 


### PR DESCRIPTION
* If using letsencrypt, which we are currently as a secondary, put some logic in to recheck this.
* Letsencrypt renews  automatically runs every 12 hours *(which is very inefficient imho but could change on snap update)* on installation. Modifying this routine to let it run by itself and copy certs for usage in backend.
* Notated up the source a bit regarding dev and pro quirks. Outages should be no more than n seconds *(hours)* on the interval and primary will disable itself, then secondary, which is always running atm, will kick in. If failure on secondary should revert to non-secure and recheck every n seconds *(hours)* to auto-secure if renewable certs are available.

NOTE: May need some fine tuning on pro but won't know until it's there. :)

Applies to #1776