### PR TITLE
Additional dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ Repository | Reference | Recent Version
 [toobusy-js][toobusy-jsGHUrl] <br />&#x22D4; [`harmony`][toobusy-jsGHUrlHarmonyUrl] | [Documentation][toobusy-jsDOCUrl] | [![NPM version][toobusy-jsNPMVersionImage]][toobusy-jsNPMUrl]
 [underscore][underscoreGHUrl] | [Documentation][underscoreDOCUrl] | [![NPM version][underscoreNPMVersionImage]][underscoreNPMUrl]
 [useragent][useragentGHUrl] | [Documentation][useragentDOCUrl] | [![NPM version][useragentNPMVersionImage]][useragentNPMUrl]
+[@octokit/auth-oauth-app][auth-oauth-appUrl] | [Documentation][auth-oauth-appDOCUrl] | [![NPM version][auth-oauth-appNPMVersionImage]][auth-oauth-appNPMUrl]
 [@octokit/rest ᶠᵏᵃ ᵍᶦᵗʰᵘᵇ][githubGHUrl] | [Documentation][githubDOCUrl] | [![NPM version][githubNPMVersionImage]][githubNPMUrl]
-
 
 ##### Static
 
@@ -477,6 +477,11 @@ Outdated dependencies list can also be achieved with `$ npm outdated`
 [squadaOneREPOUrl]: https://www.google.com/fonts/specimen/Squada+One
 [squadaOneDOCUrl]: https://github.com/google/fonts/blob/master/README.md
 [squadaOneGHUrlRecent]: https://github.com/google/fonts/blob/master/ofl/squadaone/SquadaOne-Regular.ttf
+
+[auth-oauth-appGHUrl]: https://github.com/octokit/auth-oauth-app.js
+[auth-oauth-appDOCUrl]: https://github.com/octokit/auth-oauth-app.js/blob/master/README.md
+[auth-oauth-appNPMUrl]: https://www.npmjs.com/package/@octokit/auth-oauth-app
+[auth-oauth-appNPMVersionImage]: https://img.shields.io/npm/v/@octokit/auth-oauth-app.svg?style=flat
 
 [githubGHUrl]: https://github.com/octokit/rest.js
 [githubDOCUrl]: https://github.com/octokit/rest.js/blob/master/README.md

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "ace-builds": "1.4.12",
     "ansi-colors": "4.1.1",
     "async": "3.2.0",
+    "@octokit/auth-oauth-app": "4.1.2",
     "aws-sdk": "2.879.0",
     "base62": "2.0.1",
     "body-parser": "1.19.0",

--- a/routes.js
+++ b/routes.js
@@ -136,9 +136,11 @@ module.exports = function (aApp) {
   aApp.route('/users/:username/comments').get(listLimiter, user.userCommentListPage);
   aApp.route('/users/:username/scripts').get(listLimiter, user.userScriptListPage);
   aApp.route('/users/:username/syncs').get(listLimiter, user.userSyncListPage);
+
   aApp.route('/users/:username/github/repos').get(authentication.validateUser, user.userGitHubRepoListPage);
   aApp.route('/users/:username/github/repo').get(authentication.validateUser, user.userGitHubRepoPage);
   aApp.route('/users/:username/github/import').post(authentication.validateUser, user.userGitHubImportScriptPage);
+
   aApp.route('/users/:username/profile/edit').get(authentication.validateUser, user.userEditProfilePage).post(authentication.validateUser, user.update);
   aApp.route('/users/:username/update').post(authentication.validateUser, admin.adminUserUpdate);
   // NOTE: Some below inconsistent with priors


### PR DESCRIPTION
* Partially migrate to newer dep for GH API
* Adding some error protection, **but not all**, to the GH API deprecation of QSP's. This is probably temporary until a broader fix is implemented. GH importing may have to be disabled after May 5th, 2021... webhooks might be affected if the old (or new) Promise rejection fails. i.e. no more webhooks... but we'll see after the 5th of next month if not addressed.

Applies to #1705

NOTE(S):
* Due to the nature of the dependency with Promises it is currently contrary to the STYLEGUIDE.md See #1556 as is #1729 with ES6+ syntax.
* Doing what I can to avert this chaos but the Code is spread out all over the place.