### PR TITLE
Shrink instructions

### DIFF
--- a/views/pages/newScriptPage.html
+++ b/views/pages/newScriptPage.html
@@ -69,7 +69,7 @@
             <a href="{{{authedUser.userGitHubRepoListPageUrl}}}" class="list-group-item">
               <h4 class="list-group-item-heading"><i class="octicon octicon-fw octicon-repo-clone"></i> Import Script from GitHub</h4>
               <p class="list-group-item-text">
-                Click here to import a script<em>(s)</em> from a personal user GitHub repository. If Sync Script using GitHub has already been set up for the selected repository then it should automatically be linked for any scripts imported.
+                Click here to import a script<em>(s)</em> from a personal user GitHub repository. If Sync Script using GitHub has already been set up for the selected repository then it should automatically be linked for any scripts imported or previously directly published.
               </p>
             </a>
             {{/authedUser.hasGithub}}
@@ -299,7 +299,7 @@
               <div id="collapse-openuserjs-collaboration" class="panel-collapse collapse">
                 <div class="panel-body">
                   <p>The OpenUserJS Author username to collaborate with.</p>
-                  <p>Required to activate <a href="#collaboration">Collaboration</a>. <strong>Please ensure the usernames exist for your scripts security.</strong></p>
+                  <p><strong>Required to activate</strong> <a href="#collaboration">Collaboration</a>. <strong>Please ensure the usernames exist for your scripts security.</strong></p>
                   <p>May be defined multiple times.</p>
                   <p>All values shown in reverse order.</p>
                 </div>
@@ -313,15 +313,29 @@
           <div class="panel panel-default">
             <div class="panel-body">
               <h3><a id="collaboration"></a><img src="/images/favicon.gs.min.svg" width="26" height="26"> Collaboration<a href="#collaboration" class="anchor"><i class="fa fa-link"></i></a></h3>
-              <p>To allow other users to upload modified versions of your script to your account from this site create an OpenUserJS metadata block and add the necessary keys... one for you yourself and for every existing user you wish to give write access as demonstrated here:<pre class="small"><code>// ==OpenUserJS==</code><br /><code>// @author {{#authedUser}}{{authedUser.name}}{{/authedUser}}{{^authedUser}}username{{/authedUser}}</code><br /><code>// @collaborator username</code><br /><code>// ==/OpenUserJS==</code></pre></p>
-              <h4>Caveats</h4>
-              <ul class="small">
-                <li>Only the real author of the script may modify these metadata keys.</li>
-                {{#authedUser.hasGithub}}
-                <li>Collaborators on this site may not use GitHub integration to update the script. Add them as collaborators to the GitHub repository instead.</li>
-                <li>If the webhook is enabled on a GitHub repository it will clobber any changes here on this site.</li>
-                {{/authedUser.hasGithub}}
-              </ul>
+              <p>To allow other users to upload modified versions of your script to your account from this site create an OpenUserJS metadata block and add the necessary keys.
+              <div class="panel panel-default">
+                <div class="panel-heading">
+                  <h4>
+                    <a id="sync-script-collaboration" rel="bookmark"></a>
+                    <a data-toggle="collapse" data-parent="#accordion-sync-script-collaboration" href="#collapse-collaboration-instructions">Instructions</a>
+                  </h4>
+                </div>
+                <div id="collapse-collaboration-instructions" class="panel-collapse collapse">
+                  <div class="panel-body">
+                    <p>Add one for you yourself and for every existing user you wish to give write access as demonstrated here:</p>
+                    <pre class="small"><code>// ==OpenUserJS==</code><br /><code>// @author {{#authedUser}}{{authedUser.name}}{{/authedUser}}{{^authedUser}}username{{/authedUser}}</code><br /><code>// @collaborator username</code><br /><code>// ==/OpenUserJS==</code></pre></p>
+                    <h4>Caveats</h4>
+                    <ul class="small">
+                      <li>Only the real author of the script may modify these metadata keys.</li>
+                      {{#authedUser.hasGithub}}
+                      <li>Collaborators on this site may not use GitHub integration to update the script. Add them as collaborators to the GitHub repository instead.</li>
+                      <li>If the webhook is enabled on a GitHub repository it will clobber any changes here on this site.</li>
+                      {{/authedUser.hasGithub}}
+                    </ul>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
           {{#authedUser.hasGithub}}
@@ -329,23 +343,34 @@
             <div class="panel-body">
               <h3><a id="github"></a><i class="octicon octicon-mark-github"></i> GitHub<a href="#github" class="anchor"><i class="fa fa-link"></i></a></h3>
               <p>You may add a webhook to one or more of your personal user GitHub repositories to automatically keep it up to date on OpenUserJS.org.</p>
-              <h4>Instructions</h4>
-              <p>Optionally you may upload the script to the site first. You may also use <a href="{{{authedUser.userGitHubRepoListPageUrl}}}">Import from Github</a> to speed things up as a shortcut.</p>
-              <ol>
-                <li>Ensure that you have GitHub as an authentication for this site.</li>
-                <li>Ensure that you have and use a default <code>master</code> branch.</li>
-                <li>On your target GitHub repo, click Settings &gt; Webhooks &gt; Add Webhook.</li>
-                <li>In the Payload URL input, paste<br /><code>https://openuserjs.org/github/hook</code></li>
-                <li>Change the Content Type dropdown to<br /><code>application/x-www-form-urlencoded</code></li>
-                <li>Click <code>Add Webhook</code>.</li>
-              </ol>
-              <p>After adding the webhook, push a change to GitHub to make sure it's working.</p>
-              <h4>Caveats</h4>
-              <ul class="small">
-                <li>This site will return an acknowledgement to GitHub of acceptance for queued retrieval. Larger payloads will take more time to process.</li>
-                <li>GitHub currently has a caching mecahnism that may prevent serving the next version from being pulled too quickly so please give a little time in-between commits.</li>
-                <li>If the database is locked, such as during brief maintenance periods or lockdown, updates may be temporarily rejected and may need to be redelivered manually.</li>
-              </ul>
+              <div class="panel panel-default">
+                <div class="panel-heading">
+                  <h4>
+                    <a id="sync-script-github" rel="bookmark"></a>
+                    <a data-toggle="collapse" data-parent="#accordion-sync-script-github" href="#collapse-github-instructions">Instructions</a>
+                  </h4>
+                </div>
+                <div id="collapse-github-instructions" class="panel-collapse collapse">
+                  <div class="panel-body">
+                    <p>Optionally you may upload the script to the site first. You may also use <a href="{{{authedUser.userGitHubRepoListPageUrl}}}">Import from Github</a> to speed things up as a shortcut.</p>
+                    <ol>
+                      <li>Ensure that you have GitHub as an authentication for this site.</li>
+                      <li>Ensure that you have and use a default <code>master</code> branch.</li>
+                      <li>On your target GitHub repo, click Settings &gt; Webhooks &gt; Add Webhook.</li>
+                      <li>In the Payload URL input, paste<br /><code>https://openuserjs.org/github/hook</code></li>
+                      <li>Change the Content Type dropdown to<br /><code>application/x-www-form-urlencoded</code></li>
+                      <li>Click <code>Add Webhook</code>.</li>
+                    </ol>
+                    <p>After adding the webhook, push a change to GitHub to make sure it's working.</p>
+                    <h4>Caveats</h4>
+                    <ul class="small">
+                      <li>This site will return an acknowledgement to GitHub of acceptance for queued retrieval. Larger payloads will take more time to process.</li>
+                      <li>GitHub currently has a caching mecahnism that may prevent serving the next version from being pulled too quickly so please give a little time in-between commits.</li>
+                      <li>If the database is locked, such as during brief maintenance periods or lockdown, updates may be temporarily rejected and may need to be redelivered manually.</li>
+                    </ul>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
           {{/authedUser.hasGithub}}


### PR DESCRIPTION
* Use *bootstrap* accordion to hide the instructions until clicked/tapped. If/when the feature gets reenabled they might be longer for GH.
* Symmetry
* Some bolding elsewhere
* Verbage on previously published... webhook currently sends all push notices whether published or not.

Applies to #1705 and post #1736