### PR TITLE
More error checking and casing

### DIFF
--- a/libs/repoManager.js
+++ b/libs/repoManager.js
@@ -106,7 +106,7 @@ function fetchJSON(aPath, aCallback) {
   var encodedAuth = Buffer.from(`${clientId}:${clientKey}`).toString('base64');
   var opts = {
     headers: {
-      Authorization: `Basic ${encodedAuth}`
+      authorization: `basic ${encodedAuth}`
     }
   };
   fetchRaw('api.github.com', aPath, function (aBufs) {


### PR DESCRIPTION
* Translate GH's 403 to 503
* If/when the dep gets updated, gracefully handle GH's 403 as much as possible at authenticated and non-authenticated requests.
* The *@octokit/auth-token* dep returns lower casings for `authentication` and `basic`... not sure if matching this makes a difference but today I've been getting 45 maximum on unauthenticated GH rate limiting with this. Post #1729

Applies to #1705 #37