### PR TITLE
Enable debugging of *github* dep

### DIFF
--- a/libs/debug.js
+++ b/libs/debug.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var inspector = require('inspector');
 var fs = require('fs');
 var os = require('os');
 
@@ -10,7 +11,7 @@ pkg.org = pkg.name.substring(0, pkg.name.indexOf('.'));
 
 var isPro = process.env.NODE_ENV === 'production';
 var isDev = !isPro;
-var isDbg = typeof v8debug === 'object';
+var isDbg = typeof v8debug === 'object' || inspector.url();
 
 var privkey = null;
 var fullchain = null;

--- a/libs/githubClient.js
+++ b/libs/githubClient.js
@@ -18,7 +18,11 @@ var createOAuthAppAuth = require("@octokit/auth-oauth-app").createOAuthAppAuth;
 
 // Client
 var github = new GitHubApi({
-  version: "3.0.0"
+  version: "3.0.0",
+  debug: (isDbg ? true : false),
+  headers: {
+    "User-Agent": uaOUJS + (process.env.UA_SECRET ? ' ' + process.env.UA_SECRET : '')
+  }
 });
 module.exports = github;
 


### PR DESCRIPTION
* Also at some point *node* changed the way to detect if debugging was in process. Updated original comment at https://github.com/OpenUserJS/OpenUserJS.org/pull/429#issuecomment-63425552 Been a while since I've been in this mode for deep debug examination.
* Fix missing custom headers for UA. This is optional but didn't know this until now that it had that option for the *github* dep. Post #1753

Applies to #1705

Ref(s):
* https://nodejs.org/api/inspector.html#inspector_inspector_url
* https://nodejs.org/api/debugger.html