### PR TITLE
More error checking

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -1254,7 +1254,9 @@ exports.userGitHubRepoListPage = function (aReq, aRes, aNext) {
     var msg = null;
 
     if (aErr) {
-      switch (aErr.code) {
+      switch (aErr.code) { // NOTE: Important to test for GH code vs potential OUJS code
+        case 401:
+          // fallsthrough
         case 403:
           try {
             msg = JSON.parse(aErr.message);
@@ -1398,7 +1400,9 @@ exports.userGitHubRepoPage = function (aReq, aRes, aNext) {
     var msg = null;
 
     if (aErr) {
-      switch (aErr.code) {
+      switch (aErr.code) { // NOTE: Important to test for GH code vs potential OUJS code
+        case 401:
+          // fallsthrough
         case 403:
           try {
             msg = JSON.parse(aErr.message);
@@ -1766,7 +1770,9 @@ exports.userGitHubImportScriptPage = function (aReq, aRes, aNext) {
       }
 
       if (!(aErr instanceof String)) {
-        switch (aErr.code) { // NOTE: Important to test for GH 403 vs potential OUJS 403
+        switch (aErr.code) { // NOTE: Important to test for GH code vs potential OUJS code
+          case 401:
+            // fallsthrough
           case 403:
             try {
               msg = JSON.parse(aErr.message);

--- a/libs/repoManager.js
+++ b/libs/repoManager.js
@@ -107,7 +107,7 @@ function fetchJSON(aPath, aCallback) {
     encodedAuth = Buffer.from(`${clientId}:${clientKey}`).toString('base64');
     opts = {
       headers: {
-        authorization: `basic ${encodedAuth}`
+        Authorization: `Basic ${encodedAuth}`
       }
     };
   }


### PR DESCRIPTION
* Transform GH 401 to 503 .  Mentioned at https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/ and encountered with newer *(attempted)* migrated dep.
* Spec for authorization shows uppercasing... so new dep has it with incorrect casing I believe... may not matter on their server but consistancy here. Reverting.
* Add a few more important comments

Applies to #1705 #37 and post #1799

Ref(s):
* https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.8
* https://developer.mozilla.org/docs/Web/HTTP/Authentication