### PR TITLE
CSS toolbar spacing for input editors

### DIFF
--- a/public/css/common.css
+++ b/public/css/common.css
@@ -130,8 +130,15 @@ h2.page-heading {
   position: fixed;
 }
 
-.md-editor {
+.md-editor,
+.md-input {
   min-height: 300px;
+}
+
+.md-editor textarea,
+.md-input textarea,
+.md-editor .md-preview {
+  margin-bottom: 10px !important;
 }
 
 textarea {

--- a/views/includes/commentEditor.html
+++ b/views/includes/commentEditor.html
@@ -21,7 +21,7 @@
         </div>
         <div class="topic-post-contents row">
           <div class="user-data">
-            <textarea name="comment-content" data-provide="markdown" data-iconlibrary="fa" class="col-xs-12" placeholder="Type here using Markdown." required="required"></textarea>
+            <textarea name="comment-content" data-provide="markdown" data-iconlibrary="fa" rows="28" class="col-xs-12" placeholder="Type here using Markdown." required="required"></textarea>
           </div>
           <div class="submit-panel btn-toolbar">
             <a href="/about/Frequently-Asked-Questions"><i class="fa fa-question-circle" title="FAQ"></i></a>

--- a/views/pages/scriptEditMetadataPage.html
+++ b/views/pages/scriptEditMetadataPage.html
@@ -20,7 +20,7 @@
             <div class="col-xs-12">
               {{> includes/scriptPageHeader.html }}
               <div class="user-content">
-                <textarea name="about" data-provide="markdown" data-iconlibrary="fa" rows="28" class="col-xs-12">{{script.about}}</textarea>
+                <textarea name="about" data-provide="markdown" data-iconlibrary="fa" rows="28" class="col-xs-12" placeholder="Type here using Markdown.">{{script.about}}</textarea>
               </div>
               <div class="btn-toolbar">
                 <a href="/about/Frequently-Asked-Questions"><i class="fa fa-question-circle" title="FAQ"></i></a>

--- a/views/pages/userEditProfilePage.html
+++ b/views/pages/userEditProfilePage.html
@@ -15,7 +15,7 @@
             {{> includes/userPageHeader.html }}
             <form action="" method="post">
               <div class="user-content">
-                <textarea name="about" data-provide="markdown" data-iconlibrary="fa" rows="28" class="col-xs-12">{{user.about}}</textarea>
+                <textarea name="about" data-provide="markdown" data-iconlibrary="fa" rows="28" class="col-xs-12" placeholder="Type here using Markdown.">{{user.about}}</textarea>
               </div>
               <div class="btn-toolbar">
                 <a href="/about/Frequently-Asked-Questions"><i class="fa fa-question-circle" title="FAQ"></i></a>


### PR DESCRIPTION
* Replying to an existing comment should remain at default rows at this time.
* Absent `placeholder`s for helping tip fixed.

Post #1803

NOTE(s):
* Don't like using `!important` but necessary at this time with *bootstrap-markdown*. Little finicky still.