### PR TITLE
Automate closure locking w GH Actions

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,14 @@
+name: 'Lock Threads'
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  lock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v2
+        with:
+          github-token: ${{ github.token }}
+          issue-lock-inactive-days: '1'


### PR DESCRIPTION
* May still do this manually per policy before triggered or failed.
* If an issue needs to be reopened for some reason reset lock if necessary.
* Adds a layer of security against occasional spamming.

Applies to #249 #1791

Ref:
* https://github.com/dessant/lock-threads