### PR TITLE
Flip auth type

### DIFF
--- a/libs/githubClient.js
+++ b/libs/githubClient.js
@@ -51,12 +51,13 @@ Strategy.findOne({ name: 'github' }, async function (aErr, aStrat) {
     // TODO: Do something with `appAuthentication`
 
 
-    // DEPRECATED: This method will break on May 5th, 2021. See #1705
-    //  and importing a repo will be severely hindered with possible timeouts/failures
+    // DEPRECATED: See #1705
+    // NOTE: We are technically an oauth app client but uses the same authentication type
+    //   methodology in the static version of the dependency. In future versions it may be different.
     github.authenticate({
-      type: 'oauth',
-      key: aStrat.id,
-      secret: aStrat.key
+      type: 'basic',
+      username: aStrat.id,
+      password: aStrat.key
     });
 
     // TODO: error handler for UnhandledPromiseRejectionWarning if it crops up after deprecation.


### PR DESCRIPTION
* I'm guessing the failure that was encountered at https://github.com/OpenUserJS/OpenUserJS.org/issues/1705#issuecomment-582658182 may have been a fluke on the GH back-end.
* GH Docs and blog posts are a little too vague for my tastes with `username` and `password`... however upon manual deconstruction and inspection of the *github* dep at https://github.com/OpenUserJS/rest.js/blob/29dedb3022649c27ac1dad79326270b6b2a48047/index.js#L730 it uses nearly what the maintainer mentioned at [the discussion](https://github.com/octokit/octokit.js/discussions/2070) and what joeytwiddle did at #1729 in the recently discovered dead code. *nodes* default for `Buffer` is `utf8` whereas *github*@0.2.4 via commit ref uses `ascii`. Since hashes usually only contain ASCII should not be an issue.
* Newest dep at the time of testing with *@octokit/rest* for this seems to be unstable so going with this for a while since it currently gives the higher rate limit. This could change depending on what they do in the back-end.

Applies to #1705

NOTE(s)
* a GH url changed recently from https://github.com/octokit/rest.js to https://github.com/octokit/octokit.js ... may affect things even further.