### PR TITLE
Move around flagging a bit.

### DIFF
--- a/controllers/flag.js
+++ b/controllers/flag.js
@@ -26,6 +26,7 @@ var flagLib = require('../libs/flag');
 var statusCodePage = require('../libs/templateHelpers').statusCodePage;
 
 //--- Configuration inclusions
+var userRoles = require('../models/userRoles.json');
 
 //---
 
@@ -184,6 +185,7 @@ exports.getFlaggedListForContent = function (aModelName, aOptions, aCallback) {
 
           contentList[aContentKey].flaggedList.push({
             name: aUser.name,
+            rank: userRoles[aUser.role],
             reason: aFlagList[aFlagKey].reason,
             since: aFlagList[aFlagKey].created
           });

--- a/controllers/index.js
+++ b/controllers/index.js
@@ -100,7 +100,7 @@ exports.home = function (aReq, aRes) {
 
     async.parallel([
       function (aCallback) {
-        if (!!!options.isFlagged || !options.isAdmin) {  // NOTE: Watchpoint
+        if (!!!options.isFlagged || !options.isMod) {  // NOTE: Watchpoint
           aCallback();
           return;
         }

--- a/controllers/script.js
+++ b/controllers/script.js
@@ -340,7 +340,7 @@ exports.view = function (aReq, aRes, aNext) {
 
         async.parallel([
           function (aCallback) {
-            if (!options.isAdmin) {  // NOTE: Watchpoint
+            if (!options.isMod) {  // NOTE: Watchpoint
               aCallback();
               return;
             }

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -398,7 +398,7 @@ exports.userListPage = function (aReq, aRes, aNext) {
 
     async.parallel([
       function (aCallback) {
-        if (!!!options.isFlagged || !options.isAdmin) {  // NOTE: Watchpoint
+        if (!!!options.isFlagged || !options.isMod) {  // NOTE: Watchpoint
           aCallback();
           return;
         }
@@ -471,7 +471,7 @@ exports.view = function (aReq, aRes, aNext) {
 
       async.parallel([
         function (aCallback) {
-          if (!options.isAdmin) {  // NOTE: Watchpoint
+          if (!options.isMod) {  // NOTE: Watchpoint
             aCallback();
             return;
           }
@@ -703,7 +703,7 @@ exports.userScriptListPage = function (aReq, aRes, aNext) {
 
       async.parallel([
         function (aCallback) {
-          if (!!!options.isFlagged || !options.isAdmin) {  // NOTE: Watchpoint
+          if (!!!options.isFlagged || !options.isMod) {  // NOTE: Watchpoint
             aCallback();
             return;
           }

--- a/views/includes/scriptAdminToolsPanel.html
+++ b/views/includes/scriptAdminToolsPanel.html
@@ -7,23 +7,6 @@
     </div>
   </div>
   <div class="panel-body">
-    {{#hasFlagged}}
-    <div class="form-horizontal">
-      <div class="form-group">
-        <label class="col-sm-4 control-label">Flagged</label>
-        <div class="col-sm-8">
-          <ul class="flaggedList">
-          {{#script.flaggedList}}
-            <li>
-              {{#name}}<span class="label label-info"><a href="/users/{{name}}">{{name}}</a></span>{{/name}}
-              <span title="{{since}}">{{#reason}}{{reason}}{{/reason}}{{^reason}}&hellip;{{/reason}}</span>
-            </li>
-          {{/script.flaggedList}}
-          </ul>
-        </div>
-      </div>
-    </div>
-    {{/hasFlagged}}
     <div class="form-group">
       <div class="input-group col-xs-12">
         <span class="input-group-btn">

--- a/views/includes/scriptList.html
+++ b/views/includes/scriptList.html
@@ -11,51 +11,100 @@
     </tr>
   </thead>
   <tbody>
-    {{#scriptList}}
-    <tr class="tr-link">
-      <td>
-        {{#showSourceNotices}}<span class="pull-right"><i class="fa fa-fw fa-exclamation-triangle" title="Source Code notices"></i></span>{{/showSourceNotices}}
-        {{#showSourceNoticesCritical}}<span class="pull-right"><i class="fa fa-fw fa-exclamation-circle" title="Critical Source Code notices"></i></span>{{/showSourceNoticesCritical}}
-        {{#_issueCount}}<span class="pull-right"><a href="{{{scriptIssuesPageUri}}}/open" title="Open issue discussions"><i class="fa fa-fw fa-commenting"></i>{{_issueCount}}</a></span>{{/_issueCount}}
-        <span class="script-icon hidden-xs" {{#icon16Url}}data-icon-src="{{{icon16Url}}}" data-icon-size="16"{{/icon16Url}}>
-          {{#isLib}}<i class="fa fa-fw fa-file-excel-o"></i>{{/isLib}}{{^isLib}}<i class="fa fa-fw fa-file-code-o"></i>{{/isLib}}
-        </span>
-        <a href="{{{scriptPageUrl}}}" class="tr-link-a"><b>{{name}}</b></a>
-        {{#meta.UserScript.version}}
-        <span class="script-version label label-default">{{value}}</span>
-        {{/meta.UserScript.version}}
-        <span class="inline-block">by <a href="{{{author.userPageUrl}}}">{{author.name}}</a></span>
-        {{#_description}}<p>{{_description}}{{#hasLongDescription}}<strong>&hellip;</strong>{{/hasLongDescription}}</p>{{/_description}}
-      </td>
-      {{^librariesOnly}}
-      <td class="text-center td-fit">
-        <p>{{#isLib}}&ndash;{{/isLib}}{{^isLib}}{{installs}}{{/isLib}}</p>
-      </td>
-      {{/librariesOnly}}
-      <td class="rating text-center td-fit">
-        <p>{{rating}}</p>
-        <div class="progress">
-          <div style="width: {{votesPercent}}%" class="progress-bar progress-bar-good"></div>
-          <div style="width: {{flagsPercent}}%" class="progress-bar progress-bar-danger"></div>
-        </div>
-      </td>
-      <td class="text-center td-fit">
-        <time datetime="{{updatedISOFormat}}" title="{{updated}}" class="iconic">{{{updatedHumanizedIconic}}}</time>
-      </td>
-      {{#hasFlagged}}
-      <td>
-        <ul class="flaggedList">
-        {{#flaggedList}}
-          <li>
-            {{#name}}<span class="label label-info"><a href="/users/{{name}}">{{name}}</a></span>{{/name}}
-            <span title="{{since}}">{{#reason}}{{reason}}{{/reason}}{{^reason}}&hellip;{{/reason}}</span>
-          </li>
-        {{/flaggedList}}
-        </ul>
-      </td>
-      {{/hasFlagged}}
-    </tr>
-    {{/scriptList}}
+    {{#isAdmin}}
+      {{#scriptList}}
+      <tr class="tr-link">
+        <td>
+          {{#showSourceNotices}}<span class="pull-right"><i class="fa fa-fw fa-exclamation-triangle" title="Source Code notices"></i></span>{{/showSourceNotices}}
+          {{#showSourceNoticesCritical}}<span class="pull-right"><i class="fa fa-fw fa-exclamation-circle" title="Critical Source Code notices"></i></span>{{/showSourceNoticesCritical}}
+          {{#_issueCount}}<span class="pull-right"><a href="{{{scriptIssuesPageUri}}}/open" title="Open issue discussions"><i class="fa fa-fw fa-commenting"></i>{{_issueCount}}</a></span>{{/_issueCount}}
+          <span class="script-icon hidden-xs" {{#icon16Url}}data-icon-src="{{{icon16Url}}}" data-icon-size="16"{{/icon16Url}}>
+            {{#isLib}}<i class="fa fa-fw fa-file-excel-o"></i>{{/isLib}}{{^isLib}}<i class="fa fa-fw fa-file-code-o"></i>{{/isLib}}
+          </span>
+          <a href="{{{scriptPageUrl}}}" class="tr-link-a"><b>{{name}}</b></a>
+          {{#meta.UserScript.version}}
+          <span class="script-version label label-default">{{value}}</span>
+          {{/meta.UserScript.version}}
+          <span class="inline-block">by <a href="{{{author.userPageUrl}}}">{{author.name}}</a></span>
+          {{#_description}}<p>{{_description}}{{#hasLongDescription}}<strong>&hellip;</strong>{{/hasLongDescription}}</p>{{/_description}}
+        </td>
+        {{^librariesOnly}}
+        <td class="text-center td-fit">
+          <p>{{#isLib}}&ndash;{{/isLib}}{{^isLib}}{{installs}}{{/isLib}}</p>
+        </td>
+        {{/librariesOnly}}
+        <td class="rating text-center td-fit">
+          <p>{{rating}}</p>
+          <div class="progress">
+            <div style="width: {{votesPercent}}%" class="progress-bar progress-bar-good"></div>
+            <div style="width: {{flagsPercent}}%" class="progress-bar progress-bar-danger"></div>
+          </div>
+        </td>
+        <td class="text-center td-fit">
+          <time datetime="{{updatedISOFormat}}" title="{{updated}}" class="iconic">{{{updatedHumanizedIconic}}}</time>
+        </td>
+        {{#hasFlagged}}
+        <td>
+          <ul class="flaggedList">
+          {{#flaggedList}}
+            <li>
+              {{#name}}<span class="label label-info"><a href="/users/{{name}}">{{name}}</a></span>{{/name}}
+              <span title="{{since}}">{{#reason}}{{reason}}{{/reason}}{{^reason}}&hellip;{{/reason}}</span>
+            </li>
+          {{/flaggedList}}
+          </ul>
+        </td>
+        {{/hasFlagged}}
+      </tr>
+      {{/scriptList}}
+    {{/isAdmin}}
+    {{^isAdmin}}
+      {{#scriptList}}
+      <tr class="tr-link">
+        <td>
+          {{#showSourceNotices}}<span class="pull-right"><i class="fa fa-fw fa-exclamation-triangle" title="Source Code notices"></i></span>{{/showSourceNotices}}
+          {{#showSourceNoticesCritical}}<span class="pull-right"><i class="fa fa-fw fa-exclamation-circle" title="Critical Source Code notices"></i></span>{{/showSourceNoticesCritical}}
+          {{#_issueCount}}<span class="pull-right"><a href="{{{scriptIssuesPageUri}}}/open" title="Open issue discussions"><i class="fa fa-fw fa-commenting"></i>{{_issueCount}}</a></span>{{/_issueCount}}
+          <span class="script-icon hidden-xs" {{#icon16Url}}data-icon-src="{{{icon16Url}}}" data-icon-size="16"{{/icon16Url}}>
+            {{#isLib}}<i class="fa fa-fw fa-file-excel-o"></i>{{/isLib}}{{^isLib}}<i class="fa fa-fw fa-file-code-o"></i>{{/isLib}}
+          </span>
+          <a href="{{{scriptPageUrl}}}" class="tr-link-a"><b>{{name}}</b></a>
+          {{#meta.UserScript.version}}
+          <span class="script-version label label-default">{{value}}</span>
+          {{/meta.UserScript.version}}
+          <span class="inline-block">by <a href="{{{author.userPageUrl}}}">{{author.name}}</a></span>
+          {{#_description}}<p>{{_description}}{{#hasLongDescription}}<strong>&hellip;</strong>{{/hasLongDescription}}</p>{{/_description}}
+        </td>
+        {{^librariesOnly}}
+        <td class="text-center td-fit">
+          <p>{{#isLib}}&ndash;{{/isLib}}{{^isLib}}{{installs}}{{/isLib}}</p>
+        </td>
+        {{/librariesOnly}}
+        <td class="rating text-center td-fit">
+          <p>{{rating}}</p>
+          <div class="progress">
+            <div style="width: {{votesPercent}}%" class="progress-bar progress-bar-good"></div>
+            <div style="width: {{flagsPercent}}%" class="progress-bar progress-bar-danger"></div>
+          </div>
+        </td>
+        <td class="text-center td-fit">
+          <time datetime="{{updatedISOFormat}}" title="{{updated}}" class="iconic">{{{updatedHumanizedIconic}}}</time>
+        </td>
+        {{#hasFlagged}}
+        <td>
+          <ul class="flaggedList">
+          {{#flaggedList}}
+            <li>
+              {{#name}}<span class="label label-default">{{rank}}</a></span>{{/name}}
+              <span title="{{since}}">{{#reason}}{{reason}}{{/reason}}{{^reason}}&hellip;{{/reason}}</span>
+            </li>
+          {{/flaggedList}}
+          </ul>
+        </td>
+        {{/hasFlagged}}
+      </tr>
+      {{/scriptList}}
+    {{/isAdmin}}
     {{^scriptList}}
     <tr class="tr-link">
       <td colspan="4">

--- a/views/includes/scriptModToolsPanel.html
+++ b/views/includes/scriptModToolsPanel.html
@@ -1,5 +1,5 @@
 {{#modTools}}
-<div class="panel panel-default">
+<div class="panel {{#canRemove}}panel-danger{{/canRemove}}{{^canRemove}}panel-default{{/canRemove}}">
   <div class="panel-heading">
     <div class="panel-title">
       <i class="fa fa-fw fa-eye"></i>
@@ -10,6 +10,44 @@
     {{#script}}
     {{> includes/flagModelSnippet.html }}
     {{/script}}
+    {{#isAdmin}}
+      {{#hasFlagged}}
+      <div class="form-horizontal">
+        <div class="form-group">
+          <label class="col-sm-4 control-label">Flagger</label>
+          <div class="col-sm-8">
+            <ul class="flaggedList">
+            {{#script.flaggedList}}
+              <li>
+                {{#name}}<span class="label label-info"><a href="/users/{{name}}">{{name}}</a></span>{{/name}}
+                <span title="{{since}}">{{#reason}}{{reason}}{{/reason}}{{^reason}}&hellip;{{/reason}}</span>
+              </li>
+            {{/script.flaggedList}}
+            </ul>
+          </div>
+        </div>
+      </div>
+      {{/hasFlagged}}
+    {{/isAdmin}}
+    {{^isAdmin}}
+      {{#hasFlagged}}
+      <div class="form-horizontal">
+        <div class="form-group">
+          <label class="col-sm-4 control-label">Flagger</label>
+          <div class="col-sm-8">
+            <ul class="flaggedList">
+            {{#script.flaggedList}}
+              <li>
+                {{#name}}<span class="label label-default">{{rank}}</span>{{/name}}
+                <span title="{{since}}">{{#reason}}{{reason}}{{/reason}}{{^reason}}&hellip;{{/reason}}</span>
+              </li>
+            {{/script.flaggedList}}
+            </ul>
+          </div>
+        </div>
+      </div>
+      {{/hasFlagged}}
+    {{/isAdmin}}
     {{#canRemove}}
     <ul class="nav nav-pills nav-justified">
       <li><a rel="nofollow" href="#" data-toggle="modal" data-target="#removeScriptModal"><i class="fa fa-ban"></i> Remove Script</a></li>

--- a/views/includes/userAdminToolsPanel.html
+++ b/views/includes/userAdminToolsPanel.html
@@ -7,23 +7,6 @@
     </div>
   </div>
   <div class="panel-body">
-    {{#hasFlagged}}
-    <div class="form-horizontal">
-      <div class="form-group">
-        <label class="col-sm-4 control-label">Flagged</label>
-        <div class="col-sm-8">
-          <ul class="flaggedList">
-          {{#user.flaggedList}}
-            <li>
-              {{#name}}<span class="label label-info"><a href="/users/{{name}}">{{name}}</a></span>{{/name}}
-              <span title="{{since}}">{{#reason}}{{reason}}{{/reason}}{{^reason}}&hellip;{{/reason}}</span>
-            </li>
-          {{/user.flaggedList}}
-          </ul>
-        </div>
-      </div>
-    </div>
-    {{/hasFlagged}}
     <form class="form-horizontal" role="form" method="post" action="{{{user.userUpdatePageUrl}}}">
       <div class="form-group container-fluid">
         <label class="col-sm-2 control-label">Role</label>

--- a/views/includes/userList.html
+++ b/views/includes/userList.html
@@ -1,7 +1,7 @@
 <table class="table table-hover table-condensed">
   <thead>
     <tr>
-      <th class="{{#orderedByName}}active{{/orderedByName}}"><a href="?orderBy=name&orderDir={{orderDir.name}}{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}{{#isFlagged}}&flagged={{isFlagged}}{{/isFlagged}}">Name</a></th>
+      <th class="text-center{{#orderedByName}} active{{/orderedByName}}"><a href="?orderBy=name&orderDir={{orderDir.name}}{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}{{#isFlagged}}&flagged={{isFlagged}}{{/isFlagged}}">Name</a></th>
       <th class="text-center td-fit{{#orderedByCreated}} active{{/orderedByCreated}}"><a href="?orderBy=created&orderDir={{orderDir.created}}{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}{{#isFlagged}}&flagged={{isFlagged}}{{/isFlagged}}">Since</a></th>
       <th class="text-center td-fit{{#orderedByRole}} active{{/orderedByRole}}"><a href="?orderBy=role&orderDir={{orderDir.role}}{{#searchBarValue}}&q={{searchBarValue}}{{/searchBarValue}}{{#isFlagged}}&flagged={{isFlagged}}{{/isFlagged}}">Rank</a></th>
       {{#hasFlagged}}
@@ -10,35 +10,68 @@
     </tr>
   </thead>
   <tbody>
-    {{#userList}}
-    <tr class="tr-link">
-      <td>
-        <b>
-          <a href="{{{userPageUrl}}}" class="tr-link-a">{{name}}</a>
-        </b>
-      </td>
-      <td class="text-center td-fit">
-        <time datetime="{{createdISOFormat}}" title="{{created}}" class="iconic">{{{createdHumanizedIconic}}}</time>
-      </td>
-      <td class="text-center td-fit">
-        <p>
-          <span class="label label-default">{{roleName}}</span>
-        </p>
-      </td>
-      {{#hasFlagged}}
-      <td>
-        <ul class="flaggedList">
-        {{#flaggedList}}
-          <li>
-            {{#name}}<span class="label label-info"><a href="/users/{{name}}">{{name}}</a></span>{{/name}}
-            <span title="{{since}}">{{#reason}}{{reason}}{{/reason}}{{^reason}}&hellip;{{/reason}}</span>
-          </li>
-        {{/flaggedList}}
-        </ul>
-      </td>
-      {{/hasFlagged}}
-    </tr>
-    {{/userList}}
+    {{#isAdmin}}
+      {{#userList}}
+      <tr class="tr-link">
+        <td>
+          <b>
+            <a href="{{{userPageUrl}}}" class="tr-link-a">{{name}}</a>
+          </b>
+        </td>
+        <td class="text-center td-fit">
+          <time datetime="{{createdISOFormat}}" title="{{created}}" class="iconic">{{{createdHumanizedIconic}}}</time>
+        </td>
+        <td class="text-center td-fit">
+          <p>
+            <span class="label label-default">{{roleName}}</span>
+          </p>
+        </td>
+        {{#hasFlagged}}
+        <td>
+          <ul class="flaggedList">
+          {{#flaggedList}}
+            <li>
+              {{#name}}<span class="label label-info"><a href="/users/{{name}}">{{name}}</a></span>{{/name}}
+              <span title="{{since}}">{{#reason}}{{reason}}{{/reason}}{{^reason}}&hellip;{{/reason}}</span>
+            </li>
+          {{/flaggedList}}
+          </ul>
+        </td>
+        {{/hasFlagged}}
+      </tr>
+      {{/userList}}
+    {{/isAdmin}}
+    {{^isAdmin}}
+      {{#userList}}
+      <tr class="tr-link">
+        <td>
+          <b>
+            <a href="{{{userPageUrl}}}" class="tr-link-a">{{name}}</a>
+          </b>
+        </td>
+        <td class="text-center td-fit">
+          <time datetime="{{createdISOFormat}}" title="{{created}}" class="iconic">{{{createdHumanizedIconic}}}</time>
+        </td>
+        <td class="text-center td-fit">
+          <p>
+            <span class="label label-default">{{roleName}}</span>
+          </p>
+        </td>
+        {{#hasFlagged}}
+        <td>
+          <ul class="flaggedList">
+          {{#flaggedList}}
+            <li>
+              {{#name}}<span class="label label-default">{{rank}}</span>{{/name}}
+              <span title="{{since}}">{{#reason}}{{reason}}{{/reason}}{{^reason}}&hellip;{{/reason}}</span>
+            </li>
+          {{/flaggedList}}
+          </ul>
+        </td>
+        {{/hasFlagged}}
+      </tr>
+      {{/userList}}
+    {{/isAdmin}}
     {{^userList}}
     <tr class="tr-link">
       <td colspan="4">

--- a/views/includes/userModToolsPanel.html
+++ b/views/includes/userModToolsPanel.html
@@ -1,5 +1,5 @@
 {{#modTools}}
-<div class="panel panel-default">
+<div class="panel {{#canRemove}}panel-danger{{/canRemove}}{{^canRemove}}panel-default{{/canRemove}}">
   <div class="panel-heading">
     <div class="panel-title">
       <i class="fa fa-fw fa-eye"></i>
@@ -10,6 +10,44 @@
     {{#user}}
     {{> includes/flagModelSnippet.html }}
     {{/user}}
+    {{#isAdmin}}
+      {{#hasFlagged}}
+      <div class="form-horizontal">
+        <div class="form-group">
+          <label class="col-sm-4 control-label">Flagger</label>
+          <div class="col-sm-8">
+            <ul class="flaggedList">
+            {{#user.flaggedList}}
+              <li>
+                {{#name}}<span class="label label-info"><a href="/users/{{name}}">{{name}}</a></span>{{/name}}
+                <span title="{{since}}">{{#reason}}{{reason}}{{/reason}}{{^reason}}&hellip;{{/reason}}</span>
+              </li>
+            {{/user.flaggedList}}
+            </ul>
+          </div>
+        </div>
+      </div>
+      {{/hasFlagged}}
+    {{/isAdmin}}
+    {{^isAdmin}}
+      {{#hasFlagged}}
+      <div class="form-horizontal">
+        <div class="form-group">
+          <label class="col-sm-4 control-label">Flagger</label>
+          <div class="col-sm-8">
+            <ul class="flaggedList">
+            {{#user.flaggedList}}
+              <li>
+                {{#name}}<span class="label label-default">{{rank}}</span>{{/name}}
+                <span title="{{since}}">{{#reason}}{{reason}}{{/reason}}{{^reason}}&hellip;{{/reason}}</span>
+              </li>
+            {{/user.flaggedList}}
+            </ul>
+          </div>
+        </div>
+      </div>
+      {{/hasFlagged}}
+    {{/isAdmin}}
     {{#canRemove}}
     <ul class="nav nav-pills nav-justified">
       <li><a rel="nofollow" href="#" data-toggle="modal" data-target="#removeUserModal"><i class="fa fa-ban"></i> Remove User</a></li>


### PR DESCRIPTION
* Moderators can now see the reason why something is flagged. This is absolutely necessary to evaluate if a pardon occurs. Moderators may currently additionally flag with their requested intentions/summary. This has been idle on response for several years and really has to be implemented this way.
* Moderators will only see Rank so that there isn't a flame war since @sizzlemctwizzle defined it as ~"dime a dozen".
* Moved flagger *(renamed to match)* to mod panel and put a danger class on it for those that can remove to prevent accidental removal *(hasn't happened yet but good idea)*
* Some twiddling with class usage in *bootstrap* UI

Applies to #642

Note(s):
* This version of mustache generates a lot of extra UI code due to `{{#isAdmin}}` not being in scope in certain circumstances.