### PR TITLE
Adopt a portion of SRI for our implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ Repository | Reference | Recent Version
 [ansi-colors][ansi-colorsGHUrl] | [Documentation][ansi-colorsDOCUrl] | [![NPM version][ansi-colorsNPMVersionImage]][ansi-colorsNPMUrl]
 [async][asyncGHUrl] | [Documentation][asyncDOCUrl] | [![NPM version][asyncNPMVersionImage]][asyncNPMUrl]
 [aws-sdk][aws-sdkGHUrl] | [Documentation][aws-sdkDOCUrl] | [![NPM version][aws-sdkNPMVersionImage]][aws-sdkNPMUrl]
-[base62][base62GHUrl] | [Documentation][base62DOCUrl] | [![NPM version][base62NPMVersionImage]][base62NPMUrl]
 [body-parser][body-parserGHUrl] | [Documentation][body-parserDOCUrl] | [![NPM version][body-parserNPMVersionImage]][body-parserNPMUrl]
 [bootstrap][bootstrapGHUrl] | [Documentation][bootstrapDOCUrl] | [![NPM version][bootstrapNPMVersionImage]][bootstrapNPMUrl]
 [bootstrap-markdown][bootstrap-markdownGHUrl] | [Documentation][bootstrap-markdownDOCUrl] | [![NPM version][bootstrap-markdownNPMVersionImage]][bootstrap-markdownNPMUrl]
@@ -146,11 +145,6 @@ Outdated dependencies list can also be achieved with `$ npm outdated`
 [aws-sdkDOCUrl]: https://github.com/aws/aws-sdk-js/blob/master/README.md
 [aws-sdkNPMUrl]: https://www.npmjs.com/package/aws-sdk
 [aws-sdkNPMVersionImage]: https://img.shields.io/npm/v/aws-sdk.svg?style=flat
-
-[base62GHUrl]: https://github.com/base62/base62.js
-[base62DOCUrl]: https://github.com/base62/base62.js/blob/master/Readme.md
-[base62NPMUrl]: https://www.npmjs.com/package/base62
-[base62NPMVersionImage]: https://img.shields.io/npm/v/base62.svg?style=flat
 
 [body-parserGHUrl]: https://github.com/expressjs/body-parser
 [body-parserDOCUrl]: https://github.com/expressjs/body-parser/blob/master/README.md

--- a/libs/modelParser.js
+++ b/libs/modelParser.js
@@ -489,7 +489,14 @@ var parseScript = function (aScript) {
   parseDateProperty(script, 'updated');
 
   // Hash
-  script.hashShort = script.hash ? script.hash.substr(0, 7) : 'undefined';
+  script.hashShort = 'undefined';
+  script.hashSRI = 'undefined';
+
+  if (script.hash) {
+     // NOTE: May be absent in dev DB but should not be in pro DB
+    script.hashShort = script.hash.substr(0, 7);
+    script.hashSRI = 'sha512-' + Buffer.from(script.hash).toString('base64');
+  }
 
   if (script.created && script.updated && script.created.toString() !== script.updated.toString()) {
     script.isUpdated = true;

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "async": "3.2.0",
     "@octokit/auth-oauth-app": "4.3.0",
     "aws-sdk": "2.944.0",
-    "base62": "2.0.1",
     "body-parser": "1.19.0",
     "bootstrap": "3.4.1",
     "bootstrap-markdown": "2.10.0",

--- a/views/pages/scriptPage.html
+++ b/views/pages/scriptPage.html
@@ -27,7 +27,7 @@
 
             <div class="script-meta">
               <p><i class="fa fa-fw fa-clock-o"></i> <b>Published:</b> <time datetime="{{script.createdISOFormat}}" title="{{script.created}}">{{script.createdHumanized}}</time></p>
-              <p><i class="fa fa-fw fa-history"></i> <b>Version:</b> <code>{{script.meta.UserScript.version.0.value}}<span title="SHA-512 {{script.hash}}">+{{script.hashShort}}</span></code>{{#script.isUpdated}} updated <time class="script-updated" datetime="{{script.updatedISOFormat}}" title="{{script.updated}}">{{script.updatedHumanized}}</time>{{/script.isUpdated}}</p>
+              <p><i class="fa fa-fw fa-history"></i> <b>Version:</b> <code>{{script.meta.UserScript.version.0.value}}<span title="{{script.hashSRI}}">+{{script.hashShort}}</span></code>{{#script.isUpdated}} updated <time class="script-updated" datetime="{{script.updatedISOFormat}}" title="{{script.updated}}">{{script.updatedHumanized}}</time>{{/script.isUpdated}}</p>
               {{#script.description}}<p><i class="fa fa-fw fa-info"></i> <b>Summary:</b> {{script.description}}</p>{{/script.description}}
               {{#script.hasGroups}}
                 <span>


### PR DESCRIPTION
* This was already implemented pre W3C recommendation in our form but normalizing to their syntax.
* UI and DB remaining non-base64 encoded... semver limitation with extra characters that violate that spec as well as line numbers.
* Change caching mechanism... unfortunately traffic for a while will be increased while syncing with browsers. Also because spec doesn't use hex, which it probably should, the eTag header value will be bigger. Hashes, so far, are always "hex-able" by design of SHA but that could change in the future... who knows.
* Base62 being dropped in favor of Base64 for cache mechanism. Should be okay with extra `+/` in base64 since that falls within ASCII limitations.
* Any .user.js utilizing the .meta.json, or other language, will need to modify to check for the `sha512-` prefix and decode the value appropriately.
* If .meta.json shows empty `hash` clear browser cache *(weird Fx issue perhaps)*
* Bugfix on local copy of metadata script access... non-fatal atm just incorrect live copy referenced.

Post #1076 and applies to #432 #249

Ref(s):
* https://developer.mozilla.org/docs/Web/HTTP/Headers/ETag
* https://developer.mozilla.org/docs/Web/Security/Subresource_Integrity
* https://w3c.github.io/webappsec-subresource-integrity/
* https://www.srihash.org/