### PR TITLE
Post fix for incorrect type

### DIFF
--- a/controllers/scriptStorage.js
+++ b/controllers/scriptStorage.js
@@ -629,7 +629,7 @@ exports.sendScript = function (aReq, aRes, aNext) {
     }
 
     hashSRI = aScript.hash
-      ? 'sha512-' + Buffer.from(aScript.hash).toString('base64')
+      ? 'sha512-' + Buffer.from(aScript.hash, 'hex').toString('base64')
       : 'undefined';
 
     // HTTP/1.1 Caching
@@ -687,6 +687,7 @@ exports.sendScript = function (aReq, aRes, aNext) {
           source = chunks.join(''); // NOTE: Watchpoint
 
           // Send the script
+          aRes.set('Access-Control-Allow-Origin', '*');
           aRes.set('Content-Type', 'text/javascript; charset=UTF-8');
           aStream.setEncoding('utf8');
 

--- a/libs/modelParser.js
+++ b/libs/modelParser.js
@@ -495,7 +495,7 @@ var parseScript = function (aScript) {
   if (script.hash) {
      // NOTE: May be absent in dev DB but should not be in pro DB
     script.hashShort = script.hash.substr(0, 7);
-    script.hashSRI = 'sha512-' + Buffer.from(script.hash).toString('base64');
+    script.hashSRI = 'sha512-' + Buffer.from(script.hash, 'hex').toString('base64');
   }
 
   if (script.created && script.updated && script.created.toString() !== script.updated.toString()) {


### PR DESCRIPTION
* We already have the hex and default for Buffer is `utf`... so coerce it to `hex`
* Open up script sending to this methodology. Minification output support may come later but if one relies on the hash and something changes in the backend it can easily foo script installation. Will have to ponder some more.

Post #1826