### PR TITLE
*node* bump

### DIFF
--- a/app.js
+++ b/app.js
@@ -422,7 +422,7 @@ app.use(session({
   cookie: {
     maxAge: 5 * 60 * 1000, // minutes in ms NOTE: Expanded after successful auth
     secure: (isSecured ? true : false),
-    sameSite: 'lax' // NOTE: Current auth necessity
+    sameSite: 'strict'
   },
   rolling: true,
   secret: sessionSecret,

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "formidable": "1.2.2",
     "git-rev": "0.2.1",
     "git-rev-sync": "3.0.1",
-    "github": "git://github.com/octokit/rest.js.git#29dedb3",
+    "github": "git+https://github.com/octokit/rest.js.git#29dedb3",
     "highlight.js": "11.2.0",
     "image-size": "1.0.0",
     "ip-range-check": "0.2.0",
@@ -85,8 +85,8 @@
     "clean": "node dev/clean.js"
   },
   "engines": {
-    "node": ">=14.8.0 <15.0.0",
-    "npm": ">=6.14.7"
+    "node": ">=16.8.0 <17.0.0",
+    "npm": ">=7.21.0"
   },
   "private": true
 }


### PR DESCRIPTION
* This finally warns using *npm* under `engines` with *node*
* Also startup with strict instead of lax. Has been in place for about a month as a test for login issues. Still `lax` is needed for OAuth/etc. unfortunately.
* Delete op, sanitize, markdown, moderation flagging, overall UI... retested
* Move git repo linkage in package.json to https. Seems like https://github.blog/2021-09-01-improving-git-protocol-security-github/#how-do-i-prepare with "anonymous" git might be affecting this from what I gather. See also https://docs.npmjs.com/cli/v7/configuring-npm/package-json#git-urls-as-dependencies . Works on current dev stack... haven't ever tried this on pro... so \*crosses things\* Indirectly applies to #1705 . After March 15, 2022 can retry `git:` but preventative atm.