### PR TITLE
Handle in a continued, long term, well-formed, standardized fashion the possible vulnerability reported by some .user.js engines

### DIFF
--- a/libs/modelParser.js
+++ b/libs/modelParser.js
@@ -273,6 +273,8 @@ var parseScript = function (aScript) {
   var supportURL = null;
   var contributionURL = null;
 
+  var CVES = null;
+
   var updateURL = null;
   var updateUtf = null;
   var updateURLForceCheck = process.env.FORCE_BUSY_UPDATEURL_CHECK === 'true';
@@ -487,6 +489,15 @@ var parseScript = function (aScript) {
   // Dates
   parseDateProperty(script, 'created');
   parseDateProperty(script, 'updated');
+
+  // CVE
+  CVES = findMeta(script.meta, 'OpenUserJS.CVE');
+  if (!!CVES && script.meta['OpenUserJS'].CVE.length > 0) {
+    script.hasCVE = true;
+    script.CVES = CVES;
+
+    script.showSourceNotices = true;
+  }
 
   // Hash
   script.hashShort = 'undefined';

--- a/views/includes/scriptPageHeaderSourceNotices.html
+++ b/views/includes/scriptPageHeaderSourceNotices.html
@@ -1,4 +1,9 @@
 <div class="alert alert-warning" role="alert">
+  {{#script.hasCVE}}
+    <p>
+      {{#script.CVES}}<i class="fa fa-fw fa-exclamation-triangle"></i> CVE: {{value}} {{/script.CVES}}
+    </p>
+  {{/script.hasCVE}}
   {{#script.hasInvalidUpdateURL}}
     <p>
       <i class="fa fa-fw fa-exclamation-circle"></i> Invalid update check target.


### PR DESCRIPTION
* Key parsing is, and should always be, `// @key` as standardized. Anything else is a vulnerability. If the vulnerability persists past "some time" may elevate to critical.
* Best I can do with available time and I always read everything so I'm not ignorant by lacking better communication skills. :)
* Will resync metadata in a while for older scripts.

Applies to https://github.com/Tampermonkey/tampermonkey/issues/1326