### PR TITLE
Work-around for *request* issue

### DIFF
--- a/controllers/scriptStorage.js
+++ b/controllers/scriptStorage.js
@@ -1577,7 +1577,12 @@ exports.storeScript = function (aUser, aMeta, aBuf, aUpdate, aCallback) {
               // TODO: Probably going to be something here
             })
             .on('error', function (aErr) {
-              aInnerCallback(aErr);
+              if (aErr && aErr.code === 'ECONNRESET') {
+                console.error('*request* ECONNRESET error with `@icon` validation at', icon);
+                // fallsthrough
+              } else {
+                aInnerCallback(aErr);
+              }
             })
             .on('data', function (aChunk) {
               var buf = null;


### PR DESCRIPTION
Not entirely sure what is happening here yet. There is a 2nd http/2 request to GH to pull the favicon.ico and it results in a 400 code which might be affecting *request*.

``` console
GET https://raw.githubusercontent.com/thoughtsunificator/anime-twist-premium-extension/master/public/resource/icon192.png
[HTTP/2 304 Not Modified 41ms]

GET https://raw.githubusercontent.com/favicon.ico

GEThttps://raw.githubusercontent.com/favicon.ico
[HTTP/2 400 Bad Request 0ms]


GET
	https://raw.githubusercontent.com/favicon.ico
Status
400
Bad Request
VersionHTTP/2
Transferred20 B (20 B size)
Referrer Policystrict-origin-when-cross-origin


    HTTP/2 400 Bad Request

    content-security-policy: default-src 'none'; style-src 'unsafe-inline'; sandbox
    strict-transport-security: max-age=31536000
    x-content-type-options: nosniff
    x-frame-options: deny
    x-xss-protection: 1; mode=block
    content-type: text/plain; charset=utf-8
    x-github-request-id: BFCA:398E:20EA4:2B1D1:6154C049
    accept-ranges: bytes
    date: Wed, 29 Sep 2021 19:36:41 GMT
    via: 1.1 varnish
    x-served-by: *clipped*
    x-cache: MISS
    x-cache-hits: 0
    x-timer: S1632944201.991904,VS0,VE55
    vary: Authorization,Accept-Encoding,Origin
    access-control-allow-origin: *
    x-fastly-request-id: 6430a82547959939007b65990d31d046decc784d
    expires: Wed, 29 Sep 2021 19:41:41 GMT
    content-length: 20
    X-Firefox-Spdy: h2
    Accept
    	image/webp,*/*
    Accept-Encoding
    	gzip, deflate, br
    Accept-Language
    	en-US,en;q=0.5
    Connection
    	keep-alive
    DNT
    	1
    Host
    	raw.githubusercontent.com
    Referer
    	https://raw.githubusercontent.com/thoughtsunificator/anime-twist-premium-extension/master/public/resource/icon192.png
    Sec-Fetch-Dest
    	image
    Sec-Fetch-Mode
    	no-cors
    Sec-Fetch-Site
    	same-origin
    Sec-GPC
    	1
    User-Agent
    	Mozilla/5.0 (X11; Linux x86_64; rv:92.0) Gecko/20100101 Firefox/92.0
```

See also:
* https://openuserjs.org/discuss/Changing_my_linked_git_hub_account#comment-17c32e96846
* #1722