### PR TITLE
Accept Github webhook requests for the Github default branch

### DIFF
--- a/controllers/scriptStorage.js
+++ b/controllers/scriptStorage.js
@@ -2223,8 +2223,9 @@ exports.webhook = function (aReq, aRes) {
 
   //
 
-  // Only accept commits from the `master` branch
-  if (payload.ref !== 'refs/heads/master') {
+  // Only accept commits from the default branch
+  defaultBranch = `ref/heads/${payload.repository.default_branch}`
+  if (!(payload.ref === defaultBranch || payload.ref === 'refs/heads/master')) {
     aRes.status(403).send(); // Forbidden
     return;
   }


### PR DESCRIPTION
This allows the webhook to work independent of the name of the default branch on Github, which used to be master, but is now main. The branch can also be renamed by the repository owner to anything they like, e.g. I have seen teams working with `default` or `develop`. 

This PR ensures the webhook works with whatever the main branch is called. Github reports it in the webhook payload as follows (this shows only the relevant details for branch handling, every other detail is omitted):

```json
{
  "ref": "refs/heads/main",
  "repository": {
    "default_branch": "main"
  }
}
```

Fixes #1781