### PR TITLE
Deprecate FB auth

### DIFF
--- a/controllers/strategies.json
+++ b/controllers/strategies.json
@@ -2,7 +2,7 @@
   "facebook": {
     "name": "Facebook",
     "oauth": true,
-    "readonly": false
+    "readonly": true
   },
   "github": {
     "name": "GitHub",


### PR DESCRIPTION
* "I want to give those FB users a chance to switch their auth provider" * sizzle ref: https://openuserjs.org/discuss/WTF_w_FB_login!#comment-17c73a0b62b
* Also they may end up breaking this with their "rebranding" news. Ref: https://www.theverge.com/2021/10/19/22735612/facebook-change-company-name-metaverse

Closes #1786