### PR TITLE
Fix a Chromium based glitch

### DIFF
--- a/controllers/scriptStorage.js
+++ b/controllers/scriptStorage.js
@@ -576,6 +576,10 @@ exports.sendScript = function (aReq, aRes, aNext) {
       aRes.set('Warning', '199 ' + aReq.headers.host +
         rfc2047.encode(' Invalid @updateURL') +
           (process.env.FORCE_BUSY_UPDATEURL_CHECK === 'true' ? ' in lockdown.' : '.'));
+
+      // NOTE: Force HTTP stack response for Chromium based browsers #1856
+      aRes.set('Content-Type', 'text/html; charset=UTF-8');
+
       aRes.status(403).send(); // Forbidden
       return;
     }


### PR DESCRIPTION
* Force HTTP stack response for Chromium based browsers so their messages show up properly since they still have native .user.js and probably a bugged interpretation of a valid response for no Content-Type. Gecko always returns a blank page no matter the setting at this time. Note this is not needed for 304 which is also a HTTP stack response. Plus they've had this issue in the past with other status codes.
* Usually Chromium based browsers seem to think the "...site can't be reached... ERR_INVALID_RESPONSE"... this changes that to "Access to localhost was denied\nYou don't have authorization to view this page.\nHTTP ERROR 403"
* Not all engines properly detect HTML content vs actual JavaScript type which is one of the reasons why it's pure response status codes.

Applies to https://openuserjs.org/scripts/omgmikey/Chaturbate_Easy_Tipping/issues/when_i_try_to_download_this_script_it_says_page_is_missing#comment-17d4b1769c4 and post #1847