### PR TITLE
Enhance *express-minify* implementation

### DIFF
--- a/app.js
+++ b/app.js
@@ -482,7 +482,8 @@ app.use(function(aReq, aRes, aNext) {
         /^\/mod\/removed\//.test(pathname)
   ) {
     aRes.minifyOptions = aRes.minifyOptions || {}; // Ensure object exists on response
-    aRes.minifyOptions.minify = false; // Skip using release minification because we control this with *terser*
+    aRes.minifyOptions.minify = false; // Skip minification because we use *terser* with .js
+    aRes.minifyOptions.enabled = false; // Force no processing on remainder of types on these routes
   }
   aNext();
 });


### PR DESCRIPTION
* Docs say exactly "Pass false to disable minifying (JS, CSS and JSON)" which is incorrect. See archived mirror at https://github.com/OpenUserJS/express-minify/blob/f0696f6d3976b6ac7c138d767bb62ae3835ddb38/index.js#L76 . Only does JS and CSS but not JSON.
* Affects admin processes and any .meta.json . We already minimize with conditionals of pro vs dev and shouldn't be needed.

Applies to #432