### PR TITLE
More input validations and abstractions

### DIFF
--- a/controllers/scriptStorage.js
+++ b/controllers/scriptStorage.js
@@ -1713,27 +1713,52 @@ exports.storeScript = function (aUser, aMeta, aBuf, aUpdate, aCallback) {
       aInnerCallback(null);
     },
     function (aInnerCallback) {
+      // `@include` validations
+      hasInvalidKey = scriptStorageLib.invalidKey(
+        userName,
+          scriptName,
+            isLib,
+              'include',
+                findMeta(aMeta, 'UserScript.include.value')
+      );
+
+      if (hasInvalidKey) {
+        aInnerCallback(hasInvalidKey, null);
+        return;
+      }
+
+      aInnerCallback(null);
+    },
+    function (aInnerCallback) {
+      // `@match` validations
+      hasInvalidKey = scriptStorageLib.invalidKey(
+        userName,
+          scriptName,
+            isLib,
+              'match',
+                findMeta(aMeta, 'UserScript.match.value')
+      );
+
+      if (hasInvalidKey) {
+        aInnerCallback(hasInvalidKey, null);
+        return;
+      }
+
+      aInnerCallback(null);
+    },
+    function (aInnerCallback) {
       // `@exclude` validations
-      var excludes = null;
-      var missingExcludeAll = true;
+      hasInvalidKey = scriptStorageLib.invalidKey(
+        userName,
+          scriptName,
+            isLib,
+              'exclude',
+                findMeta(aMeta, 'UserScript.exclude.value')
+      );
 
-      if (isLib) {
-        excludes = findMeta(aMeta, 'UserScript.exclude.value');
-        if (excludes) {
-          excludes.forEach(function (aElement, aIndex, aArray) {
-            if (aElement === '*') {
-              missingExcludeAll = false;
-            }
-          });
-        }
-
-        if (missingExcludeAll) {
-          aInnerCallback(new statusError({
-            message: 'UserScript Metadata Block missing `@exclude *`.',
-            code: 400
-          }), null);
-          return;
-        }
+      if (hasInvalidKey) {
+        aInnerCallback(hasInvalidKey, null);
+        return;
       }
 
       aInnerCallback(null);
@@ -1746,6 +1771,91 @@ exports.storeScript = function (aUser, aMeta, aBuf, aUpdate, aCallback) {
             isLib,
               'grant',
                 findMeta(aMeta, 'UserScript.grant.value')
+      );
+
+      if (hasInvalidKey) {
+        aInnerCallback(hasInvalidKey, null);
+        return;
+      }
+
+      aInnerCallback(null);
+    },
+    function (aInnerCallback) {
+      // `@require` validations
+      hasInvalidKey = scriptStorageLib.invalidKey(
+        userName,
+          scriptName,
+            isLib,
+              'require',
+                findMeta(aMeta, 'UserScript.require.value')
+      );
+
+      if (hasInvalidKey) {
+        aInnerCallback(hasInvalidKey, null);
+        return;
+      }
+
+      aInnerCallback(null);
+    },
+    function (aInnerCallback) {
+      // `@resource` validations
+      hasInvalidKey = scriptStorageLib.invalidKey(
+        userName,
+          scriptName,
+            isLib,
+              'resource',
+                findMeta(aMeta, 'UserScript.resource.value')
+      );
+
+      if (hasInvalidKey) {
+        aInnerCallback(hasInvalidKey, null);
+        return;
+      }
+
+      aInnerCallback(null);
+    },
+    function (aInnerCallback) {
+      // `@run-at` validations
+      hasInvalidKey = scriptStorageLib.invalidKey(
+        userName,
+          scriptName,
+            isLib,
+              'run-at',
+                findMeta(aMeta, 'UserScript.run-at.value')
+      );
+
+      if (hasInvalidKey) {
+        aInnerCallback(hasInvalidKey, null);
+        return;
+      }
+
+      aInnerCallback(null);
+    },
+    function (aInnerCallback) {
+      // `@noframes` validations
+      hasInvalidKey = scriptStorageLib.invalidKey(
+        userName,
+          scriptName,
+            isLib,
+              'noframes',
+                findMeta(aMeta, 'UserScript.noframes')
+      );
+
+      if (hasInvalidKey) {
+        aInnerCallback(hasInvalidKey, null);
+        return;
+      }
+
+      aInnerCallback(null);
+    },
+    function (aInnerCallback) {
+      // `@unwrap` validations
+      hasInvalidKey = scriptStorageLib.invalidKey(
+        userName,
+          scriptName,
+            isLib,
+              'unwrap',
+                findMeta(aMeta, 'UserScript.unwrap')
       );
 
       if (hasInvalidKey) {
@@ -1866,7 +1976,7 @@ exports.storeScript = function (aUser, aMeta, aBuf, aUpdate, aCallback) {
 
           try {
             url = new URL(aRequire);
-            require = url.origin +  url.pathname;
+            require = url.origin + url.pathname;
           } catch (aE) {
             // NOTE: Currently not always a real error in every .user.js engine so...
             /* falls through */

--- a/libs/scriptStorage.js
+++ b/libs/scriptStorage.js
@@ -36,6 +36,8 @@ function invalidKey(aAuthorName, aScriptName, aIsLib, aKeyName, aKeyValue) {  //
       '/(?:meta|install|src/scripts)/(.+?)/(.+)\.(?:user)\.js$'
   );
 
+  var missingExcludeAll = true;
+
   var lockdown = process.env.FORCE_BUSY_UPDATEURL_CHECK === 'true';
 
   var hasInvalidKeys = [];
@@ -43,15 +45,18 @@ function invalidKey(aAuthorName, aScriptName, aIsLib, aKeyName, aKeyValue) {  //
 
   switch (aKeyName) {
     case 'css':         // NOTE: We don't collect these yet (ref lost)
-    case 'include':
     case 'inject-into': // NOTE: We don't collect this yet
-    case 'match':
-    case 'noframes':
     case 'priority':    // NOTE: We don't collect this yet
-    case 'require':
-    case 'resource':
-    case 'run-at':
-    case 'unwrap':
+      if (aIsLib) {
+        if (aKeyValue) {
+          return new statusError({
+            message: '`@' + aKeyName +
+              '` not valid in a Library.',
+            code: 400 // Bad request
+          });
+        }
+      }
+      break;
     case 'downloadURL':
       if (aIsLib) {
         if (aKeyValue) {
@@ -59,6 +64,33 @@ function invalidKey(aAuthorName, aScriptName, aIsLib, aKeyName, aKeyValue) {  //
             message: '`@' + aKeyName +
               '` not valid in a Library.',
             code: 400 // Bad request
+          });
+        }
+      }
+      break;
+    case 'exclude':
+      if (aIsLib) {
+        if (aKeyValue) {
+          if (aKeyValue.length > 1) {
+            return new statusError({
+              message: '`@' + aKeyName +
+                '` must only have one key value in a Library.',
+              code: 400
+            });
+          }
+
+          aKeyValue.forEach(function (aElement, aIndex, aArray) {
+            if (aElement === '*') {
+              missingExcludeAll = false;
+            }
+          });
+        }
+
+        if (missingExcludeAll) {
+          return new statusError({
+            message: '`@' + aKeyName +
+              '` missing value of `*` in a Library.',
+            code: 400
           });
         }
       }
@@ -105,7 +137,6 @@ function invalidKey(aAuthorName, aScriptName, aIsLib, aKeyName, aKeyValue) {  //
               case 'GM_removeValueChangeListener':
               case 'GM_saveTab':
               case 'GM_setClipboard':
-              case 'GM_setClipboard':
               case 'GM.setClipboard':
               case 'GM_setValue':
               case 'GM.setValue':
@@ -139,8 +170,86 @@ function invalidKey(aAuthorName, aScriptName, aIsLib, aKeyName, aKeyValue) {  //
 
           if (hasInvalidKeys.length > 0) {
             // NOTE: return only first error since header limitations may throw if RFC2047'd
+            // TODO: May expand this later
             return hasInvalidKeys[0];
           }
+        }
+      }
+      break;
+    case 'include':
+      if (aIsLib) {
+        if (aKeyValue) {
+          return new statusError({
+            message: '`@' + aKeyName +
+              '` not valid in a Library.',
+            code: 400 // Bad request
+          });
+        }
+      }
+      break;
+    case 'match':
+      if (aIsLib) {
+        if (aKeyValue) {
+          return new statusError({
+            message: '`@' + aKeyName +
+              '` not valid in a Library.',
+            code: 400 // Bad request
+          });
+        }
+      }
+      break;
+    case 'noframes':
+      if (aIsLib) {
+        if (aKeyValue) {
+          return new statusError({
+            message: '`@' + aKeyName +
+              '` not valid in a Library.',
+            code: 400 // Bad request
+          });
+        }
+      }
+      break;
+    case 'require':
+      if (aIsLib) {
+        if (aKeyValue) {
+          return new statusError({
+            message: '`@' + aKeyName +
+              '` not valid in a Library.',
+            code: 400 // Bad request
+          });
+        }
+      }
+      break;
+    case 'resource':
+      if (aIsLib) {
+        if (aKeyValue) {
+          return new statusError({
+            message: '`@' + aKeyName +
+              '` not valid in a Library.',
+            code: 400 // Bad request
+          });
+        }
+      }
+      break;
+    case 'run-at':
+      if (aIsLib) {
+        if (aKeyValue) {
+          return new statusError({
+            message: '`@' + aKeyName +
+              '` not valid in a Library.',
+            code: 400 // Bad request
+          });
+        }
+      }
+      break;
+    case 'unwrap':
+      if (aIsLib) {
+        if (aKeyValue) {
+          return new statusError({
+            message: '`@' + aKeyName +
+              '` not valid in a Library.',
+            code: 400 // Bad request
+          });
         }
       }
       break;


### PR DESCRIPTION
* Stubs for `@include`, `@match`, `@require`, `@resource`, `@run-at`, `@unwrap`, `@noframes`, and `@exclude` moving and expansion.
* Remove a duplicate `@grant` test.

Post #944