### PR TITLE
Scope helpers

### DIFF
--- a/views/includes/scripts/clipboard.html
+++ b/views/includes/scripts/clipboard.html
@@ -1,12 +1,15 @@
 <script type="text/javascript" charset="UTF-8" src="/redist/npm/clipboard/dist/clipboard.js"></script>
-<script type="text/javascript" charset="UTF-8" src="/redist/npm/ace-builds/src/ace.js"></script>
 <script type="text/javascript">
   (function () {
 
     var clipboard = null;
     var rMin = /\.min\.js$/;
 
+    {{#isScriptViewSourcePage}}
+    {{#isOwner}}
     var regenerateId = '#regenerate';
+    {{/isOwner}}
+    {{/isScriptViewSourcePage}}
 
     var allowedIds = [
       '#copyright-raw',
@@ -29,6 +32,8 @@
       });
     }
 
+    {{#isScriptViewSourcePage}}
+    {{#isOwner}}
     // TODO: Should keep in sync with all peg.js upmixes eventually
     function parseMeta(aString) {
       aString = aString.toString();
@@ -86,6 +91,8 @@
 
       return cleanName || aDefaultName;
     };
+    {{/isOwner}}
+    {{/isScriptViewSourcePage}}
 
     //
     if (ClipboardJS.isSupported()) {
@@ -105,6 +112,8 @@
       unsupported();
     }
 
+    {{#isScriptViewSourcePage}}
+    {{#isOwner}}
     editor = ace.edit("editor");
 
     $(regenerateId).on('click', function () {
@@ -220,6 +229,8 @@
 
       $('#alt-install-target-btn').attr('disabled', 'disabled');
     });
+    {{/isOwner}}
+    {{/isScriptViewSourcePage}}
 
   })();
 </script>

--- a/views/pages/scriptViewSourcePage.html
+++ b/views/pages/scriptViewSourcePage.html
@@ -61,11 +61,11 @@
   </div>
   {{> includes/footer.html }}
   {{> includes/scripts/lazyIconScript.html }}
+  {{> includes/scripts/scriptEditor.html }}
   {{> includes/scripts/clipboard.html }}
   {{#authorTools}}
     {{ > includes/scripts/selectInstall.html}}
     {{ > includes/scripts/selectSPDX.html}}
   {{/authorTools}}
-  {{> includes/scripts/scriptEditor.html }}
 </body>
 </html>


### PR DESCRIPTION
* Ace is referenced in clipboard but not defined until scriptEditor script is loaded... scoot that around.
* Fix injection into the incorrect pages with *mu2* *(mustache)* scope checks

Post #1851