### PR TITLE
Complete new user propagation

### DIFF
--- a/libs/modifySessions.js
+++ b/libs/modifySessions.js
@@ -331,8 +331,20 @@ exports.findSessionData = function (aQuery, aStore, aOptions, aCallback) {
 
 
         data.passport.oujsOptions.username = data.username || findMeta(data.user, 'name');
+        data.passport.oujsOptions.userrole = data.passport.oujsOptions.username
+          ? data.userrole
+          : '\u2026';
         data.passport.oujsOptions.newUser = data.newUser;
         data.passport.oujsOptions.sid = aSessionData._id;
+
+        // NOTE: These only shows up during authentication otherwise don't use
+        if (data.userauth) {
+          data.passport.oujsOptions.strategy = data.userauth;
+        }
+
+        if (data.useragent) {
+          data.passport.oujsOptions.userAgent = data.useragent;
+        }
 
         // Very simple query filter search check to start.
         // Currently only looking in `data.passport.oujsOptions.username`.

--- a/views/includes/session.html
+++ b/views/includes/session.html
@@ -11,7 +11,7 @@
             <span>
               {{#user.userPageUrl}}<a href="{{{user.userPageUrl}}}" class="username">{{name}}</a>{{/user.userPageUrl}}
               {{^user.userPageUrl}}<span class="username">{{#passport.oujsOptions.newUser}}<em>{{/passport.oujsOptions.newUser}}{{#name}}{{name}}{{/name}}{{#passport.oujsOptions.newUser}}</em>{{/passport.oujsOptions.newUser}}{{^name}}<em>&hellip;</em>{{/name}}</span>{{/user.userPageUrl}}
-              <span class="label label-default">{{#user.roleName}}{{user.roleName}}{{/user.roleName}}{{^user.roleName}}<em>&hellip;</em>{{/user.roleName}}</span>
+              <span class="label label-default">{{#user.roleName}}{{user.roleName}}{{/user.roleName}}{{^user.roleName}}{{#passport.oujsOptions.userrole}}{{passport.oujsOptions.userrole}}{{/passport.oujsOptions.userrole}}{{^passport.oujsOptions.userrole}}<em>User</em>{{/passport.oujsOptions.userrole}}{{/user.roleName}}</span>
               <span class="label label-{{#cookie.secure}}success{{/cookie.secure}}{{^cookie.secure}}warning{{/cookie.secure}}" title="secure">
                 <i class="fa fa-{{^cookie.secure}}un{{/cookie.secure}}lock"></i>
               </span>


### PR DESCRIPTION
#1939 #1938 #1937 #1446 #1470 ... #944

NOTE(s):
* Camelcaps not adhered to on some... may revisit.
* `userrole` isn't consistent with `roleName` however is consistent with other objects... may revisit.
* May not be the most efficient with `parseUser` but other option is to pull in `userRoles.json` and enumerate grab... may revisit.
* Will have to boot everyone off temporarily to propagate values to sessions.