### PR TITLE
Scoot UI around and expose counts

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -567,6 +567,9 @@ exports.view = function (aReq, aRes, aNext) {
     user.aboutRendered = renderMd(user.about);
     options.isYou = authedUser && user && authedUser._id == user._id;
 
+    options.isYouOrAdmin = options.isYou || options.isAdmin;
+    options.isYouOrMod = options.isYou || options.isMod;
+
     // Page metadata
     pageMetadata(options, [user.name, 'Users']);
     options.isUserPage = true;
@@ -678,6 +681,9 @@ exports.userCommentListPage = function (aReq, aRes, aNext) {
     // User
     user = options.user = modelParser.parseUser(aUser);
     options.isYou = authedUser && user && authedUser._id == user._id;
+
+    options.isYouOrAdmin = options.isYou || options.isAdmin;
+    options.isYouOrMod = options.isYou || options.isMod;
 
     // Page metadata
     pageMetadata(options, [user.name, 'Users']);
@@ -832,6 +838,9 @@ exports.userScriptListPage = function (aReq, aRes, aNext) {
     options.user = user = modelParser.parseUser(aUser);
     options.isYou = authedUser && user && authedUser._id == user._id;
 
+    options.isYouOrAdmin = options.isYou || options.isAdmin;
+    options.isYouOrMod = options.isYou || options.isMod;
+
     switch (aReq.query.library) {
       case 'true': // List just libraries
         options.includeLibraries = true;
@@ -950,8 +959,11 @@ exports.userSyncListPage = function (aReq, aRes, aNext) {
     user = options.user = modelParser.parseUser(aUser);
     options.isYou = authedUser && user && authedUser._id == user._id;
 
+    options.isYouOrAdmin = options.isYou || options.isAdmin;
+    options.isYouOrMod = options.isYou || options.isMod;
+
     // If not you or not synacable auth strategy move along
-    if (!options.isYou || !options.user.canSync) {
+    if (!options.isYouOrAdmin || !options.user.canSync) {
       aNext();
       return;
     }

--- a/routes.js
+++ b/routes.js
@@ -366,9 +366,9 @@ module.exports = function (aApp) {
   // User routes
   aApp.route('/users').get(listRateLimiter, listCapLimiter, user.userListPage);
   aApp.route('/users/:username').get(user.view);
-  aApp.route('/users/:username/comments').get(listRateLimiter, listCapLimiter, user.userCommentListPage);
   aApp.route('/users/:username/scripts').get(listRateLimiter, listCapLimiter, user.userScriptListPage);
   aApp.route('/users/:username/syncs').get(listRateLimiter, listCapLimiter, user.userSyncListPage);
+  aApp.route('/users/:username/comments').get(listRateLimiter, listCapLimiter, user.userCommentListPage);
 
   aApp.route('/users/:username/github/repos').get(authentication.validateUser, user.userGitHubRepoListPage);
   aApp.route('/users/:username/github/repo').get(authentication.validateUser, user.userGitHubRepoPage);

--- a/views/includes/userPageHeader.html
+++ b/views/includes/userPageHeader.html
@@ -12,16 +12,16 @@
     <ul class="nav navbar-nav">
       <li class="{{#isUserPage}}active{{/isUserPage}}"><a href="{{{user.userPageUrl}}}">Profile</a></li>
       <li class="{{#isUserScriptListPage}}active{{/isUserScriptListPage}}"><a href="{{{user.userScriptListPageUrl}}}" class="{{^user.userScriptListPageUrl}}disabled{{/user.userScriptListPageUrl}}">Scripts{{#scriptListCount}} <span class="badge">{{scriptListCount}}</span>{{/scriptListCount}}</a></li>
-      <li class="{{#isUserCommentListPage}}active{{/isUserCommentListPage}}"><a href="{{{user.userCommentListPageUrl}}}" class="{{^user.userCommentListPageUrl}}disabled{{/user.userCommentListPageUrl}}">Comments{{#commentListCount}} <span class="badge">{{commentListCount}}</span>{{/commentListCount}}</a></li>
-      {{#isAdmin}}
-      <li class=""><a href="#">Votes{{#voteListCount}} <span class="badge">{{voteListCount}}</span>{{/voteListCount}}</a></li>
-      <li class=""><a href="#">Flags{{#flagListCount}} <span class="badge">{{flagListCount}}</span>{{/flagListCount}}</a></li>
-      {{/isAdmin}}
-      {{#isYou}}
+      {{#isYouOrAdmin}}
         {{#user.canSync}}
           <li class="{{#isUserSyncListPage}}active{{/isUserSyncListPage}}"><a href="{{{user.userSyncListPageUrl}}}" class="{{^user.userSyncListPageUrl}}disabled{{/user.userSyncListPageUrl}}">Syncs{{#syncListCount}} <span class="badge">{{syncListCount}}</span>{{/syncListCount}}</a></li>
         {{/user.canSync}}
-      {{/isYou}}
+      {{/isYouOrAdmin}}
+      <li class="{{#isUserCommentListPage}}active{{/isUserCommentListPage}}"><a href="{{{user.userCommentListPageUrl}}}" class="{{^user.userCommentListPageUrl}}disabled{{/user.userCommentListPageUrl}}">Comments{{#commentListCount}} <span class="badge">{{commentListCount}}</span>{{/commentListCount}}</a></li>
+      {{#isYouOrAdmin}}
+        <li class=""><a href="#">Votes{{#voteListCount}} <span class="badge">{{voteListCount}}</span>{{/voteListCount}}</a></li>
+        <li class=""><a href="#">Flags{{#flagListCount}} <span class="badge">{{flagListCount}}</span>{{/flagListCount}}</a></li>
+      {{/isYouOrAdmin}}
     </ul>
   </div>
 </nav>


### PR DESCRIPTION
* Scoot syncs closer to scripts since they are related. Post #1736
* Expose previous counts to the authed user... still tracking at admin+ but may allow mod+ for just the counts but not content for mods... still pondering... votes may not be necessary and they already have access to "anonymous" flagging... thinking out loud... still pondering.
* Flags include historical count regardless of action taken. This will eventually change.

Post #1942 #785

NOTE:
* Btw AuthAs is great however it's really annoying at times *(think reauthentication confirmations)* so this is why Admin+ have quicker access to see what's going on without authAs then end session and restart a new Admin+ session.