### PR TITLE
Hide flags nav for those that shouldn't have it.

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -567,9 +567,6 @@ exports.view = function (aReq, aRes, aNext) {
     user.aboutRendered = renderMd(user.about);
     options.isYou = authedUser && user && authedUser._id == user._id;
 
-    options.isYouOrAdmin = options.isYou || options.isAdmin;
-    options.isYouOrMod = options.isYou || options.isMod;
-
     // Page metadata
     pageMetadata(options, [user.name, 'Users']);
     options.isUserPage = true;
@@ -681,9 +678,6 @@ exports.userCommentListPage = function (aReq, aRes, aNext) {
     // User
     user = options.user = modelParser.parseUser(aUser);
     options.isYou = authedUser && user && authedUser._id == user._id;
-
-    options.isYouOrAdmin = options.isYou || options.isAdmin;
-    options.isYouOrMod = options.isYou || options.isMod;
 
     // Page metadata
     pageMetadata(options, [user.name, 'Users']);
@@ -838,9 +832,6 @@ exports.userScriptListPage = function (aReq, aRes, aNext) {
     options.user = user = modelParser.parseUser(aUser);
     options.isYou = authedUser && user && authedUser._id == user._id;
 
-    options.isYouOrAdmin = options.isYou || options.isAdmin;
-    options.isYouOrMod = options.isYou || options.isMod;
-
     switch (aReq.query.library) {
       case 'true': // List just libraries
         options.includeLibraries = true;
@@ -959,11 +950,8 @@ exports.userSyncListPage = function (aReq, aRes, aNext) {
     user = options.user = modelParser.parseUser(aUser);
     options.isYou = authedUser && user && authedUser._id == user._id;
 
-    options.isYouOrAdmin = options.isYou || options.isAdmin;
-    options.isYouOrMod = options.isYou || options.isMod;
-
     // If not you or not synacable auth strategy move along
-    if (!options.isYouOrAdmin || !options.user.canSync) {
+    if (!(options.isYou || options.isAdmin) || !options.user.canSync) {
       aNext();
       return;
     }

--- a/libs/modelParser.js
+++ b/libs/modelParser.js
@@ -673,6 +673,8 @@ var parseUser = function (aUser) {
   user.isRoot = user.role < 1;
   user.roleName = userRoles[user.role];
 
+  user.showFlags = user.role >= 3;
+
   //
   user.slug = user.name;
 

--- a/views/includes/userPageHeader.html
+++ b/views/includes/userPageHeader.html
@@ -12,16 +12,39 @@
     <ul class="nav navbar-nav">
       <li class="{{#isUserPage}}active{{/isUserPage}}"><a href="{{{user.userPageUrl}}}">Profile</a></li>
       <li class="{{#isUserScriptListPage}}active{{/isUserScriptListPage}}"><a href="{{{user.userScriptListPageUrl}}}" class="{{^user.userScriptListPageUrl}}disabled{{/user.userScriptListPageUrl}}">Scripts{{#scriptListCount}} <span class="badge">{{scriptListCount}}</span>{{/scriptListCount}}</a></li>
-      {{#isYouOrAdmin}}
-        {{#user.canSync}}
+      {{#user.canSync}}
+        {{#isYou}}
           <li class="{{#isUserSyncListPage}}active{{/isUserSyncListPage}}"><a href="{{{user.userSyncListPageUrl}}}" class="{{^user.userSyncListPageUrl}}disabled{{/user.userSyncListPageUrl}}">Syncs{{#syncListCount}} <span class="badge">{{syncListCount}}</span>{{/syncListCount}}</a></li>
-        {{/user.canSync}}
-      {{/isYouOrAdmin}}
+        {{/isYou}}
+        {{^isYou}}
+          {{#isAdmin}}
+            <li class="{{#isUserSyncListPage}}active{{/isUserSyncListPage}}"><a href="{{{user.userSyncListPageUrl}}}" class="{{^user.userSyncListPageUrl}}disabled{{/user.userSyncListPageUrl}}">Syncs{{#syncListCount}} <span class="badge">{{syncListCount}}</span>{{/syncListCount}}</a></li>
+          {{/isAdmin}}
+        {{/isYou}}
+      {{/user.canSync}}
       <li class="{{#isUserCommentListPage}}active{{/isUserCommentListPage}}"><a href="{{{user.userCommentListPageUrl}}}" class="{{^user.userCommentListPageUrl}}disabled{{/user.userCommentListPageUrl}}">Comments{{#commentListCount}} <span class="badge">{{commentListCount}}</span>{{/commentListCount}}</a></li>
-      {{#isYouOrAdmin}}
+      {{#isYou}}
         <li class=""><a href="#">Votes{{#voteListCount}} <span class="badge">{{voteListCount}}</span>{{/voteListCount}}</a></li>
+        {{#user.showFlags}}
         <li class=""><a href="#">Flags{{#flagListCount}} <span class="badge">{{flagListCount}}</span>{{/flagListCount}}</a></li>
-      {{/isYouOrAdmin}}
+        {{/user.showFlags}}
+      {{/isYou}}
+      {{^isYou}}
+        {{#isAdmin}}
+          <li class=""><a href="#">Votes{{#voteListCount}} <span class="badge">{{voteListCount}}</span>{{/voteListCount}}</a></li>
+          {{#user.showFlags}}
+            <li class=""><a href="#">Flags{{#flagListCount}} <span class="badge">{{flagListCount}}</span>{{/flagListCount}}</a></li>
+          {{/user.showFlags}}
+        {{/isAdmin}}
+        {{^isAdmin}}
+          {{#isMod}}
+            <li class=""><a href="#">Votes{{#voteListCount}} <span class="badge">Yes</span>{{/voteListCount}}</a></li>
+            {{#user.showFlags}}
+              <li class=""><a href="#">Flags{{#flagListCount}} <span class="badge">Yes</span>{{/flagListCount}}</a></li>
+            {{/user.showFlags}}
+          {{/isMod}}
+        {{/isAdmin}}
+      {{/isYou}}
     </ul>
   </div>
 </nav>


### PR DESCRIPTION
* Ref: Post https://github.com/OpenUserJS/OpenUserJS.org/issues/642#issuecomment-150357163
* Bloat up *mu2* *(mustache)* with some deep conditionals instead to achieve this. Not that this is a new thing.
* Also expose "Yes" to Moderators for ambiguity. Parallel to actual flag list ambiguity. This can change if discussed with establishing owner but content will be semi-blocked when implemented *(fully on homepages and partial currently on flagged moderation lists)*.

Post #1943 #1942 #785

NOTE:
* If you don't "trust the admin" going up the hierarchy can block the content but need to know counts at least for manual validation and actions upon moderation.