### PR TITLE
Repair DOM inclusion for *markdown*

### DIFF
--- a/views/includes/scripts/markdownEditor.html
+++ b/views/includes/scripts/markdownEditor.html
@@ -1,4 +1,4 @@
-<script type="text/javascript" charset="UTF-8" src="/redist/npm/marked/lib/marked.js"></script>
+<script type="text/javascript" charset="UTF-8" src="/redist/npm/marked/marked.cjs"></script>
 <script type="text/javascript" charset="UTF-8" src="/redist/npm/bootstrap-markdown/js/bootstrap-markdown.js"></script>
 <script type="text/javascript">
   (function () {


### PR DESCRIPTION
* Previews seem to be severely busted in v4.x ... will have to decide if a rollback or other change is needed, or if a different dep needs to be used [*markdown-it](https://www.npmjs.com/package/markdown-it) for example. I do prefer regex speed in *markdown* but a lot of errors.

Post #1957 and may apply to #1775

Note(s):
* `marked.min.js` is made by https://github.com/markedjs/marked/blob/078352f2198f9a2359b9c66286007202be919be1/Makefile#L3 as referenced in https://github.com/markedjs/marked/blob/078352f2198f9a2359b9c66286007202be919be1/README.md#usage