### PR TITLE
Remove meta indexing

### DIFF
--- a/models/script.js
+++ b/models/script.js
@@ -55,9 +55,7 @@ scriptSchema.index({
   name: 1,
   author: 1,
   _description: 1,
-  _about: 1,
-  'meta.UserScript.match.value': 1,
-  'meta.UserScript.include.value': 1
+  _about: 1
 });
 
 /*


### PR DESCRIPTION
* Pro MongoDB throws `cannot index parallel arrays [include] [match]` however dev works fine. See soon to be attached to PR.
* Current live testing on pro shows very little difference between meta indexing and non-meta indexing... so just omitting because this is a screwy error on MongoDB's part.... is it or isn't it an error? is the question.

Dev:
![dev db Screenshot_20221212](https://user-images.githubusercontent.com/114709/207109401-e97228cd-576e-4fd2-b2df-ff5d92af8dc1.png)

Pro:
![pro db Screenshot_20221212](https://user-images.githubusercontent.com/114709/207109500-f0c50859-d3c8-428c-ae66-eb358ca0aab6.png)
