### PR TITLE
Suspend new twitter based accounts

### DIFF
--- a/controllers/strategies.json
+++ b/controllers/strategies.json
@@ -37,6 +37,6 @@
   "twitter": {
     "name": "Twitter",
     "oauth": true,
-    "readonly": false
+    "readonly": true
   }
 }


### PR DESCRIPTION
* This is a precautionary measure as the new owner hasn't provided stability of the platform and further reporting has shown things are getting worse.