### PR TITLE
Special use case for an embedded library

### DIFF
--- a/views/pages/scriptPage.html
+++ b/views/pages/scriptPage.html
@@ -53,7 +53,7 @@
                 <ul>
                 {{#script.fork}}
                   <li>
-                    <a href="/{{#script.isLib}}libs{{/script.isLib}}{{^script.isLib}}scripts{{/script.isLib}}/{{{url}}">{{utf}}</a>
+                    <a href="/{{#script.isLib}}libs{{/script.isLib}}{{^script.isLib}}{{^embeddedLib}}scripts{{/embeddedLib}}{{#embeddedLib}}libs{{/embeddedLib}}{{/script.isLib}}/{{{url}}">{{utf}}</a>
                   </li>
                 {{/script.fork}}
                 </ul>


### PR DESCRIPTION
* Usually we would just remove the script for improper forking but there is a case for this with a Founder.
* This allows an embedded test to point to it's ancestor on OUJS (even if it has changed concurrently)