### PR TITLE
Fix OAuth RO options and show everyone status

### DIFF
--- a/controllers/index.js
+++ b/controllers/index.js
@@ -263,7 +263,7 @@ exports.register = function (aReq, aRes) {
         options.strategies.push({
           'strat': aStrategy.name,
           'display': aStrategy.display,
-          'disabled': aStrategy.readonly
+          'disabled': strategies[aStrategy.name].readonly
         });
       });
 

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -1180,13 +1180,13 @@ exports.userEditPreferencesPage = function (aReq, aRes, aNext) {
             options.usedStrategies.push({
               'strat': aStrat.name,
               'display': aStrat.display,
-              'disabled': aStrat.readonly
+              'disabled': strategies[aStrat.name].readonly
             });
           } else {
             options.openStrategies.push({
               'strat': aStrat.name,
               'display': aStrat.display,
-              'disabled': aStrat.readonly
+              'disabled': strategies[aStrat.name].readonly
             });
           }
         });
@@ -1220,6 +1220,9 @@ exports.userEditPreferencesPage = function (aReq, aRes, aNext) {
         options.defaultStrategy = strategies[defaultStrategy]
           ? strategies[defaultStrategy].name
           : null;
+        options.defaultStrategyDisabled = strategies[defaultStrategy]
+          ? strategies[defaultStrategy].readonly
+          : false;
 
         options.defaultStrat = defaultStrategy;
         options.haveOtherStrategies = options.usedStrategies.length > 0;

--- a/views/pages/loginPage.html
+++ b/views/pages/loginPage.html
@@ -35,7 +35,7 @@
           </div>
           <select name="auth" class="form-control">
             {{#strategies}}
-            <option value="{{strat}}" {{#selected}}selected="selected"{{/selected}}{{#disabled}} disabled="disabled"{{/disabled}}>{{display}}</option>
+            <option value="{{strat}}" {{#selected}}selected="selected"{{/selected}}>{{display}}{{#disabled}} &#x1D3F;&#x1D3C;{{/disabled}}</option>
             {{/strategies}}
           </select>
           <div class="width-100">

--- a/views/pages/userEditPreferencesPage.html
+++ b/views/pages/userEditPreferencesPage.html
@@ -21,7 +21,7 @@
                       <i class="fa fa-user fa-fw"></i>
                     </span>
                     <span class="list-group-item">
-                      <img src="/images/strat/{{defaultStrat}}16.png"> <strong>{{defaultStrategy}}</strong>
+                      <img src="/images/strat/{{defaultStrat}}16.png"> <strong>{{defaultStrategy}} {{#defaultStrategyDisabled}} &#x1D3F;&#x1D3C;{{/defaultStrategyDisabled}}</strong>
                     </span>
                     <div style="width: 100%;">
                       <div class="input-group-addon">
@@ -36,7 +36,7 @@
                       <i class="fa fa-user fa-fw"></i>
                     </span>
                     <span class="list-group-item">
-                      <img src="/images/strat/{{strat}}16.png"> {{display}}
+                      <img src="/images/strat/{{strat}}16.png"> {{display}}{{#disabled}} &#x1D3F;&#x1D3C;{{/disabled}}
                     </span>
                     <div style="width: 100%;">
                       <div class="input-group-addon">
@@ -54,7 +54,7 @@
                       </span>
                       <select name="auth" class="form-control">
                         {{#openStrategies}}
-                        <option value="{{strat}}"{{#disabled}} disabled="disabled"{{/disabled}}>{{display}}</option>
+                        <option value="{{strat}}"{{#disabled}} disabled="disabled"{{/disabled}}>{{display}}{{#disabled}} &#x1D3F;&#x1D3C;{{/disabled}}</option>
                         {{/openStrategies}}
                       </select>
                       <div style="width: 100%;">


### PR DESCRIPTION
* Superscripting status allows changing of existing alternate auth instead of disabling. I did try CSS styling at one point but one of Fx/Chromium mix supported it and other did not... next best thing imho. Could use an asterisk but then more in view I think to describe what it means.

Post #1350

NOTE(s):
* Disabling is omitted on login page in case you want to login with existing registered account with that strategy. Attaching doesn't need this so disabled is on there. Still denoting status in both places.