### PR TITLE
Work-around for *marked* issue on single tags and dep update

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "js-beautify": "1.14.9",
     "jsdom": "22.1.0",
     "less-middleware": "3.1.0",
-    "marked": "4.3.0",
+    "marked": "7.0.5",
     "media-type": "0.3.1",
     "method-override": "3.0.0",
     "mime-db": "1.52.0",


### PR DESCRIPTION
* walkTokens in *marked* is not any better because `<kbd>` + `string` + `</kbd>` still happen individually... more maintenance needed.
* tokenizer in *marked* could work as long as the default handler wouldn't split the input but untested at the moment and I suspect it would split. Also even more to maintain.
* Only applying this workaround to `html` type input with single tags only for now. Nested is unsupported.
* Not closing atm because this is extremely hacky and it may not cover all instances since user-content can be anything.
* Next *marked* will be breaking in multiple places and requires yet another dependency to continue to work with highlighting at minimum.
* Alternative sanitizers, that may or may not auto close tags are either built on current, or have DOM only prerequisites/hacky Server implementation.
* Missing semicolon.

NOTE(s):
* `blockquote` renderer appears to never be called but haven't typed everything there is possible into user-content. ;)
* `innerHTML` *possibly* auto-closes just like GM_setStyle lib does with CSS in the DOM i.e. validation before execution... a form of sanitizing... currently untested but assumed for future ease-of maintainability.

Applies to #1775