### PR TITLE
Rely less on DOM sanitization for *marked* work-around

### DIFF
--- a/libs/markdown.js
+++ b/libs/markdown.js
@@ -154,7 +154,7 @@ blockRenderers.forEach(function (aType) {
         openTagName = matches[1];
       }
       matches = arguments[0].match(/^<\/([a-z]+)>$/);
-      if (matches) {
+      if (matches && !!sanitize('<' + matches[1] + '></' + matches[1] + '>')) {
         closeTagName = matches[1];
       }
     }


### PR DESCRIPTION
* Additional check just keeps it cleaner but the browser could change how it handles an isolated close tag... so just don't create it if it's blocked with a pre block test... plus a few bytes less out. Only need to do this on additions. `.replace` on empty string doesn't add nor on another tag such as `a` which can show up here.

Post #2014 and applies to #1775