### PR TITLE
Change the Doc TOC to be more like the rest of the site

### DIFF
--- a/controllers/document.js
+++ b/controllers/document.js
@@ -137,6 +137,7 @@ exports.view = function (aReq, aRes, aNext) {
 
             if (/\.md$/.test(aFileList[file])) {
               options.fileList.push({
+                active: document === aFileList[file].replace(/\.md$/, ''),
                 href: aFileList[file].replace(/\.md$/, ''),
                 textContent: aFileList[file].replace(/\.md$/, '').replace(/-/g, ' ')
               });

--- a/public/css/common.css
+++ b/public/css/common.css
@@ -302,6 +302,14 @@ h6:hover a.anchor {
   min-width: 16px;
 }
 
+.list-group-striped > a:nth-of-type(2n+1) {
+  background-color: #f9f9f9;
+}
+
+.list-group-striped a.active {
+  background-color: #2c3e50;
+}
+
 .table-responsive {
   overflow-x: auto;
 }

--- a/views/pages/documentPage.html
+++ b/views/pages/documentPage.html
@@ -67,9 +67,9 @@
               <div class="panel-title"><em class="fa fa-fw fa-file-text-o"></em> Pages</div>
             </div>
             <div class="panel-body">
-              <ul class="list-group">
-                {{#fileList}}<li class="list-group-item"><a href="{{{href}}}">{{textContent}}</a></li>{{/fileList}}</li>
-              </ul>
+              <div class="list-group list-group-striped">
+                {{#fileList}}<a class="list-group-item{{#active}} active{{/active}}" href="{{{href}}}">{{textContent}}</a>{{/fileList}}
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
* Just some CSS to get closer to current *bootstrap* defaults. Useful if on smaller viewports. Use some striping to minimize parallax.
* Show current selection

Post #741