### PR TITLE
Fix the iconic datetime display (maybe)

### DIFF
--- a/libs/modelParser.js
+++ b/libs/modelParser.js
@@ -134,8 +134,8 @@ moment.locale('en-iconic', {
     }
   },
   relativeTime : {
-    future : "<strong>&NegativeVeryThinSpace;</strong> <span>in</span> <em>%s</em>",
-    past : "<strong>&NegativeVeryThinSpace;</strong> <span>%s</span> <em>ago</em>",
+    future : "<strong>in</strong> <span>&NegativeVeryThinSpace;</span> <em>%s</em>",
+    past : "<strong>%s</strong> <span>&NegativeVeryThinSpace;</span> <em>ago</em>",
     s : function (aNumber, aWithoutSuffix, aKey, aIsFuture) {
       return aNumber + "s";
     },


### PR DESCRIPTION
The datetime icon does not look good in my browser (Firefox 135.0.1) for displaying things like "3d ago". See the following screenshot (taken from https://openuserjs.org/announcements/Server_Maintenance?p=2#comment-19545b42833) for more details:

![Screenshot 2025-03-03 Server Maintenance Discussions OpenUserJS](https://github.com/user-attachments/assets/87cd82ae-e3ca-46a2-9183-8a34d2713f44)

This patch might fix it, but it was written after searching through the codebase for less than 5 minutes, so please be sure to test if it actually works. Thanks!