### PR TITLE
Modify some validations

### DIFF
--- a/libs/scriptStorage.js
+++ b/libs/scriptStorage.js
@@ -152,13 +152,19 @@ function invalidKey(aAuthorName, aScriptName, aIsLib, aKeyName, aKeyValue) {  //
               case 'none':
                 hasGrantNone = true;
                 // fallsthrough
-              case 'GM.*':
               case 'GM_addElement':
               case 'GM_addStyle':
+              case 'GM.addStyle':
               case 'GM_addValueChangeListener':
               case 'GM.addValueChangeListener':
+              case 'GM_audio':
+              case 'GM.audio':
+              case 'GM_cookie':
+              case 'GM.cookie':
               case 'GM_deleteValue':
               case 'GM.deleteValue':
+              case 'GM_deleteValues':
+              case 'GM.deleteValues':
               case 'GM_download':
               case 'GM_getResourceText':
               case 'GM_getResourceURL':
@@ -183,6 +189,8 @@ function invalidKey(aAuthorName, aScriptName, aIsLib, aKeyName, aKeyValue) {  //
               case 'GM.setClipboard':
               case 'GM_setValue':
               case 'GM.setValue':
+              case 'GM_setValues':
+              case 'GM.setValues':
               case 'GM_unregisterMenuCommand':
               case 'GM_xmlhttpRequest':
               case 'GM.xmlHttpRequest':


### PR DESCRIPTION
* Add some newer TM and VM keys
* NOTE: TM doesn't appear to need individual sync and async declarations with `@grant`... but putting in for VM if it needs it. i.e. @grant GM_addStyle and await GM.addStyle( css ) usage is allowed in scripts... questionable practice for sure and probably invalidates an ignored rules issue that was closed recently.
* NOTE: Couldn't get GM_addStyle or GM.addStyle to work at all in VM with Brave.
* More detailed look at the GM_* is it's just a header on VM's pages... so removing.

Refs:
* TM examples for async since the documentation is not very clear. One confirmation on issue 2244
* VM documenation confirmed although actual usage not.